### PR TITLE
fix(useBodyScrollLock): improve document SSR

### DIFF
--- a/packages/radix-vue/src/shared/useBodyScrollLock.ts
+++ b/packages/radix-vue/src/shared/useBodyScrollLock.ts
@@ -1,14 +1,17 @@
-import { useScrollLock } from "@vueuse/core";
+import { useScrollLock, defaultDocument } from "@vueuse/core";
+import { isClient } from "@vueuse/shared";
 import { computed } from "vue";
 
 export const useBodyScrollLock = (initialState?: boolean | undefined) => {
-  const locked = useScrollLock(document.body, initialState);
+  const locked = useScrollLock(defaultDocument?.body, initialState);
 
   return computed<boolean>({
     get() {
       return locked.value;
     },
     set(newLocked) {
+      if (!isClient) return;
+
       if (newLocked) {
         const verticalScrollbarWidth =
           window.innerWidth - document.documentElement.clientWidth;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

To prevent SSR error (`document is not defined`) in Nuxt playground,
Used **existing** utils in `@vueuse/core` and `@vueuse/shared` modules


