### PR TITLE
[Docs] Convert mdx to mdc

### DIFF
--- a/docs/content/3.components/accordion.md
+++ b/docs/content/3.components/accordion.md
@@ -16,11 +16,11 @@ associated section of content.
 #previewSlot
   :demo-accordion
 #codeSlot
-::hero-code-group{folder="Accordion"}
-::
+  ::hero-code-group{folder="Accordion"}
 ::
 
 ## Features
+
 :br
 ::list{type="success"}
 - Full keyboard navigation.
@@ -44,7 +44,13 @@ Import all parts and piece them together.
 
 ```vue
 <script setup>
-import { AccordionRoot, AccordionItem, AccordionHeader, AccordionTrigger, AccordionContent } from "radix-vue";
+import {
+  AccordionRoot,
+  AccordionItem,
+  AccordionHeader,
+  AccordionTrigger,
+  AccordionContent,
+} from "radix-vue";
 </script>
 
 <template>
@@ -67,105 +73,104 @@ Contains all the parts of an accordion.
 
 ::props-table
 ---
-data: [{
-      name: 'asChild',
-      required: false,
-      type: 'boolean',
-      default: 'false',
-      description: 'Change the default rendered element for the one passed as a child,
-          merging their props and behavior.',
-    },
-    {
+data: [
+  {
+    name: 'asChild',
+    required: false,
+    type: 'boolean',
+    default: 'false',
+    description: 'Change the default rendered element for the one passed as a child, merging their props and behavior.',
+  },
+  {
       name: 'type',
       required: true,
       type: '"single" | "multiple"',
       typeSimple: 'enum',
       description: 'Determines whether one or multiple items can be opened at the same time.',
-    },
-    {
-      name: 'value',
-      required: false,
-      type: 'string',
-      description: 'The controlled value of the item to expand when',
-    },
-    {
-      name: 'defaultValue',
-      required: false,
-      type: 'string',
-      description: 'The value of the item to expand when initially rendered and',
-    },
-    {
-      name: 'onValueChange',
-      required: false,
-      type: '(value: string) => void',
-      typeSimple: 'function',
-      description: 'Event handler called when the expanded state of an item changes and',
-    },
-    {
-      name: 'value',
-      required: false,
-      default: '[]',
-      type: 'string[]',
-      description: 'The controlled value of the item to expand when',
-    },
-    {
-      name: 'defaultValue',
-      required: false,
-      default: '[]',
-      type: 'string[]',
-      description: 'The value of the item to expand when initially rendered when',
-    },
-    {
-      name: 'onValueChange',
-      required: false,
-      type: '(value: string[]) => void',
-      typeSimple: 'function',
-      description: 'Event handler called when the expanded state of an item changes and',
-    },
-    {
-      name: 'collapsible',
-      required: false,
-      default: 'false',
-      type: 'boolean',
-      description: 'allows closing content when clicking trigger for an open item.',
-    },
-    {
-      name: 'disabled',
-      required: false,
-      type: 'boolean',
-      default: 'false',
-      description: 'When `true`, prevents the user from interacting with the
-          accordion and all its items.',
-    },
-    {
-      name: 'dir',
-      required: false,
-      type: '"ltr" | "rtl"',
-      typeSimple: 'enum',
-      default: '"ltr"',
-      description:
-        'The reading direction of the accordion when applicable. If omitted, assumes LTR (left-to-right) reading mode.',
-    },
-    {
-      name: 'orientation',
-      required: false,
-      type: '"horizontal" | "vertical"',
-      typeSimple: 'enum',
-      default: '"vertical"',
-      description: 'The orientation of the accordion.',
-    },
-  ]
+  },
+  {
+    name: 'value',
+    required: false,
+    type: 'string',
+    description: 'The controlled value of the item to expand when',
+  },
+  {
+    name: 'defaultValue',
+    required: false,
+    type: 'string',
+    description: 'The value of the item to expand when initially rendered and',
+  },
+  {
+    name: 'onValueChange',
+    required: false,
+    type: '(value: string) => void',
+    typeSimple: 'function',
+    description: 'Event handler called when the expanded state of an item changes and',
+  },
+  {
+    name: 'value',
+    required: false,
+    default: '[]',
+    type: 'string[]',
+    description: 'The controlled value of the item to expand when',
+  },
+  {
+    name: 'defaultValue',
+    required: false,
+    default: '[]',
+    type: 'string[]',
+    description: 'The value of the item to expand when initially rendered when',
+  },
+  {
+    name: 'onValueChange',
+    required: false,
+    type: '(value: string[]) => void',
+    typeSimple: 'function',
+    description: 'Event handler called when the expanded state of an item changes and',
+  },
+  {
+    name: 'collapsible',
+    required: false,
+    default: 'false',
+    type: 'boolean',
+    description: 'allows closing content when clicking trigger for an open item.',
+  },
+  {
+    name: 'disabled',
+    required: false,
+    type: 'boolean',
+    default: 'false',
+    description: 'When `true`, prevents the user from interacting with the
+    accordion and all its items.',
+  },
+  {
+    name: 'dir',
+    required: false,
+    type: '"ltr" | "rtl"',
+    typeSimple: 'enum',
+    default: '"ltr"',
+    description: 'The reading direction of the accordion when applicable. If omitted, assumes LTR (left-to-right) reading mode.',
+  },
+  {
+    name: 'orientation',
+    required: false,
+    type: '"horizontal" | "vertical"',
+    typeSimple: 'enum',
+    default: '"vertical"',
+    description: 'The orientation of the accordion.',
+  },
+]
 ---
 ::
 
 ::data-attributes-table
 ---
 data: [
-    {
-      attribute: '[data-orientation]',
-      values: ['vertical', 'horizontal'],
-    },
-  ]
+  {
+    attribute: '[data-orientation]',
+    values: ['vertical', 'horizontal'],
+  },
+]
 ---
 ::
 
@@ -176,46 +181,46 @@ Contains all the parts of a collapsible section.
 ::props-table
 ---
 data: [{
-      name: 'asChild',
-      required: false,
-      type: 'boolean',
-      default: 'false',
-      description: 'Change the default rendered element for the one passed as a child,
-          merging their props and behavior.',
-    },
-    {
-      name: 'disabled',
-      required: false,
-      type: 'boolean',
-      default: 'false',
-      description: 'When true, prevents the user from interacting with accordion and all items',
-    },
-    {
-      name: 'value',
-      required: true,
-      type: 'string',
-      description: 'A unique value for the item.',
-    },
-  ]
+name: 'asChild',
+required: false,
+type: 'boolean',
+default: 'false',
+description: 'Change the default rendered element for the one passed as a child,
+merging their props and behavior.',
+},
+{
+name: 'disabled',
+required: false,
+type: 'boolean',
+default: 'false',
+description: 'When true, prevents the user from interacting with accordion and all items',
+},
+{
+name: 'value',
+required: true,
+type: 'string',
+description: 'A unique value for the item.',
+},
+]
 ---
 ::
 
 ::data-attributes-table
 ---
 data: [
-    {
-      attribute: '[data-state]',
-      values: ['open', 'closed'],
-    },
-    {
-      attribute: '[data-disabled]',
-      values: 'Present when disabled',
-    },
-    {
-      attribute: '[data-orientation]',
-      values: ['vertical', 'horizontal'],
-    },
-  ]
+{
+attribute: '[data-state]',
+values: ['open', 'closed'],
+},
+{
+attribute: '[data-disabled]',
+values: 'Present when disabled',
+},
+{
+attribute: '[data-orientation]',
+values: ['vertical', 'horizontal'],
+},
+]
 ---
 ::
 
@@ -226,33 +231,33 @@ Wraps an `Accordion.Trigger`. Use the `asChild` prop to update it to the appropr
 ::props-table
 ---
 data: [{
-      name: 'asChild',
-      required: false,
-      type: 'boolean',
-      default: 'false',
-      description: 'Change the default rendered element for the one passed as a child,
-          merging their props and behavior.',
-    },
-  ]
+name: 'asChild',
+required: false,
+type: 'boolean',
+default: 'false',
+description: 'Change the default rendered element for the one passed as a child,
+merging their props and behavior.',
+},
+]
 ---
 ::
 
 ::data-attributes-table
 ---
 data: [
-    {
-      attribute: '[data-state]',
-      values: ['open', 'closed'],
-    },
-    {
-      attribute: '[data-disabled]',
-      values: 'Present when disabled',
-    },
-    {
-      attribute: '[data-orientation]',
-      values: ['vertical', 'horizontal'],
-    },
-  ]
+{
+attribute: '[data-state]',
+values: ['open', 'closed'],
+},
+{
+attribute: '[data-disabled]',
+values: 'Present when disabled',
+},
+{
+attribute: '[data-orientation]',
+values: ['vertical', 'horizontal'],
+},
+]
 ---
 ::
 
@@ -263,33 +268,33 @@ Toggles the collapsed state of its associated item. It should be nested inside o
 ::props-table
 ---
 data: [{
-      name: 'asChild',
-      required: false,
-      type: 'boolean',
-      default: 'false',
-      description: 'Change the default rendered element for the one passed as a child,
-          merging their props and behavior.',
-    },
-  ]
+name: 'asChild',
+required: false,
+type: 'boolean',
+default: 'false',
+description: 'Change the default rendered element for the one passed as a child,
+merging their props and behavior.',
+},
+]
 ---
 ::
 
 ::data-attributes-table
 ---
 data: [
-    {
-      attribute: '[data-state]',
-      values: ['open', 'closed'],
-    },
-    {
-      attribute: '[data-disabled]',
-      values: 'Present when disabled',
-    },
-    {
-      attribute: '[data-orientation]',
-      values: ['vertical', 'horizontal'],
-    },
-  ]
+{
+attribute: '[data-state]',
+values: ['open', 'closed'],
+},
+{
+attribute: '[data-disabled]',
+values: 'Present when disabled',
+},
+{
+attribute: '[data-orientation]',
+values: ['vertical', 'horizontal'],
+},
+]
 ---
 ::
 
@@ -300,54 +305,57 @@ Contains the collapsible content for an item.
 ::props-table
 ---
 data: [{
-      name: 'asChild',
-      required: false,
-      type: 'boolean',
-      default: 'false',
-      description: 'Change the default rendered element for the one passed as a child,
-          merging their props and behavior.',
-    },
-    {
-      name: 'forceMount',
-      type: 'boolean',
-      description: 'Used to force mounting when more control is needed. Useful when
-          controlling animation with React animation libraries.',
-    },
-  ]
+name: 'asChild',
+required: false,
+type: 'boolean',
+default: 'false',
+description: 'Change the default rendered element for the one passed as a child,
+merging their props and behavior.',
+},
+{
+name: 'forceMount',
+type: 'boolean',
+description: 'Used to force mounting when more control is needed. Useful when
+controlling animation with React animation libraries.',
+},
+]
 ---
 ::
 
 ::data-attributes-table
 ---
 data: [
-    {
-      attribute: '[data-state]',
-      values: ['open', 'closed'],
-    },
-    {
-      attribute: '[data-disabled]',
-      values: 'Present when disabled',
-    },
-    {
-      attribute: '[data-orientation]',
-      values: ['vertical', 'horizontal'],
-    },
-  ]
+{
+attribute: '[data-state]',
+values: ['open', 'closed'],
+},
+{
+attribute: '[data-disabled]',
+values: 'Present when disabled',
+},
+{
+attribute: '[data-orientation]',
+values: ['vertical', 'horizontal'],
+},
+]
 ---
 ::
 
-<CssVariablesTable
-  data={[
-    {
-      cssVariable: '--radix-accordion-content-width',
-      description: 'The width of the content when it opens/closes',
-    },
-    {
-      cssVariable: '--radix-accordion-content-height',
-      description: 'The height of the content when it opens/closes',
-    },
-  ]}
-/>
+::css-variables-table
+---
+data: [
+{
+cssVariable: '--radix-accordion-content-width',
+description: 'The width of the content when it opens/closes',
+},
+{
+cssVariable: '--radix-accordion-content-height',
+description: 'The height of the content when it opens/closes',
+},
+]
+---
+::
+
 
 ## Examples
 
@@ -390,9 +398,9 @@ You can add extra decorative elements, such as chevrons, and rotate it when the 
 
 ```jsx line=12
 // index.jsx
