### PR TITLE
fix: primitive `aschild` not working properly

### DIFF
--- a/packages/radix-vue/src/Primitive/Primitive.vue
+++ b/packages/radix-vue/src/Primitive/Primitive.vue
@@ -3,10 +3,11 @@ import {
   defineComponent,
   h,
   getCurrentInstance,
+  Fragment,
   type NativeElements,
   type ReservedProps,
+  type VNode,
 } from "vue";
-import Slot from "./Slot.vue";
 
 const NODES = [
   "a",
@@ -34,20 +35,29 @@ type Primitives = {
     };
 };
 
+export function renderSlotFragments(children?: VNode[]): VNode[] {
+  if (!children) return [];
+  return children.flatMap((child) => {
+    if (child.type === Fragment) {
+      return renderSlotFragments(child.children as VNode[]);
+    }
+    return [child];
+  });
+}
+
 const Primitive = NODES.reduce((primitive, node) => {
   const Node = defineComponent({
     setup(props, { slots, attrs }) {
-      const numberOfChildElements =
-        (slots.default?.()[0].children?.length as number) ?? 0;
-
       const asChild =
         attrs.asChild === "true" ||
         attrs.asChild === "" ||
         (attrs.asChild as boolean);
 
       if (asChild) {
+        const children = renderSlotFragments(slots.default?.());
+
         const instance = getCurrentInstance();
-        if (numberOfChildElements > 1) {
+        if (children.length > 1) {
           const componentName = instance?.parent?.type.__name
             ? `<${instance.parent.type.__name} />`
             : "component";
@@ -67,7 +77,7 @@ const Primitive = NODES.reduce((primitive, node) => {
           );
         }
 
-        return () => h(Slot, slots.default?.());
+        return () => h(children[0]);
       } else {
         return () => h(node, slots.default?.());
       }

--- a/playground/vue3/src/components/Demo/AccordionDemo.vue
+++ b/playground/vue3/src/components/Demo/AccordionDemo.vue
@@ -19,7 +19,9 @@ const rootDisabled = false;
   >
     <AccordionItem class="accordion-item" value="item-1">
       <AccordionHeader class="flex">
-        <AccordionTrigger class="accordion-trigger">Is it accessible?</AccordionTrigger>
+        <AccordionTrigger class="accordion-trigger" asChild>
+          <button class="custom-trigger">Is it accessible?</button>
+        </AccordionTrigger>
       </AccordionHeader>
       <AccordionContent
         class="accordion-content data-[state=open]:animate-slideDown data-[state=closed]:animate-slideUp"
@@ -46,7 +48,9 @@ const rootDisabled = false;
       <AccordionContent
         class="accordion-content data-[state=open]:animate-slideDown data-[state=closed]:animate-slideUp"
       >
-        <div class="px-5 py-4">Yes! You can use the transition prop to configure the animation.</div>
+        <div>
+          <div class="px-5 py-4">Yes! You can use the transition prop to configure the animation.</div>
+        </div>
       </AccordionContent>
     </AccordionItem>
   </AccordionRoot>


### PR DESCRIPTION
because `AccordionTrigger` is wrapped with `CollapsibleTrigger`, somehow that makes the `asChild` doesn't work.


this would closed off #129  as well, as we are not passing `slots.default?.()` now