### PR TITLE
chore: add types for histoire components

### DIFF
--- a/packages/radix-vue/env.d.ts
+++ b/packages/radix-vue/env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="@histoire/plugin-vue/components" />


### PR DESCRIPTION
I encountered that the histoire components were not being detected by typscript. I fixed this according to the histoire documentation.
https://histoire.dev/guide/vue3/getting-started.html#typescript

> BEFORE
![image](https://github.com/radix-vue/radix-vue/assets/51422045/1b2222cc-5685-4a7a-ad79-9c21ef0991ff)

> AFTER
![image](https://github.com/radix-vue/radix-vue/assets/51422045/048f031c-8818-4e23-96d8-abb62a4b576f)

