### PR TITLE
docs:  tables info popover styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ We would love to have your contributions! All PRs all welcomed! We need help bui
 
 1. Go to the docs directory : `cd docs`
 2. Run `pnpm i --ignore-workspace`
-3. Run `pnpm run dev`
+3. Run `pnpm run docs:dev`
 
 ### Package
 

--- a/docs/components/tables/EmitsTable.vue
+++ b/docs/components/tables/EmitsTable.vue
@@ -32,23 +32,25 @@ const props = defineProps<EmitsTableProps>()
     <tbody>
       <ProseTr v-for="(prop, index) in props.data" :key="`${prop.name}-${index}`">
         <ProseTd>
-          <ProseCodeInline class=" !text-[13px]">
-            {{ prop.name }}{{ prop.required ? "*" : null }}
-          </ProseCodeInline>
-          <template v-if="prop.description">
-            <PopoverRoot>
-              <PopoverTrigger class="p-1.5 rounded hover:bg-neutral-900 focus:outline-2 outline-neutral-800">
-                <Icon icon="radix-icons:info-circled" class="h-4 w-4 text-neutral-400" />
-              </PopoverTrigger>
-              <PopoverContent
-                side="top"
-                class="text-xs rounded-lg px-3 py-2.5 bg-neutral-800 w-[265px] shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] will-change-[transform,opacity] data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade"
-              >
-                <span size="2" class="leading-5" v-html="prop.description" />
-                <PopoverArrow class="fill-neutral-800" :size="8" />
-              </PopoverContent>
-            </PopoverRoot>
-          </template>
+          <div class="flex items-center gap-1">
+            <ProseCodeInline class=" !text-[13px]">
+              {{ prop.name }}{{ prop.required ? "*" : null }}
+            </ProseCodeInline>
+            <template v-if="prop.description">
+              <PopoverRoot>
+                <PopoverTrigger class="p-1.5 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-2 outline-neutral-800">
+                  <Icon icon="radix-icons:info-circled" class="h-4 w-4 text-neutral-400" />
+                </PopoverTrigger>
+                <PopoverContent
+                  side="top"
+                  class="text-xs rounded-lg px-3 py-2.5 bg-white dark:bg-neutral-800 w-[265px] shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] will-change-[transform,opacity] data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade"
+                >
+                  <span size="2" class="leading-5" v-html="prop.description" />
+                  <PopoverArrow class="dark:fill-neutral-800 fill-white" :size="8" />
+                </PopoverContent>
+              </PopoverRoot>
+            </template>
+          </div>
         </ProseTd>
         <ProseTd>
           <ProseCodeInline variant="secondary">

--- a/docs/components/tables/PropsTable.vue
+++ b/docs/components/tables/PropsTable.vue
@@ -42,15 +42,15 @@ const props = defineProps<PropsTableProps>()
             </ProseCodeInline>
             <template v-if="prop.description">
               <PopoverRoot>
-                <PopoverTrigger class="p-1.5 rounded hover:bg-neutral-900 focus:outline-2 outline-neutral-800">
+                <PopoverTrigger class="p-1.5 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-2 outline-neutral-800">
                   <Icon icon="radix-icons:info-circled" class="h-4 w-4 text-neutral-400" />
                 </PopoverTrigger>
                 <PopoverContent
                   side="top"
-                  class="text-xs rounded-lg px-3 py-2.5 bg-neutral-800 w-[265px] shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] will-change-[transform,opacity] data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade"
+                  class="text-xs rounded-lg px-3 py-2.5 bg-white dark:bg-neutral-800 w-[265px] shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] will-change-[transform,opacity] data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade"
                 >
                   <span size="2" class="leading-5" v-html="prop.description" />
-                  <PopoverArrow class="fill-neutral-800" :size="8" />
+                  <PopoverArrow class="dark:fill-neutral-800 fill-white" :size="8" />
                 </PopoverContent>
               </PopoverRoot>
             </template>


### PR DESCRIPTION
I was browsing the docs in a bright environment with light mode turned on and noticed the popovers weren't readable. In this small contribution colors in light mode are fixed. I've also updated the positioning of the popover trigger in the `EmitsTable` to match the `PropsTable`.