### PR TITLE
[AlertDialog] fix possible errors with watchEffect, implement radix-ui accesibility attirbutes that depends on element id ...

### DIFF
--- a/packages/radix-vue/src/AlertDialog/AlertDialogAction.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogAction.vue
@@ -1,25 +1,20 @@
 <script setup lang="ts">
 import { inject } from "vue";
 import { PrimitiveButton, type PrimitiveProps } from "@/Primitive";
-import {
-  ALERT_DIALOG_INJECTION_KEY,
-  type AlertDialogProvideValue,
-} from "./AlertDialogRoot.vue";
+import { ALERT_DIALOG_INJECTION_KEY } from "./AlertDialogRoot.vue";
 
 export interface AlertDialogActionProps extends PrimitiveProps {}
 const props = defineProps<AlertDialogActionProps>();
 
-const injectedValue = inject<AlertDialogProvideValue>(
-  ALERT_DIALOG_INJECTION_KEY
-);
-
-function handleClick() {
-  injectedValue?.closeModal();
-}
+const injectedValue = inject(ALERT_DIALOG_INJECTION_KEY);
 </script>
 
 <template>
-  <PrimitiveButton v-bind="props" type="button" @click="handleClick">
+  <PrimitiveButton
+    v-bind="props"
+    type="button"
+    @click="injectedValue?.closeModal()"
+  >
     <slot />
   </PrimitiveButton>
 </template>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogCancel.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogCancel.vue
@@ -1,25 +1,20 @@
 <script setup lang="ts">
 import { inject } from "vue";
 import { PrimitiveButton, type PrimitiveProps } from "@/Primitive";
-import {
-  ALERT_DIALOG_INJECTION_KEY,
-  type AlertDialogProvideValue,
-} from "./AlertDialogRoot.vue";
+import { ALERT_DIALOG_INJECTION_KEY } from "./AlertDialogRoot.vue";
 
 export interface AlertDialogCancelProps extends PrimitiveProps {}
 const props = defineProps<AlertDialogCancelProps>();
 
-const injectedValue = inject<AlertDialogProvideValue>(
-  ALERT_DIALOG_INJECTION_KEY
-);
-
-function handleClick() {
-  injectedValue?.closeModal();
-}
+const injectedValue = inject(ALERT_DIALOG_INJECTION_KEY);
 </script>
 
 <template>
-  <PrimitiveButton v-bind="props" type="button" @click="handleClick">
+  <PrimitiveButton
+    v-bind="props"
+    type="button"
+    @click="injectedValue?.closeModal()"
+  >
     <slot />
   </PrimitiveButton>
 </template>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogContent.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogContent.vue
