### PR TITLE
[Dialog]: fix the screen scrolling behavior

### DIFF
--- a/packages/radix-vue/src/AlertDialog/AlertDialogContent.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogContent.vue
@@ -51,13 +51,11 @@ watchEffect(() => {
       trapFocus(currentElement.value);
     }
     setBodyUninteractive();
-    window.addEventListener("wheel", lockScroll, { passive: false });
     window.addEventListener("keydown", lockKeydown);
     window.addEventListener("keydown", handleKeydown);
     emit("open");
   } else {
     setBodyInteractive();
-    window.removeEventListener("wheel", lockScroll);
     window.removeEventListener("keydown", lockKeydown);
     window.removeEventListener("keydown", handleKeydown);
 
@@ -68,11 +66,6 @@ watchEffect(() => {
     emit("close");
   }
 });
-
-function lockScroll(e: WheelEvent) {
-  e.preventDefault();
-}
-
 function lockKeydown(e: KeyboardEvent) {
   if (e.key === "ArrowDown" || e.key === "ArrowUp") {
     const activeElement = document.activeElement;

--- a/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
@@ -18,8 +18,8 @@ export type AlertDialogProvideValue = {
 </script>
 
 <script setup lang="ts">
-import { provide, ref } from "vue";
-import { useVModel } from "@vueuse/core";
+import { provide, ref, watch, watchEffect } from "vue";
+import { useScrollLock, useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<AlertDialogRootProps>(), {
   open: undefined,
@@ -33,6 +33,12 @@ const emit = defineEmits<{
 const open = useVModel(props, "open", emit, {
   defaultValue: props.defaultOpen,
   passive: true,
+});
+
+const locked = useScrollLock(document.querySelector("body"), open.value);
+
+watchEffect(() => {
+  locked.value = open.value;
 });
 
 provide<AlertDialogProvideValue>(ALERT_DIALOG_INJECTION_KEY, {

--- a/packages/radix-vue/src/Dialog/DialogContent.vue
+++ b/packages/radix-vue/src/Dialog/DialogContent.vue
@@ -68,14 +68,12 @@ watchEffect(() => {
       setBodyUninteractive();
     }
     if (injectedValue?.modal) {
-      window.addEventListener("wheel", lockScroll, { passive: false });
       window.addEventListener("keydown", lockKeydown);
     }
     window.addEventListener("keydown", handleKeydown);
     emit("open");
   } else {
     setBodyInteractive();
-    window.removeEventListener("wheel", lockScroll);
     window.removeEventListener("keydown", lockKeydown);
     window.removeEventListener("keydown", handleKeydown);
 
@@ -86,10 +84,6 @@ watchEffect(() => {
     emit("close");
   }
 });
-
-function lockScroll(e: WheelEvent) {
-  e.preventDefault();
-}
 
 function lockKeydown(e: KeyboardEvent) {
   if (e.key === "ArrowDown" || e.key === "ArrowUp") {

--- a/packages/radix-vue/src/Dialog/DialogRoot.vue
+++ b/packages/radix-vue/src/Dialog/DialogRoot.vue
@@ -20,8 +20,8 @@ export type DialogProvideValue = {
 </script>
 
 <script setup lang="ts">
-import { provide, ref } from "vue";
-import { useVModel } from "@vueuse/core";
+import { provide, ref, watchEffect } from "vue";
+import { useScrollLock, useVModel } from "@vueuse/core";
 
 const props = withDefaults(defineProps<DialogRootProps>(), {
   open: undefined,
@@ -36,6 +36,12 @@ const emit = defineEmits<{
 const open = useVModel(props, "open", emit, {
   defaultValue: props.defaultOpen,
   passive: true,
+});
+
+const locked = useScrollLock(document.querySelector("body"), open.value);
+
+watchEffect(() => {
+  locked.value = open.value;
 });
 
 provide<DialogProvideValue>(DIALOG_INJECTION_KEY, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**The dialog has some wrong behaviors. Include `Dialog` and `AlertDialog`**
- Always scrollable background on mobile browser.
- Can't scroll the dialog content by mouse wheel, when its overflow behavior is scroll.

## Description
<!--- Describe your changes in detail -->
1. Remove `wheel` event listener. 
If the `DialogContent` is a scrollable componet, `wheel` prevented will make content can't scroll by mouse wheel.
2. Lock body scroll
Through `useScrollLock`, easy to lock body scrolling on mobile and Desktop. It adds style: `overflow: hidden` to body.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #256

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- What will change? Provide a before and after -->
Fixed an issue 
- #256

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes, tested with histoire. Include mobile and desktop.

## Screenshots (if appropriate):

### On mobile
https://github.com/radix-vue/radix-vue/assets/37807381/baa92df9-e5b2-40c8-93d1-6d7c22486466

### On desktop, can't seem to tell the difference.
https://github.com/radix-vue/radix-vue/assets/37807381/382e1911-58f8-4427-9fae-075a88510e36

