### PR TITLE
fix: component emitted an undefined event.

### DIFF
--- a/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
@@ -27,7 +27,7 @@ const props = withDefaults(defineProps<AlertDialogRootProps>(), {
 });
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
+  (e: "update:open", value: boolean): void;
 }>();
 
 const open = useVModel(props, "open", emit, {

--- a/packages/radix-vue/src/Dialog/DialogRoot.vue
+++ b/packages/radix-vue/src/Dialog/DialogRoot.vue
@@ -30,7 +30,7 @@ const props = withDefaults(defineProps<DialogRootProps>(), {
 });
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
+  (e: "update:open", value: boolean): void;
 }>();
 
 const open = useVModel(props, "open", emit, {

--- a/packages/radix-vue/src/Menubar/MenubarRoot.vue
+++ b/packages/radix-vue/src/Menubar/MenubarRoot.vue
@@ -39,7 +39,6 @@ const props = withDefaults(defineProps<MenubarRootProps>(), {
 
 const emit = defineEmits<{
   (e: "update:modelValue", value: boolean): void;
-  (e: "update:open", value: boolean): void;
 }>();
 
 const modelValue = useVModel(props, "modelValue", emit, {


### PR DESCRIPTION
The following warning will appear when the `key` of `useVModel`'s parameters is not defined in `defineEmits`.

```console
[Vue warn]: Component emitted event "xxxx" but it is neither declared in the emits option nor as an "xxxx" prop.
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

1. update the event name in `defineEmits` to the same as the `key` of `useVModel`'s parameters. `AlertDialogRoot`,`DialogRoot`
2. remove redundant event names. `MenubarRoot`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #252 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- What will change? Provide a before and after -->

make a better DX

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested it with histoire.

## Screenshots (if appropriate):
![](https://user-images.githubusercontent.com/37807381/256119463-06dcab5b-63e8-4dc9-a49b-1d5acf0b17a1.png)
