### PR TITLE
chore(accordion-item): remove watcher that was logging 'run' in accordion-item

### DIFF
--- a/packages/radix-vue/src/Accordion/AccordionItem.vue
+++ b/packages/radix-vue/src/Accordion/AccordionItem.vue
@@ -69,10 +69,6 @@ const dataState = computed(() =>
   open.value ? AccordionItemState.Open : AccordionItemState.Closed
 );
 
-watch(dataState, () => {
-  console.log("run");
-});
-
 const { primitiveElement, currentElement } = usePrimitiveElement();
 
 provide<AccordionItemProvideValue>(ACCORDION_ITEM_INJECTION_KEY, {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Removed the watcher in the AccordionItem component that was logging the word 'run' when the `dataState` value was truthy.

## Screenshots (if appropriate):

<img width="1151" alt="image" src="https://github.com/radix-vue/radix-vue/assets/53905713/7d8fa82a-aa5a-4ce3-8836-b4e2ad279bda">
