### PR TITLE
feat: add `prefix` option to Nuxt module

### DIFF
--- a/packages/radix-nuxt/src/index.ts
+++ b/packages/radix-nuxt/src/index.ts
@@ -3,7 +3,11 @@ import { addComponent, defineNuxtModule } from '@nuxt/kit'
 import type { } from '@nuxt/schema' // workaround for TS bug with "phantom" deps
 import * as components from 'radix-vue'
 
-export default defineNuxtModule({
+export interface ModuleOptions {
+  prefix: string
+}
+
+export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@radix-vue/nuxt',
     configKey: 'radix',
@@ -11,10 +15,13 @@ export default defineNuxtModule({
       nuxt: '^3.0.0',
     },
   },
-  setup() {
+  defaults: {
+    prefix: '',
+  },
+  setup(options) {
     for (const component of Object.keys(components)) {
       addComponent({
-        name: component,
+        name: `${options.prefix}${component}`,
         export: component,
         filePath: 'radix-vue',
       })


### PR DESCRIPTION
This PR allows for (optionally) prefixing auto-imported Nuxt components' names.