### PR TITLE
feat: allow defaultValue props, able to work without v-model

### DIFF
--- a/packages/radix-vue/src/Tabs/TabsRoot.vue
+++ b/packages/radix-vue/src/Tabs/TabsRoot.vue
@@ -5,19 +5,17 @@ import type { DataOrientation, Direction } from "../shared/types";
 export interface TabsRootProps {
   asChild?: boolean;
   defaultValue?: string;
-  value: string;
-  //onValueChange?: void;
   orientation?: DataOrientation;
   dir?: Direction;
   activationMode?: "automatic" | "manual";
-  modelValue?: string | string[];
+  modelValue?: string;
 }
 
 export const TABS_INJECTION_KEY = Symbol() as InjectionKey<TabsProvideValue>;
 
 export interface TabsProvideValue {
-  modelValue?: Readonly<Ref<string | string[] | undefined>>;
-  changeModelValue: (value: any) => void;
+  modelValue?: Readonly<Ref<string | undefined>>;
+  changeModelValue: (value: string) => void;
   parentElement: Ref<HTMLElement | undefined>;
   orientation: DataOrientation;
   dir?: Direction;
@@ -25,8 +23,9 @@ export interface TabsProvideValue {
 </script>
 
 <script setup lang="ts">
-import { ref, toRef, provide } from "vue";
+import { ref, provide } from "vue";
 import { PrimitiveDiv } from "@/Primitive";
+import { useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<TabsRootProps>(), {
   asChild: false,
@@ -39,10 +38,15 @@ const emits = defineEmits(["update:modelValue"]);
 
 const parentElementRef = ref<HTMLElement>();
 
+const modelValue = useVModel(props, "modelValue", emits, {
+  defaultValue: props.defaultValue,
+  passive: true,
+});
+
 provide<TabsProvideValue>(TABS_INJECTION_KEY, {
-  modelValue: toRef(() => props.modelValue),
-  changeModelValue: (value: any) => {
-    emits("update:modelValue", value);
+  modelValue,
+  changeModelValue: (value: string) => {
+    modelValue.value = value;
   },
   parentElement: parentElementRef,
   orientation: props.orientation,

--- a/playground/vue3/src/components/Demo/TabsDemo.vue
+++ b/playground/vue3/src/components/Demo/TabsDemo.vue
@@ -8,12 +8,9 @@ const toggleStateSingle = ref("tab1");
 
 <template>
   <div class="absolute left-4 top-3 text-sm">
-  <p>Value: {{ toggleStateSingle }}</p>
-</div>
-  <TabsRoot
-    class="flex flex-col w-[300px] shadow-[0_2px_10px] shadow-blackA4"
-    v-model="toggleStateSingle"
-  >
+    <p>Value: {{ toggleStateSingle }}</p>
+  </div>
+  <TabsRoot class="flex flex-col w-[300px] shadow-[0_2px_10px] shadow-blackA4" default-value="tab1">
     <TabsList class="shrink-0 flex border-b border-mauve6" aria-label="Manage your account">
       <TabsTrigger
         class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none first:rounded-tl-md last:rounded-tr-md hover:text-violet11 data-[state=active]:text-violet11 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=active]:shadow-current data-[state=active]:focus:relative data-[state=active]:focus:shadow-[0_0_0_2px] data-[state=active]:focus:shadow-black outline-none cursor-default"
@@ -36,9 +33,7 @@ const toggleStateSingle = ref("tab1");
         Make changes to your account here. Click save when you're done.
       </p>
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
-        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="name">
-          Name
-        </label>
+        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="name"> Name </label>
         <input
           class="grow shrink-0 rounded px-2.5 text-[15px] leading-none text-violet11 shadow-[0_0_0_1px] shadow-violet7 h-[35px] focus:shadow-[0_0_0_2px] focus:shadow-violet8 outline-none"
           id="name"
@@ -46,9 +41,7 @@ const toggleStateSingle = ref("tab1");
         />
       </fieldset>
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
-        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="username">
-          Username
-        </label>
+        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="username"> Username </label>
         <input
           class="grow shrink-0 rounded px-2.5 text-[15px] leading-none text-violet11 shadow-[0_0_0_1px] shadow-violet7 h-[35px] focus:shadow-[0_0_0_2px] focus:shadow-violet8 outline-none"
           id="username"
@@ -56,7 +49,9 @@ const toggleStateSingle = ref("tab1");
         />
       </fieldset>
       <div class="flex justify-end mt-5">
-        <button class="inline-flex items-center justify-center rounded px-[15px] text-[15px] leading-none font-medium h-[35px] bg-green4 text-green11 hover:bg-green5 focus:shadow-[0_0_0_2px] focus:shadow-green7 outline-none cursor-default">
+        <button
+          class="inline-flex items-center justify-center rounded px-[15px] text-[15px] leading-none font-medium h-[35px] bg-green4 text-green11 hover:bg-green5 focus:shadow-[0_0_0_2px] focus:shadow-green7 outline-none cursor-default"
+        >
           Save changes
         </button>
       </div>
@@ -69,10 +64,7 @@ const toggleStateSingle = ref("tab1");
         Change your password here. After saving, you'll be logged out.
       </p>
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
-        <label
-          class="text-[13px] leading-none mb-2.5 text-violet12 block"
-          for="currentPassword"
-        >
+        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="currentPassword">
           Current password
         </label>
         <input
@@ -82,12 +74,7 @@ const toggleStateSingle = ref("tab1");
         />
       </fieldset>
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
-        <label
-          class="text-[13px] leading-none mb-2.5 text-violet12 block"
-          for="newPassword"
-        >
-          New password
-        </label>
+        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="newPassword"> New password </label>
         <input
           class="grow shrink-0 rounded px-2.5 text-[15px] leading-none text-violet11 shadow-[0_0_0_1px] shadow-violet7 h-[35px] focus:shadow-[0_0_0_2px] focus:shadow-violet8 outline-none"
           id="newPassword"
@@ -95,10 +82,7 @@ const toggleStateSingle = ref("tab1");
         />
       </fieldset>
       <fieldset class="mb-[15px] w-full flex flex-col justify-start">
-        <label
-          class="text-[13px] leading-none mb-2.5 text-violet12 block"
-          for="confirmPassword"
-        >
+        <label class="text-[13px] leading-none mb-2.5 text-violet12 block" for="confirmPassword">
           Confirm password
         </label>
         <input
@@ -108,7 +92,9 @@ const toggleStateSingle = ref("tab1");
         />
       </fieldset>
       <div class="flex justify-end mt-5">
-        <button class="inline-flex items-center justify-center rounded px-[15px] text-[15px] leading-none font-medium h-[35px] bg-green4 text-green11 hover:bg-green5 focus:shadow-[0_0_0_2px] focus:shadow-green7 outline-none cursor-default">
+        <button
+          class="inline-flex items-center justify-center rounded px-[15px] text-[15px] leading-none font-medium h-[35px] bg-green4 text-green11 hover:bg-green5 focus:shadow-[0_0_0_2px] focus:shadow-green7 outline-none cursor-default"
+        >
           Change password
         </button>
       </div>


### PR DESCRIPTION
Remove dependencies on v-model. So tabs should now be working without v-model, as it will have it's own local state now.