@@ -35,6 +35,20 @@ const emit = defineEmits<AlertDialogContentEmits>();
 const { primitiveElement, currentElement } = usePrimitiveElement();
 
 watchEffect((onCleanup) => {
+  onCleanup(() => {
+    document.body.style.pointerEvents = "";
+
+    window.removeEventListener("wheel", lockScroll);
+    window.removeEventListener("keydown", lockKeydown);
+    window.removeEventListener("keydown", handleKeydown);
+
+    if (props.isCloseAutoFocus) {
+      injectedValue?.triggerButton.value?.focus();
+    }
+
+    emit("close");
+  });
+
   if (!currentElement.value) {
     return;
   }
@@ -50,20 +64,6 @@ watchEffect((onCleanup) => {
     window.addEventListener("keydown", handleKeydown);
     emit("open");
   }
-
-  onCleanup(() => {
-    document.body.style.pointerEvents = "";
-
-    window.removeEventListener("wheel", lockScroll);
-    window.removeEventListener("keydown", lockKeydown);
-    window.removeEventListener("keydown", handleKeydown);
-
-    if (props.isCloseAutoFocus) {
-      injectedValue?.triggerButton.value?.focus();
-    }
-
-    emit("close");
-  });
 });
 
 const lockScroll = (e: WheelEvent) => e.preventDefault();

--- a/packages/radix-vue/src/AlertDialog/AlertDialogDescription.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogDescription.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
+import { inject } from "vue";
 import { PrimitiveP, type PrimitiveProps } from "@/Primitive";
+import { ALERT_DIALOG_INJECTION_KEY } from "./AlertDialogRoot.vue";
 
 export interface AlertDialogDescriptionProps extends PrimitiveProps {}
 const props = defineProps<AlertDialogDescriptionProps>();
+
+const injectedValue = inject(ALERT_DIALOG_INJECTION_KEY);
 </script>
 
 <template>
-  <PrimitiveP v-bind="props"><slot /></PrimitiveP>
+  <PrimitiveP v-bind="props" :id="injectedValue?.descriptionId"
+    ><slot
+  /></PrimitiveP>
 </template>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogOverlay.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogOverlay.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
-import { inject } from "vue";
-import {
-  ALERT_DIALOG_INJECTION_KEY,
-  type AlertDialogProvideValue,
-} from "./AlertDialogRoot.vue";
+import { ALERT_DIALOG_INJECTION_KEY } from "./AlertDialogRoot.vue";
 import { PrimitiveDiv, type PrimitiveProps } from "@/Primitive";
+import { inject } from "vue";
 
 export interface AlertDialogOverlayProps extends PrimitiveProps {}
 const props = defineProps<AlertDialogOverlayProps>();
 
-const injectedValue = inject<AlertDialogProvideValue>(
-  ALERT_DIALOG_INJECTION_KEY
-);
+const injectedValue = inject(ALERT_DIALOG_INJECTION_KEY);
 </script>
 
 <template>
   <PrimitiveDiv
-    v-bind="props"
     v-if="injectedValue?.open.value"
+    v-bind="props"
     :as-child="props.asChild"
     :data-state="injectedValue?.open.value ? 'open' : 'closed'"
     style="pointer-events: auto"

--- a/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
@@ -10,32 +10,41 @@ export const ALERT_DIALOG_INJECTION_KEY =
   Symbol() as InjectionKey<AlertDialogProvideValue>;
 
 export type AlertDialogProvideValue = {
+  contentId: string;
+  titleId: string;
+  descriptionId: string;
   open: Readonly<Ref<boolean>>;
   openModal(): void;
   closeModal(): void;
   triggerButton: Ref<HTMLElement | undefined>;
+};
+
+export type AlertDialogRootEmits = {
+  (e: "update:open", value: boolean): void;
 };
 </script>
 
 <script setup lang="ts">
 import { provide, ref } from "vue";
 import { useVModel } from "@vueuse/core";
+import { useId } from "@/shared";
 
 const props = withDefaults(defineProps<AlertDialogRootProps>(), {
   open: undefined,
   defaultOpen: false,
 });
 
-const emit = defineEmits<{
-  (e: "update:open", value: boolean): void;
-}>();
+const emit = defineEmits<AlertDialogRootEmits>();
 
 const open = useVModel(props, "open", emit, {
   defaultValue: props.defaultOpen,
   passive: true,
 });
 
-provide<AlertDialogProvideValue>(ALERT_DIALOG_INJECTION_KEY, {
+provide(ALERT_DIALOG_INJECTION_KEY, {
+  contentId: useId(),
+  titleId: useId(),
+  descriptionId: useId(),
   open,
   openModal: () => {
     open.value = true;

--- a/packages/radix-vue/src/AlertDialog/AlertDialogTitle.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogTitle.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
+import { inject } from "vue";
 import { PrimitiveH2, type PrimitiveProps } from "@/Primitive";
+import { ALERT_DIALOG_INJECTION_KEY } from "./AlertDialogRoot.vue";
 
 export interface AlertDialogTitleProps extends PrimitiveProps {}
 const props = defineProps<AlertDialogTitleProps>();
+
+const injectedValue = inject(ALERT_DIALOG_INJECTION_KEY);
 </script>
 
 <template>
-  <PrimitiveH2 v-bind="props"><slot /></PrimitiveH2>
+  <PrimitiveH2 v-bind="props" :id="injectedValue?.titleId">
+    <slot />
+  </PrimitiveH2>
 </template>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogTrigger.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogTrigger.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 import { inject, onMounted } from "vue";
-import {
-  ALERT_DIALOG_INJECTION_KEY,
-  type AlertDialogProvideValue,
-} from "./AlertDialogRoot.vue";
+import { ALERT_DIALOG_INJECTION_KEY } from "./AlertDialogRoot.vue";
 import {
   PrimitiveButton,
   usePrimitiveElement,
@@ -12,22 +9,16 @@ import {
 
 export interface AlertDialogTriggerProps extends PrimitiveProps {}
 
-const injectedValue = inject<AlertDialogProvideValue>(
-  ALERT_DIALOG_INJECTION_KEY
-);
+const injectedValue = inject(ALERT_DIALOG_INJECTION_KEY);
 const { primitiveElement, currentElement } = usePrimitiveElement();
-
-function showErrorInjectedValueNotExist() {
-  console.error(
-    "Injected value not found, AlertDialogTrigger possibly not wrapped with AlertDialogRoot. Component may not be working properly."
-  );
-}
 
 onMounted(() => {
   if (injectedValue) {
     injectedValue.triggerButton.value = currentElement.value;
   } else {
-    showErrorInjectedValueNotExist();
+    console.error(
+      "Injected value not found, AlertDialogTrigger possibly not wrapped with AlertDialogRoot. Component may not be working properly."
+    );
   }
 });
 
@@ -39,6 +30,8 @@ const props = defineProps<AlertDialogTriggerProps>();
     v-bind="props"
     type="button"
     ref="primitiveElement"
+    aria-haspopup="dialog"
+    :aria-controls="injectedValue?.contentId"
     :aria-expanded="injectedValue?.open.value || false"
     :data-state="injectedValue?.open.value ? 'open' : 'closed'"
     @click="injectedValue?.openModal"


### PR DESCRIPTION
1. Move cleanup logic from watchEffect to onCleanup hook. 
2. Changed role for DialogContent from "dialog" to "alertdialog". (to match radix-ui)
3. Add id attributes to title, description and dialog content to implement aria-labelledby, and other accasibility things. Now should be the same as in radix
4. Removed unnecessary generic casting for inject/provide values. 

