### PR TITLE
fix(tooltip): Remove unnecessary inline style

### DIFF
--- a/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
@@ -46,7 +46,6 @@ useHover(triggerElement, {
       :aria-expanded="injectedValue?.open.value || false"
       @focus="injectedValue?.showTooltip(false)"
       @blur="injectedValue?.hideTooltip"
-      style="cursor: default"
     >
       <slot />
     </PrimitiveButton>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes unnecessary inline style (cursor: default) in TooltipTrigger

## Related Issue
#258

## Motivation and Context
Prevents cursor styles from child elements from being overridden

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

