### PR TITLE
overwrite default `@nuxtjs/tailwindcss` paths

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -2,8 +2,3 @@
 #__nuxt > div > header > div > div.section.right > button {
   display: none;
 }
-
-/* forcefully set max-width as pinceau is causing layout shift */
-.page-layout .container {
-  @apply xl:!max-w-screen-xl;
-}

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -25,4 +25,13 @@ export default defineNuxtConfig({
   colorMode: {
     preference: "dark",
   },
+  tailwindcss: {
+    config: {
+      content() {
+        return [
+          './components/**/*.{vue,ts,js}'
+        ]
+      },
+    },
+  }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Only scan `docs/components` path instead of [**this**](https://github.com/nuxt-modules/tailwindcss/blob/main/src/resolvers.ts#L25C1-L35C3) to prevent conflict between the same `@nuxt-themes/docus` components classes and `tailwindcss` class names


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- What will change? Provide a before and after -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

