### PR TITLE
fix: enable components to be controlled or uncontrolled

### DIFF
--- a/packages/radix-vue/src/Collapsible/CollapsibleRoot.vue
+++ b/packages/radix-vue/src/Collapsible/CollapsibleRoot.vue
@@ -48,8 +48,8 @@ provide<CollapsibleProvideValue>(COLLAPSIBLE_INJECTION_KEY, {
 
 <template>
   <div
-    :data-state="props.open ? 'open' : 'closed'"
-    :data-disabled="props.disabled ? 'true' : undefined"
+    :data-state="open ? 'open' : 'closed'"
+    :data-disabled="disabled ? 'true' : undefined"
   >
     <slot :open="open" />
   </div>

--- a/packages/radix-vue/src/HoverCard/HoverCardContent.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardContent.vue
@@ -70,14 +70,14 @@ async function handleMouseleave(e: MouseEvent) {
 <template>
   <div
     ref="tooltipContentElement"
-    v-if="injectedValue?.modelValue.value"
+    v-if="injectedValue?.open.value"
     style="min-width: max-content; will-change: transform; z-index: auto"
     :style="floatingStyles"
     @mouseover="injectedValue.isHover = true"
     @mouseleave="handleMouseleave"
   >
     <div
-      :data-state="injectedValue?.modelValue.value ? 'delayed-open' : 'closed'"
+      :data-state="injectedValue?.open.value ? 'delayed-open' : 'closed'"
       data-side="bottom"
       role="tooltip"
       tabindex="-1"

--- a/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
@@ -2,7 +2,8 @@
 import type { Ref, InjectionKey } from "vue";
 
 export interface HoverCardRootProps {
-  modelValue?: boolean;
+  defaultOpen: false;
+  open?: boolean;
   openDelay?: number;
   closeDelay?: number;
 }
@@ -11,7 +12,7 @@ export const HOVER_CARD_INJECTION_KEY =
   Symbol() as InjectionKey<HoverCardProvideValue>;
 
 export type HoverCardProvideValue = {
-  modelValue: Readonly<Ref<boolean>>;
+  open: Readonly<Ref<boolean>>;
   showTooltip(): void;
   hideTooltip(): void;
   triggerElement: Ref<HTMLElement | undefined>;
@@ -24,34 +25,36 @@ export type HoverCardProvideValue = {
 </script>
 
 <script setup lang="ts">
-import { provide, toRef, ref, watch } from "vue";
+import { provide, ref } from "vue";
+import { useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<HoverCardRootProps>(), {
+  defaultOpen: false,
+  open: undefined,
   openDelay: 700,
   closeDelay: 300,
 });
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
+  (e: "update:open", value: boolean): void;
 }>();
 
 const triggerElement = ref<HTMLElement>();
 const floatingElement = ref<HTMLElement>();
 const arrowElement = ref<HTMLElement>();
 
-const modelValue = ref(props.modelValue ?? false);
-
-watch(modelValue, (newValue) => {
-  emit("update:modelValue", newValue);
+const open = useVModel(props, "open", emit, {
+  defaultValue: props.defaultOpen,
+  passive: true,
 });
 
 provide<HoverCardProvideValue>(HOVER_CARD_INJECTION_KEY, {
-  modelValue: toRef(() => modelValue.value),
+  open,
   showTooltip: () => {
-    modelValue.value = true;
+    open.value = true;
   },
   hideTooltip: () => {
-    modelValue.value = false;
+    open.value = false;
   },
   triggerElement: triggerElement,
   floatingElement: floatingElement,

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -38,8 +38,8 @@ async function handleMouseleave(e: MouseEvent) {
   <button
     type="button"
     ref="triggerElement"
-    :aria-expanded="injectedValue?.modelValue.value || false"
-    :data-state="injectedValue?.modelValue.value ? 'open' : 'closed'"
+    :aria-expanded="injectedValue?.open.value || false"
+    :data-state="injectedValue?.open.value ? 'open' : 'closed'"
     @mouseover="injectedValue!.isHover = true"
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseleave"

--- a/packages/radix-vue/src/Popover/PopoverClose.vue
+++ b/packages/radix-vue/src/Popover/PopoverClose.vue
@@ -11,9 +11,9 @@ const injectedValue = inject<PopoverProvideValue>(POPOVER_INJECTION_KEY);
 <template>
   <button
     type="button"
-    :aria-expanded="injectedValue?.modelValue.value || false"
-    :data-state="injectedValue?.modelValue.value ? 'open' : 'closed'"
-    @click="injectedValue?.hideTooltip"
+    :aria-expanded="injectedValue?.open.value || false"
+    :data-state="injectedValue?.open.value ? 'open' : 'closed'"
+    @click="injectedValue?.hidePopover"
   >
     <slot />
   </button>

--- a/packages/radix-vue/src/Popover/PopoverContent.vue
+++ b/packages/radix-vue/src/Popover/PopoverContent.vue
@@ -56,7 +56,7 @@ const {
 
 watchEffect(() => {
   if (tooltipContentElement.value) {
-    if (injectedValue?.modelValue.value) {
+    if (injectedValue?.open.value) {
       setTimeout(() => {
         trapFocus(tooltipContentElement.value!);
       }, 0);
@@ -74,7 +74,7 @@ watchEffect(() => {
 function closeDialogWhenClickOutside(e: MouseEvent) {
   const clickOutside = useClickOutside(e, tooltipContentElement.value!);
   if (clickOutside) {
-    injectedValue?.hideTooltip();
+    injectedValue?.hidePopover();
   }
 }
 
@@ -92,12 +92,12 @@ provide<PopoverContentProvideValue>(POPOVER_CONTENT_INJECTION_KEY, {
 <template>
   <div
     ref="tooltipContentElement"
-    v-if="injectedValue?.modelValue.value"
+    v-if="injectedValue?.open.value"
     style="min-width: max-content; will-change: transform; z-index: auto"
     :style="floatingStyles"
   >
     <div
-      :data-state="injectedValue?.modelValue.value ? 'open' : 'closed'"
+      :data-state="injectedValue?.open.value ? 'open' : 'closed'"
       data-side="bottom"
       role="tooltip"
       :class="props.class"

--- a/packages/radix-vue/src/Popover/PopoverRoot.vue
+++ b/packages/radix-vue/src/Popover/PopoverRoot.vue
@@ -2,7 +2,8 @@
 import type { Ref, InjectionKey } from "vue";
 
 export interface PopoverRootProps {
-  modelValue?: boolean;
+  defaultOpen?: boolean;
+  open?: boolean;
   delayDuration?: number;
   disableHoverableContent?: boolean;
 }
@@ -11,9 +12,9 @@ export const POPOVER_INJECTION_KEY =
   Symbol() as InjectionKey<PopoverProvideValue>;
 
 export type PopoverProvideValue = {
-  modelValue: Readonly<Ref<boolean>>;
-  showTooltip(): void;
-  hideTooltip(): void;
+  open: Readonly<Ref<boolean>>;
+  showPopover(): void;
+  hidePopover(): void;
   triggerElement: Ref<HTMLElement | undefined>;
   floatingElement: Ref<HTMLElement | undefined>;
   arrowElement: Ref<HTMLElement | undefined>;
@@ -23,27 +24,35 @@ export type PopoverProvideValue = {
 </script>
 
 <script setup lang="ts">
-import { provide, toRef, ref } from "vue";
+import { provide, ref } from "vue";
+import { useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<PopoverRootProps>(), {
+  defaultOpen: false,
+  open: undefined,
   delayDuration: 700,
 });
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
+  (e: "update:open", value: boolean): void;
 }>();
+
+const open = useVModel(props, "open", emit, {
+  defaultValue: props.defaultOpen,
+  passive: true,
+});
 
 const triggerElement = ref<HTMLElement>();
 const floatingElement = ref<HTMLElement>();
 const arrowElement = ref<HTMLElement>();
 
 provide<PopoverProvideValue>(POPOVER_INJECTION_KEY, {
-  modelValue: toRef(() => props.modelValue),
-  showTooltip: () => {
-    emit("update:modelValue", true);
+  open,
+  showPopover: () => {
+    open.value = true;
   },
-  hideTooltip: () => {
-    emit("update:modelValue", false);
+  hidePopover: () => {
+    open.value = false;
   },
   triggerElement: triggerElement,
   floatingElement: floatingElement,

--- a/packages/radix-vue/src/Popover/PopoverTrigger.vue
+++ b/packages/radix-vue/src/Popover/PopoverTrigger.vue
@@ -17,9 +17,9 @@ onMounted(() => {
   <button
     type="button"
     ref="triggerElement"
-    :aria-expanded="injectedValue?.modelValue.value || false"
-    :data-state="injectedValue?.modelValue.value ? 'open' : 'closed'"
-    @click="injectedValue?.showTooltip"
+    :aria-expanded="injectedValue?.open.value || false"
+    :data-state="injectedValue?.open.value ? 'open' : 'closed'"
+    @click="injectedValue?.showPopover"
   >
     <slot />
   </button>

--- a/packages/radix-vue/src/Switch/SwitchRoot.vue
+++ b/packages/radix-vue/src/Switch/SwitchRoot.vue
@@ -6,16 +6,16 @@ export interface SwitchRootProps {
   required?: boolean;
   name?: string;
   id?: string;
-  defaultValue?: boolean;
-  modelValue?: boolean;
+  defaultOpen?: boolean;
+  open?: boolean;
 }
 
 export const SWITCH_INJECTION_KEY =
   Symbol() as InjectionKey<SwitchProvideValue>;
 
 export interface SwitchProvideValue {
-  modelValue?: Readonly<Ref<boolean>>;
-  toggleModelValue: (value: string) => void;
+  open?: Readonly<Ref<boolean>>;
+  toggleOpen: (value: string) => void;
   disabled: boolean;
 }
 </script>
@@ -26,55 +26,55 @@ import { useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<SwitchRootProps>(), {
   disabled: false,
-  defaultValue: false,
-  modelValue: undefined,
+  defaultOpen: false,
+  open: undefined,
 });
 
-const emit = defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:open"]);
 
-const modelValue = useVModel(props, "modelValue", emit, {
-  defaultValue: props.defaultValue,
+const open = useVModel(props, "open", emit, {
+  defaultValue: props.defaultOpen,
   passive: true, // set passive to true so that if no props.modelValue was passed, it will still update
 });
 
-const toggleModelValue = () => {
-  modelValue.value = !modelValue.value;
+const toggleOpen = () => {
+  open.value = !open.value;
 };
 
 provide<SwitchProvideValue>(SWITCH_INJECTION_KEY, {
-  modelValue: modelValue,
-  toggleModelValue,
+  open: open,
+  toggleOpen,
   disabled: props.disabled,
 });
 
 function handleKeydown(e: KeyboardEvent) {
   if (e.key === "Enter") {
-    toggleModelValue();
+    toggleOpen();
   }
 }
 </script>
 
 <template>
   <div
-    :value="modelValue"
+    :value="open"
     role="checkbox"
-    :aria-checked="modelValue"
-    :data-state="modelValue ? 'checked' : 'unchecked'"
+    :aria-checked="open"
+    :data-state="open ? 'checked' : 'unchecked'"
     :data-disabled="props.disabled ? '' : undefined"
     style="position: relative"
   >
     <input
       type="checkbox"
       :id="props.id"
-      v-bind="modelValue"
-      @change="toggleModelValue"
-      :checked="modelValue"
+      v-bind="open"
+      @change="toggleOpen"
+      :checked="open"
       :name="props.name"
       @keydown="handleKeydown"
       aria-hidden="true"
       :disabled="props.disabled"
       :required="props.required"
-      :data-state="modelValue ? 'checked' : 'unchecked'"
+      :data-state="open ? 'checked' : 'unchecked'"
       :data-disabled="props.disabled ? '' : undefined"
       style="opacity: 0; position: absolute; inset: 0"
     />

--- a/packages/radix-vue/src/Switch/SwitchThumb.vue
+++ b/packages/radix-vue/src/Switch/SwitchThumb.vue
@@ -10,9 +10,9 @@ const injectedValue = inject<SwitchProvideValue>(SWITCH_INJECTION_KEY);
 
 <template>
   <span
-    :data-state="injectedValue?.modelValue?.value ? 'checked' : 'unchecked'"
+    :data-state="injectedValue?.open?.value ? 'checked' : 'unchecked'"
     :data-disabled="injectedValue?.disabled ? '' : undefined"
-    @click="injectedValue?.toggleModelValue"
+    @click="injectedValue?.toggleOpen"
   >
     <slot />
   </span>

--- a/packages/radix-vue/src/Toggle/Toggle.vue
+++ b/packages/radix-vue/src/Toggle/Toggle.vue
@@ -2,8 +2,8 @@
 type DataState = "on" | "off";
 
 export interface ToggleProps {
-  defaultValue?: boolean;
-  modelValue?: boolean;
+  defaultPressed?: boolean;
+  pressed?: boolean;
   disabled?: boolean;
   name?: string;
   id?: string;
@@ -11,42 +11,42 @@ export interface ToggleProps {
 </script>
 
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { computed } from "vue";
 import { useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<ToggleProps>(), {
   disabled: false,
-  defaultValue: false,
-  modelValue: undefined,
+  defaultPressed: false,
+  pressed: undefined,
 });
 
-const emit = defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:pressed"]);
 
-const modelValue = useVModel(props, "modelValue", emit, {
-  defaultValue: props.defaultValue,
-  passive: true, // set passive to true so that if no props.modelValue was passed, it will still update
+const pressed = useVModel(props, "pressed", emit, {
+  defaultValue: props.defaultPressed,
+  passive: true, // set passive to true so that if no props.pressed was passed, it will still update
 });
 
-const toggleModelValue = () => {
-  modelValue.value = !modelValue.value;
+const togglePressed = () => {
+  pressed.value = !pressed.value;
 };
 
 const dataState = computed<DataState>(() => {
-  return modelValue.value ? "on" : "off";
+  return pressed.value ? "on" : "off";
 });
 
 function handleKeydown(e: KeyboardEvent) {
   if (e.key === "Enter") {
-    toggleModelValue();
+    togglePressed();
   }
 }
 </script>
 
 <template>
   <div
-    :value="modelValue"
+    :value="pressed"
     role="checkbox"
-    :aria-checked="modelValue"
+    :aria-checked="pressed"
     :data-state="dataState"
     style="position: relative"
   >
@@ -54,9 +54,9 @@ function handleKeydown(e: KeyboardEvent) {
       type="checkbox"
       :id="props.id"
       @keydown="handleKeydown"
-      v-bind="modelValue"
-      @change="toggleModelValue"
-      :checked="modelValue"
+      v-bind="pressed"
+      @change="togglePressed"
+      :checked="pressed"
       :name="props.name"
       aria-hidden="true"
       :disabled="props.disabled"

--- a/packages/radix-vue/src/Tooltip/TooltipContent.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipContent.vue
@@ -53,12 +53,12 @@ provide<TooltipContentProvideValue>(TOOLTIP_CONTENT_INJECTION_KEY, {
 <template>
   <div
     ref="tooltipContentElement"
-    v-if="injectedValue?.modelValue.value"
+    v-if="injectedValue?.open.value"
     style="min-width: max-content; will-change: transform; z-index: auto"
     :style="floatingStyles"
   >
     <div
-      :data-state="injectedValue?.modelValue.value ? 'delayed-open' : 'closed'"
+      :data-state="injectedValue?.open.value ? 'delayed-open' : 'closed'"
       data-side="top"
       role="tooltip"
       tabindex="-1"

--- a/packages/radix-vue/src/Tooltip/TooltipRoot.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipRoot.vue
@@ -2,7 +2,8 @@
 import type { Ref, InjectionKey } from "vue";
 
 export interface TooltipRootProps {
-  modelValue?: boolean;
+  defaultOpen?: boolean;
+  open?: boolean;
   delayDuration?: number;
   disableHoverableContent?: boolean;
 }
@@ -11,7 +12,7 @@ export const TOOLTIP_INJECTION_KEY =
   Symbol() as InjectionKey<TooltipProvideValue>;
 
 export type TooltipProvideValue = {
-  modelValue: Readonly<Ref<boolean>>;
+  open: Readonly<Ref<boolean>>;
   showTooltip(): void;
   hideTooltip(): void;
   triggerElement: Ref<HTMLElement | undefined>;
@@ -21,27 +22,35 @@ export type TooltipProvideValue = {
 </script>
 
 <script setup lang="ts">
-import { provide, toRef, ref } from "vue";
+import { provide, ref } from "vue";
+import { useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<TooltipRootProps>(), {
+  defaultOpen: false,
+  open: undefined,
   delayDuration: 700,
 });
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
+  (e: "update:open", value: boolean): void;
 }>();
+
+const open = useVModel(props, "open", emit, {
+  defaultValue: props.defaultOpen,
+  passive: true,
+});
 
 const triggerElement = ref<HTMLElement>();
 const floatingElement = ref<HTMLElement>();
 const arrowElement = ref<HTMLElement>();
 
 provide<TooltipProvideValue>(TOOLTIP_INJECTION_KEY, {
-  modelValue: toRef(() => props.modelValue),
+  open,
   showTooltip: () => {
-    emit("update:modelValue", true);
+    open.value = true;
   },
   hideTooltip: () => {
-    emit("update:modelValue", false);
+    open.value = false;
   },
   triggerElement: triggerElement,
   floatingElement: floatingElement,

--- a/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
@@ -25,8 +25,8 @@ async function handleMouseEnter(e: MouseEvent) {
   <button
     type="button"
     ref="triggerElement"
-    :aria-expanded="injectedValue?.modelValue.value || false"
-    :data-state="injectedValue?.modelValue.value ? 'open' : 'closed'"
+    :aria-expanded="injectedValue?.open.value || false"
+    :data-state="injectedValue?.open.value ? 'open' : 'closed'"
     @mouseenter="handleMouseEnter"
     @mouseleave="injectedValue?.hideTooltip"
     style="cursor: default"

--- a/playground/vue3/src/components/Demo/AlertDialogDemo.vue
+++ b/playground/vue3/src/components/Demo/AlertDialogDemo.vue
@@ -20,20 +20,34 @@ function handleAction() {
 </script>
 
 <template>
-  <AlertDialogRoot>
+  <div class="absolute left-4 top-3 text-sm">
+    <p>Value: {{ alertDialogOpen ? "checked" : "unchecked" }}</p>
+    <button
+      @click="alertDialogOpen = !alertDialogOpen"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ alertDialogOpen ? "Close" : "Open" }}
+    </button>
+  </div>
+  <AlertDialogRoot v-model:open="alertDialogOpen">
     <AlertDialogTrigger
       class="text-violet11 hover:bg-mauve3 shadow-blackA7 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] outline-none focus:shadow-[0_0_0_2px] focus:shadow-black"
     >
       Delete account
     </AlertDialogTrigger>
     <AlertDialogPortal>
-      <AlertDialogOverlay class="bg-blackA9 data-[state=open]:animate-overlayShow fixed inset-0" />
+      <AlertDialogOverlay
+        class="bg-blackA9 data-[state=open]:animate-overlayShow fixed inset-0"
+      />
       <AlertDialogContent
         class="data-[state=open]:animate-contentShow fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none"
       >
-        <AlertDialogTitle class="text-mauve12 m-0 text-[17px] font-medium"> Are you absolutely sure? </AlertDialogTitle>
+        <AlertDialogTitle class="text-mauve12 m-0 text-[17px] font-medium">
+          Are you absolutely sure?
+        </AlertDialogTitle>
         <AlertDialogDescription class="text-mauve11 mt-4 mb-5 text-[15px] leading-normal">
-          This action cannot be undone. This will permanently delete your account and remove your data from our servers.
+          This action cannot be undone. This will permanently delete your account and
+          remove your data from our servers.
         </AlertDialogDescription>
         <div class="flex justify-end gap-[25px]">
           <AlertDialogCancel

--- a/playground/vue3/src/components/Demo/CheckboxDemo.vue
+++ b/playground/vue3/src/components/Demo/CheckboxDemo.vue
@@ -10,9 +10,17 @@ const checkboxThree = ref(false);
 
 <template>
   <div class="absolute left-4 top-3 text-sm">
+  <p>
     States: {{ checkboxOne ? "one on" : "one off" }} -
     {{ checkboxTwo ? "two on" : "two off" }} -
     {{ checkboxThree ? "three on" : "three off" }}
+  </p>
+    <button
+      @click="checkboxOne = !checkboxOne"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ checkboxOne ? "Uncheck" : "Check" }} Checkbox 1
+    </button>
   </div>
   <div class="flex flex-col gap-2.5">
     <label class="flex flex-row gap-4 items-center [&>.checkbox]:hover:bg-neutral-100">

--- a/playground/vue3/src/components/Demo/CollapsibleDemo.vue
+++ b/playground/vue3/src/components/Demo/CollapsibleDemo.vue
@@ -3,11 +3,21 @@ import { ref } from "vue";
 import { CollapsibleRoot, CollapsibleTrigger, CollapsibleContent } from "radix-vue";
 import { Icon } from "@iconify/vue";
 
+const rootOpen = ref(false);
 const rootDisabled = ref(false);
 </script>
 
 <template>
-  <CollapsibleRoot class="w-[300px]" v-slot="slotProps" :disabled="rootDisabled" :defaultOpen="true">
+  <div class="absolute left-4 top-3 text-sm">
+    <p>Value: {{ rootOpen ? "checked" : "unchecked" }}</p>
+    <button
+      @click="rootOpen = !rootOpen"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ rootOpen ? "Close" : "Open" }}
+    </button>
+  </div>
+  <CollapsibleRoot class="w-[300px]" v-model:open="rootOpen" :disabled="rootDisabled">
     <div style="display: flex; align-items: center; justify-content: space-between">
       <span class="text-violet11 text-[15px] leading-[25px]" style="color: white"> @mujahidfa starred 3 repos </span>
       <CollapsibleTrigger
@@ -15,7 +25,7 @@ const rootDisabled = ref(false);
         class="rounded-full h-[25px] w-[25px] inline-flex items-center justify-center text-violet11 shadow-[0_2px_10px] shadow-blackA7 outline-none data-[state=closed]:bg-white data-[state=open]:bg-violet3 hover:bg-violet3 focus:shadow-[0_0_0_2px] focus:shadow-black"
       >
         <button>
-          <Icon v-if="slotProps.open" icon="radix-icons:cross-2" class="h-3 w-3 text-black" />
+          <Icon v-if="rootOpen" icon="radix-icons:cross-2" class="h-3 w-3 text-black" />
           <Icon v-else icon="radix-icons:row-spacing" class="h-3 w-3 text-black" />
         </button>
       </CollapsibleTrigger>

--- a/playground/vue3/src/components/Demo/DialogDemo.vue
+++ b/playground/vue3/src/components/Demo/DialogDemo.vue
@@ -16,7 +16,16 @@ const dialogOpen = ref(false);
 </script>
 
 <template>
-  <DialogRoot>
+  <div class="absolute left-4 top-3 text-sm">
+    <p>Value: {{ dialogOpen ? "checked" : "unchecked" }}</p>
+    <button
+      @click="dialogOpen = !dialogOpen"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ dialogOpen ? "Close" : "Open" }}
+    </button>
+  </div>
+  <DialogRoot v-model:open="dialogOpen">
     <DialogTrigger
       class="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
     >

--- a/playground/vue3/src/components/Demo/DropdownMenuDemo.vue
+++ b/playground/vue3/src/components/Demo/DropdownMenuDemo.vue
@@ -36,6 +36,12 @@ function handleClick() {
     <p>Checkbox 1: {{ checkboxOne ? "checked" : "unchecked" }}</p>
     <p>Checkbox 2: {{ checkboxTwo ? "checked" : "unchecked" }}</p>
     <p>Person: {{ person }}</p>
+    <button
+      @click="toggleState = !toggleState"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ toggleState ? "Close" : "Open" }}
+    </button>
   </div>
   <DropdownMenuRoot v-model="toggleState">
     <DropdownMenuTrigger

--- a/playground/vue3/src/components/Demo/HoverCardDemo.vue
+++ b/playground/vue3/src/components/Demo/HoverCardDemo.vue
@@ -1,11 +1,21 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import { HoverCardRoot, HoverCardTrigger, HoverCardPortal, HoverCardContent, HoverCardArrow } from "radix-vue";
+
+const hoverState = ref(false)
 </script>
 
 <template>
   <div class="absolute left-4 top-3 text-sm">
+    <p>Value: {{ hoverState ? "checked" : "unchecked" }}</p>
+    <button
+      @click="hoverState = !hoverState"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ hoverState ? "Close" : "Open" }}
+    </button>
   </div>
-  <HoverCardRoot>
+  <HoverCardRoot v-model:open="hoverState">
     <HoverCardTrigger class="inline-block cursor-pointer rounded-full shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] outline-none focus:shadow-[0_0_0_2px_white]"
         href="https://twitter.com/radix_ui"
         target="_blank"

--- a/playground/vue3/src/components/Demo/PopoverDemo.vue
+++ b/playground/vue3/src/components/Demo/PopoverDemo.vue
@@ -7,10 +7,16 @@ const toggleState = ref(false);
 </script>
 
 <template>
-  <div class="absolute left-4 top-3 text-sm">
-    <p>{{ toggleState ? "checked" : "uncheked" }}</p>
+   <div class="absolute left-4 top-3 text-sm">
+    <p>Value: {{ toggleState ? "checked" : "unchecked" }}</p>
+    <button
+      @click="toggleState = !toggleState"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ toggleState ? "Close" : "Open" }}
+    </button>
   </div>
-  <PopoverRoot v-model="toggleState">
+  <PopoverRoot v-model:open="toggleState">
     <PopoverTrigger class="rounded-full w-[35px] h-[35px] inline-flex items-center justify-center text-violet11 bg-white shadow-[0_2px_10px] shadow-blackA7 hover:bg-violet3 focus:shadow-[0_0_0_2px] focus:shadow-black cursor-default outline-none"
         aria-label="Update dimensions"
       >

--- a/playground/vue3/src/components/Demo/SwitchDemo.vue
+++ b/playground/vue3/src/components/Demo/SwitchDemo.vue
@@ -12,7 +12,7 @@ const switchState = ref(true);
       @click="switchState = !switchState"
       class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
     >
-      Toggle
+      {{switchState ? 'Off' : 'On'}}
     </button>
   </div>
   <div class="flex gap-2 items-center">
@@ -20,7 +20,6 @@ const switchState = ref(true);
       Airplane mode
     </label>
     <SwitchRoot
-      v-model="switchState"
       class="w-[42px] h-[25px] focus-within:outline focus-within:outline-black flex bg-black/50 shadow-sm rounded-full relative data-[state=checked]:bg-black cursor-default"
       id="airplane-mode"
     >

--- a/playground/vue3/src/components/Demo/SwitchDemo.vue
+++ b/playground/vue3/src/components/Demo/SwitchDemo.vue
@@ -7,14 +7,20 @@ const switchState = ref(true);
 
 <template>
   <div class="absolute left-4 top-3 text-sm">
-  <p>Value: {{ switchState ? "checked" : "unchecked" }}</p>
-  <button @click="switchState = !switchState" class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20">Toggle</button>
-</div>
+    <p>Value: {{ switchState ? "checked" : "unchecked" }}</p>
+    <button
+      @click="switchState = !switchState"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+      Toggle
+    </button>
+  </div>
   <div class="flex gap-2 items-center">
     <label className="text-white text-[15px] leading-none pr-[15px]" for="airplane-mode">
       Airplane mode
     </label>
     <SwitchRoot
+      v-model="switchState"
       class="w-[42px] h-[25px] focus-within:outline focus-within:outline-black flex bg-black/50 shadow-sm rounded-full relative data-[state=checked]:bg-black cursor-default"
       id="airplane-mode"
     >

--- a/playground/vue3/src/components/Demo/TabsDemo.vue
+++ b/playground/vue3/src/components/Demo/TabsDemo.vue
@@ -3,12 +3,7 @@ import { TabsRoot, TabsList, TabsTrigger, TabsContent } from "radix-vue";
 import { Icon } from "@iconify/vue";
 import { ref } from "vue";
 
-const toggleState = ref(true);
 const toggleStateSingle = ref("tab1");
-const toggleStateMultiple = ref(["1"]);
-
-const toggleGroupItemClasses =
-  "hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 flex h-[35px] w-[35px] items-center justify-center bg-white text-base leading-4 first:rounded-l last:rounded-r focus:z-10 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none";
 </script>
 
 <template>
@@ -41,7 +36,7 @@ const toggleGroupItemClasses =
         Make changes to your account here. Click save when you're done.
       </p>
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
-        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" htmlFor="name">
+        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="name">
           Name
         </label>
         <input
@@ -51,7 +46,7 @@ const toggleGroupItemClasses =
         />
       </fieldset>
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
-        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" htmlFor="username">
+        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="username">
           Username
         </label>
         <input
@@ -76,7 +71,7 @@ const toggleGroupItemClasses =
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
         <label
           class="text-[13px] leading-none mb-2.5 text-violet12 block"
-          htmlFor="currentPassword"
+          for="currentPassword"
         >
           Current password
         </label>
@@ -89,7 +84,7 @@ const toggleGroupItemClasses =
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
         <label
           class="text-[13px] leading-none mb-2.5 text-violet12 block"
-          htmlFor="newPassword"
+          for="newPassword"
         >
           New password
         </label>
@@ -102,7 +97,7 @@ const toggleGroupItemClasses =
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
         <label
           class="text-[13px] leading-none mb-2.5 text-violet12 block"
-          htmlFor="confirmPassword"
+          for="confirmPassword"
         >
           Confirm password
         </label>

--- a/playground/vue3/src/components/Demo/ToggleDemo.vue
+++ b/playground/vue3/src/components/Demo/ToggleDemo.vue
@@ -13,10 +13,10 @@ const toggleState = ref(true);
       @click="toggleState = !toggleState"
       class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
     >
-      Toggle
+      {{toggleState ? 'Unpress' : 'Press'}}
     </button>
   </div>
-  <Toggle v-model="toggleState" aria-label="Toggle italic"
+  <Toggle aria-label="Toggle italic"
     class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black">
     <Icon icon="radix-icons:font-italic" class="text-black"/>
   </Toggle>

--- a/playground/vue3/src/components/Demo/ToggleDemo.vue
+++ b/playground/vue3/src/components/Demo/ToggleDemo.vue
@@ -8,8 +8,14 @@ const toggleState = ref(true);
 
 <template>
    <div class="absolute left-4 top-3 text-sm">
-  <p>Value: {{ toggleState ? "checked" : "unchecked" }}</p>
-</div>
+    <p>Value: {{ toggleState ? "checked" : "unchecked" }}</p>
+    <button
+      @click="toggleState = !toggleState"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+      Toggle
+    </button>
+  </div>
   <Toggle v-model="toggleState" aria-label="Toggle italic"
     class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black">
     <Icon icon="radix-icons:font-italic" class="text-black"/>

--- a/playground/vue3/src/components/Demo/TooltipDemo.vue
+++ b/playground/vue3/src/components/Demo/TooltipDemo.vue
@@ -8,9 +8,15 @@ const toggleState = ref(false);
 
 <template>
   <div class="absolute left-4 top-3 text-sm">
-    <p>{{ toggleState ? "checked" : "uncheked" }}</p>
+    <p>Value: {{ toggleState ? "checked" : "unchecked" }}</p>
+    <button
+      @click="toggleState = !toggleState"
+      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+    >
+    {{ toggleState ? "Close" : "Open" }}
+    </button>
   </div>
-  <TooltipRoot v-model="toggleState">
+  <TooltipRoot v-model:open="toggleState">
     <TooltipTrigger class="text-violet11 shadow-blackA7 hover:bg-violet3 inline-flex h-[35px] w-[35px] items-center justify-center rounded-full bg-white shadow-[0_2px_10px] outline-none focus:shadow-[0_0_0_2px] focus:shadow-black">
         <Icon icon="radix-icons:plus" />
     </TooltipTrigger>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -985,7 +985,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.3.9(@types/node@18.16.18)
+      vite: 4.3.9
       vue: 3.3.4
     dev: true
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enable components to be controlled or uncontrolled, functioning either by providing state via v-model or without.

## Description
<!--- Describe your changes in detail -->
Make the state reactive via v-model input and able to work on its own without needing to provide state.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- [ ] #98 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- What will change? Provide a before and after -->
Some components shouldnt need to be provided state manually to work, e.g. collapsible or popover. Some others needs to be handled via outside function that mutates the v-model binded, a 2-way binding must work perfectly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In demo page we will add a custom button that mutates the v-model input to the components. Other than that, we will try and remove v-model to see if it works without it.

## Screenshots (if appropriate):