-import * as Accordion from '@radix-ui/react-accordion';
-import { ChevronDownIcon } from '@radix-ui/react-icons';
-import './styles.css';
+import * as Accordion from "@radix-ui/react-accordion";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+import "./styles.css";
 
 export default () => (
   <Accordion.Root type="single">
@@ -414,7 +422,7 @@ export default () => (
 .AccordionChevron {
   transition: transform 300ms;
 }
-.AccordionTrigger[data-state='open'] > .AccordionChevron {
+.AccordionTrigger[data-state="open"] > .AccordionChevron {
   transform: rotate(180deg);
 }
 ```
@@ -436,8 +444,8 @@ Use the `--radix-accordion-content-width` and/or `--radix-accordion-content-heig
 
 ```jsx line=9
 // index.jsx
-import * as Accordion from '@radix-ui/react-accordion';
-import './styles.css';
+import * as Accordion from "@radix-ui/react-accordion";
+import "./styles.css";
 
 export default () => (
   <Accordion.Root type="single">
@@ -454,10 +462,10 @@ export default () => (
 .AccordionContent {
   overflow: hidden;
 }
-.AccordionContent[data-state='open'] {
+.AccordionContent[data-state="open"] {
   animation: slideDown 300ms ease-out;
 }
-.AccordionContent[data-state='closed'] {
+.AccordionContent[data-state="closed"] {
   animation: slideUp 300ms ease-out;
 }
 
@@ -489,46 +497,46 @@ Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-ari
 ::keyboard-table
 ---
 data: [
-    {
-      keys: ['Space'],
-      description: 'Moves focus to the next',
-    },
-    {
-      keys: ['Enter'],
-      description: 'Moves focus to the next',
-    },
-    {
-      keys: ['Tab'],
-      description: 'Moves focus to the next focusable element.',
-    },
-    {
-      keys: ['Shift + Tab'],
-      description: 'Moves focus to the previous focusable element.',
-    },
-    {
-      keys: ['ArrowDown'],
-      description: 'Moves focus to the next',
-    },
-    {
-      keys: ['ArrowUp'],
-      description: 'Moves focus to the next',
-    },
-    {
-      keys: ['ArrowRight'],
-      description: 'Moves focus to the next',
-    },
-    {
-      keys: ['ArrowLeft'],
-      description: 'Moves focus to the next',
-    },
-    {
-      keys: ['Home'],
-      description: 'Moves focus to the next',
-    },
-    {
-      keys: ['End'],
-      description: 'Moves focus to the next',
-    },
-  ]
+{
+keys: ['Space'],
+description: 'Moves focus to the next',
+},
+{
+keys: ['Enter'],
+description: 'Moves focus to the next',
+},
+{
+keys: ['Tab'],
+description: 'Moves focus to the next focusable element.',
+},
+{
+keys: ['Shift + Tab'],
+description: 'Moves focus to the previous focusable element.',
+},
+{
+keys: ['ArrowDown'],
+description: 'Moves focus to the next',
+},
+{
+keys: ['ArrowUp'],
+description: 'Moves focus to the next',
+},
+{
+keys: ['ArrowRight'],
+description: 'Moves focus to the next',
+},
+{
+keys: ['ArrowLeft'],
+description: 'Moves focus to the next',
+},
+{
+keys: ['Home'],
+description: 'Moves focus to the next',
+},
+{
+keys: ['End'],
+description: 'Moves focus to the next',
+},
+]
 ---
 ::

--- a/docs/content/3.components/accordion.md
+++ b/docs/content/3.components/accordion.md
@@ -180,27 +180,28 @@ Contains all the parts of a collapsible section.
 
 ::props-table
 ---
-data: [{
-name: 'asChild',
-required: false,
-type: 'boolean',
-default: 'false',
-description: 'Change the default rendered element for the one passed as a child,
-merging their props and behavior.',
-},
-{
-name: 'disabled',
-required: false,
-type: 'boolean',
-default: 'false',
-description: 'When true, prevents the user from interacting with accordion and all items',
-},
-{
-name: 'value',
-required: true,
-type: 'string',
-description: 'A unique value for the item.',
-},
+data: [
+  {
+    name: 'asChild',
+    required: false,
+    type: 'boolean',
+    default: 'false',
+    description: 'Change the default rendered element for the one passed as a child,
+    merging their props and behavior.',
+  },
+  {
+    name: 'disabled',
+    required: false,
+    type: 'boolean',
+    default: 'false',
+    description: 'When true, prevents the user from interacting with accordion and all items',
+  },
+  {
+    name: 'value',
+    required: true,
+    type: 'string',
+    description: 'A unique value for the item.',
+  },
 ]
 ---
 ::
@@ -208,18 +209,18 @@ description: 'A unique value for the item.',
 ::data-attributes-table
 ---
 data: [
-{
-attribute: '[data-state]',
-values: ['open', 'closed'],
-},
-{
-attribute: '[data-disabled]',
-values: 'Present when disabled',
-},
-{
-attribute: '[data-orientation]',
-values: ['vertical', 'horizontal'],
-},
+  {
+    attribute: '[data-state]',
+    values: ['open', 'closed'],
+  },
+  {
+    attribute: '[data-disabled]',
+    values: 'Present when disabled',
+  },
+  {
+    attribute: '[data-orientation]',
+    values: ['vertical', 'horizontal'],
+  },
 ]
 ---
 ::
@@ -231,32 +232,31 @@ Wraps an `Accordion.Trigger`. Use the `asChild` prop to update it to the appropr
 ::props-table
 ---
 data: [{
-name: 'asChild',
-required: false,
-type: 'boolean',
-default: 'false',
-description: 'Change the default rendered element for the one passed as a child,
-merging their props and behavior.',
-},
-]
+  name: 'asChild',
+  required: false,
+  type: 'boolean',
+  default: 'false',
+  description: 'Change the default rendered element for the one passed as a child,
+  merging their props and behavior.',
+}]
 ---
 ::
 
 ::data-attributes-table
 ---
 data: [
-{
-attribute: '[data-state]',
-values: ['open', 'closed'],
-},
-{
-attribute: '[data-disabled]',
-values: 'Present when disabled',
-},
-{
-attribute: '[data-orientation]',
-values: ['vertical', 'horizontal'],
-},
+  {
+    attribute: '[data-state]',
+    values: ['open', 'closed'],
+  },
+  {
+    attribute: '[data-disabled]',
+    values: 'Present when disabled',
+  },
+  {
+    attribute: '[data-orientation]',
+    values: ['vertical', 'horizontal'],
+  },
 ]
 ---
 ::
@@ -268,32 +268,31 @@ Toggles the collapsed state of its associated item. It should be nested inside o
 ::props-table
 ---
 data: [{
-name: 'asChild',
-required: false,
-type: 'boolean',
-default: 'false',
-description: 'Change the default rendered element for the one passed as a child,
-merging their props and behavior.',
-},
-]
+  name: 'asChild',
+  required: false,
+  type: 'boolean',
+  default: 'false',
+  description: 'Change the default rendered element for the one passed as a child,
+  merging their props and behavior.',
+}]
 ---
 ::
 
 ::data-attributes-table
 ---
 data: [
-{
-attribute: '[data-state]',
-values: ['open', 'closed'],
-},
-{
-attribute: '[data-disabled]',
-values: 'Present when disabled',
-},
-{
-attribute: '[data-orientation]',
-values: ['vertical', 'horizontal'],
-},
+  {
+    attribute: '[data-state]',
+    values: ['open', 'closed'],
+  },
+  {
+    attribute: '[data-disabled]',
+    values: 'Present when disabled',
+  },
+  {
+    attribute: '[data-orientation]',
+    values: ['vertical', 'horizontal'],
+  },
 ]
 ---
 ::
@@ -304,20 +303,21 @@ Contains the collapsible content for an item.
 
 ::props-table
 ---
-data: [{
-name: 'asChild',
-required: false,
-type: 'boolean',
-default: 'false',
-description: 'Change the default rendered element for the one passed as a child,
-merging their props and behavior.',
-},
-{
-name: 'forceMount',
-type: 'boolean',
-description: 'Used to force mounting when more control is needed. Useful when
-controlling animation with React animation libraries.',
-},
+data: [
+  {
+    name: 'asChild',
+    required: false,
+    type: 'boolean',
+    default: 'false',
+    description: 'Change the default rendered element for the one passed as a child,
+        merging their props and behavior.',
+  },
+  {
+    name: 'forceMount',
+    type: 'boolean',
+    description: 'Used to force mounting when more control is needed. Useful when
+        controlling animation with React animation libraries.',
+  },
 ]
 ---
 ::
@@ -325,18 +325,18 @@ controlling animation with React animation libraries.',
 ::data-attributes-table
 ---
 data: [
-{
-attribute: '[data-state]',
-values: ['open', 'closed'],
-},
-{
-attribute: '[data-disabled]',
-values: 'Present when disabled',
-},
-{
-attribute: '[data-orientation]',
-values: ['vertical', 'horizontal'],
-},
+  {
+    attribute: '[data-state]',
+    values: ['open', 'closed'],
+  },
+  {
+    attribute: '[data-disabled]',
+    values: 'Present when disabled',
+  },
+  {
+    attribute: '[data-orientation]',
+    values: ['vertical', 'horizontal'],
+  },
 ]
 ---
 ::
@@ -344,14 +344,14 @@ values: ['vertical', 'horizontal'],
 ::css-variables-table
 ---
 data: [
-{
-cssVariable: '--radix-accordion-content-width',
-description: 'The width of the content when it opens/closes',
-},
-{
-cssVariable: '--radix-accordion-content-height',
-description: 'The height of the content when it opens/closes',
-},
+  {
+    cssVariable: '--radix-accordion-content-width',
+    description: 'The width of the content when it opens/closes',
+  },
+  {
+    cssVariable: '--radix-accordion-content-height',
+    description: 'The height of the content when it opens/closes',
+  },
 ]
 ---
 ::
@@ -497,46 +497,46 @@ Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-ari
 ::keyboard-table
 ---
 data: [
-{
-keys: ['Space'],
-description: 'Moves focus to the next',
-},
-{
-keys: ['Enter'],
-description: 'Moves focus to the next',
-},
-{
-keys: ['Tab'],
-description: 'Moves focus to the next focusable element.',
-},
-{
-keys: ['Shift + Tab'],
-description: 'Moves focus to the previous focusable element.',
-},
-{
-keys: ['ArrowDown'],
-description: 'Moves focus to the next',
-},
-{
-keys: ['ArrowUp'],
-description: 'Moves focus to the next',
-},
-{
-keys: ['ArrowRight'],
-description: 'Moves focus to the next',
-},
-{
-keys: ['ArrowLeft'],
-description: 'Moves focus to the next',
-},
-{
-keys: ['Home'],
-description: 'Moves focus to the next',
-},
-{
-keys: ['End'],
-description: 'Moves focus to the next',
-},
+  {
+    keys: ['Space'],
+    description: 'Moves focus to the next',
+  },
+  {
+    keys: ['Enter'],
+    description: 'Moves focus to the next',
+  },
+  {
+    keys: ['Tab'],
+    description: 'Moves focus to the next focusable element.',
+  },
+  {
+    keys: ['Shift + Tab'],
+    description: 'Moves focus to the previous focusable element.',
+  },
+  {
+    keys: ['ArrowDown'],
+    description: 'Moves focus to the next',
+  },
+  {
+    keys: ['ArrowUp'],
+    description: 'Moves focus to the next',
+  },
+  {
+    keys: ['ArrowRight'],
+    description: 'Moves focus to the next',
+  },
+  {
+    keys: ['ArrowLeft'],
+    description: 'Moves focus to the next',
+  },
+  {
+    keys: ['Home'],
+    description: 'Moves focus to the next',
+  },
+  {
+    keys: ['End'],
+    description: 'Moves focus to the next',
+  },
 ]
 ---
 ::

--- a/docs/content/3.components/alert-dialog.md
+++ b/docs/content/3.components/alert-dialog.md
@@ -60,7 +60,7 @@ import * as AlertDialog from '@radix-ui/react-alert-dialog';
       </AlertDialogContent>
     </AlertDialogPortal>
   </AlertDialogRoot>
-<template/>
+</template>
 ```
 
 ## API Reference
@@ -391,4 +391,4 @@ data: [
     },
   ]
 ---
-:: 
+::

--- a/docs/content/3.components/dropdown-menu.md
+++ b/docs/content/3.components/dropdown-menu.md
@@ -7,11 +7,6 @@ aria: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton
 
 # Dropdown Menu
 
-<Description>
-  Displays a menu to the user—such as a set of actions or functions—triggered by
-  a button.
-</Description>
-
 ::description
 Displays a menu to the user—such as a set of actions or functions—triggered by
   a button.


### PR DESCRIPTION
Converts mdx to mdc for documentation content files.

## Description
Currently the docs pages under '/components' were all copied from radix. What we need to do first is we need to convert from the current mdx syntax to [mdc](https://content.nuxtjs.org/guide/writing/mdc/). We have converted the Alert Dialog as an example to be applied to every other components.

## Related Issue
https://github.com/radix-vue/radix-vue/issues/172

