### PR TITLE
chore: update Tooltip to use Portal instead of Teleport

### DIFF
--- a/docs/components/Tooltip.vue
+++ b/docs/components/Tooltip.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TooltipArrow, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from 'radix-vue'
+import { TooltipArrow, TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from 'radix-vue'
 
 defineProps<{
   content: string
@@ -15,14 +15,14 @@ defineProps<{
       >
         <slot />
       </TooltipTrigger>
-      <Teleport to="body">
+      <TooltipPortal to="body">
         <TooltipContent
           class="text-xs data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-grass11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
         >
           {{ content }}
           <TooltipArrow class="fill-white" size="8" />
         </TooltipContent>
-      </Teleport>
+      </TooltipPortal>
     </TooltipRoot>
   </TooltipProvider>
 </template>

--- a/docs/components/Tooltip.vue
+++ b/docs/components/Tooltip.vue
@@ -15,7 +15,7 @@ defineProps<{
       >
         <slot />
       </TooltipTrigger>
-      <TooltipPortal to="body">
+      <TooltipPortal>
         <TooltipContent
           class="text-xs data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-grass11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
         >

--- a/docs/components/demo/Tooltip/index.vue
+++ b/docs/components/demo/Tooltip/index.vue
@@ -11,7 +11,7 @@ import { Icon } from '@iconify/vue'
       >
         <Icon icon="radix-icons:plus" />
       </TooltipTrigger>
-      <TooltipPortal to="body">
+      <TooltipPortal>
         <TooltipContent
           as-child
           class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-grass11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"

--- a/docs/components/demo/Tooltip/index.vue
+++ b/docs/components/demo/Tooltip/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TooltipArrow, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from 'radix-vue'
+import { TooltipArrow, TooltipContent, TooltipProvider, TooltipPortal, TooltipRoot, TooltipTrigger } from 'radix-vue'
 import { Icon } from '@iconify/vue'
 </script>
 
@@ -11,7 +11,7 @@ import { Icon } from '@iconify/vue'
       >
         <Icon icon="radix-icons:plus" />
       </TooltipTrigger>
-      <Teleport to="body">
+      <TooltipPortal to="body">
         <TooltipContent
           as-child
           class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-grass11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
@@ -22,7 +22,7 @@ import { Icon } from '@iconify/vue'
             <TooltipArrow class="fill-white" size="8" />
           </ul>
         </TooltipContent>
-      </Teleport>
+      </TooltipPortal>
     </TooltipRoot>
   </TooltipProvider>
 </template>

--- a/docs/components/home/demos/TooltipDemo.vue
+++ b/docs/components/home/demos/TooltipDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TooltipArrow, TooltipContent, TooltipRoot, TooltipTrigger } from 'radix-vue'
+import { TooltipArrow, TooltipContent, TooltipRoot, TooltipTrigger, TooltipPortal } from 'radix-vue'
 import { Icon } from '@iconify/vue'
 import { ref } from 'vue'
 
@@ -7,10 +7,10 @@ const toggleState = ref(false)
 </script>
 
 <template>
-  <div class="absolute left-4 top-3 text-sm">
+  <div class="absolute text-sm left-4 top-3">
     <p>Value: {{ toggleState ? "checked" : "unchecked" }}</p>
     <button
-      class="bg-white/20 px-2 py-1 rounded-md active:scale-90 duration-100 transform hover:bg-white/40 active:bg-white/20"
+      class="px-2 py-1 duration-100 transform rounded-md bg-white/20 active:scale-90 hover:bg-white/40 active:bg-white/20"
       @click="toggleState = !toggleState"
     >
       {{ toggleState ? "Close" : "Open" }}
@@ -22,7 +22,7 @@ const toggleState = ref(false)
     >
       <Icon icon="radix-icons:plus" />
     </TooltipTrigger>
-    <Teleport to="body">
+    <TooltipPortal to="body">
       <TooltipContent
         as-child
         class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
@@ -32,6 +32,6 @@ const toggleState = ref(false)
           <TooltipArrow class="bg-white" size="8" />
         </ul>
       </TooltipContent>
-    </Teleport>
+    </TooltipPortal>
   </TooltipRoot>
 </template>

--- a/docs/components/home/demos/TooltipDemo.vue
+++ b/docs/components/home/demos/TooltipDemo.vue
@@ -22,7 +22,7 @@ const toggleState = ref(false)
     >
       <Icon icon="radix-icons:plus" />
     </TooltipTrigger>
-    <TooltipPortal to="body">
+    <TooltipPortal>
       <TooltipContent
         as-child
         class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"

--- a/packages/radix-vue/src/Tooltip/stories/Tooltip.content.story.vue
+++ b/packages/radix-vue/src/Tooltip/stories/Tooltip.content.story.vue
@@ -17,7 +17,7 @@ const lastEvent = ref('')
             >
               <Icon icon="radix-icons:plus" />
             </TooltipTrigger>
-            <TooltipPortal to="body">
+            <TooltipPortal>
               <TooltipContent
                 as-child
                 align="start"

--- a/packages/radix-vue/src/Tooltip/stories/Tooltip.story.vue
+++ b/packages/radix-vue/src/Tooltip/stories/Tooltip.story.vue
@@ -16,7 +16,7 @@ const toggleState = ref(false)
           >
             <Icon icon="radix-icons:plus" />
           </TooltipTrigger>
-          <TooltipPortal to="body">
+          <TooltipPortal>
             <TooltipContent
               as-child
               :side-offset="5"

--- a/packages/radix-vue/src/Tooltip/stories/_Tooltip.vue
+++ b/packages/radix-vue/src/Tooltip/stories/_Tooltip.vue
@@ -13,7 +13,7 @@ const toggleState = ref(false)
       >
         some info
       </TooltipTrigger>
-      <TooltipPortal to="body">
+      <TooltipPortal>
         <TooltipContent
           :side-offset="5"
           class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"

--- a/playground/nuxt/components/TooltipDemo.vue
+++ b/playground/nuxt/components/TooltipDemo.vue
@@ -21,7 +21,7 @@ const toggleState = ref(false)
       >
         <Icon icon="radix-icons:plus" />
       </TooltipTrigger>
-      <TooltipPortal to="body">
+      <TooltipPortal>
         <TooltipContent
           as-child :side-offset="5"
           class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"

--- a/playground/nuxt/components/TooltipDemo.vue
+++ b/playground/nuxt/components/TooltipDemo.vue
@@ -21,7 +21,7 @@ const toggleState = ref(false)
       >
         <Icon icon="radix-icons:plus" />
       </TooltipTrigger>
-      <Teleport to="body">
+      <TooltipPortal to="body">
         <TooltipContent
           as-child :side-offset="5"
           class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
@@ -31,7 +31,7 @@ const toggleState = ref(false)
             <TooltipArrow class="fill-white" />
           </ul>
         </TooltipContent>
-      </Teleport>
+      </TooltipPortal>
     </TooltipRoot>
   </TooltipProvider>
 </template>

--- a/playground/vue3/src/components/Demo/TooltipDemo.vue
+++ b/playground/vue3/src/components/Demo/TooltipDemo.vue
@@ -22,7 +22,7 @@ const toggleState = ref(false)
     >
       <Icon icon="radix-icons:plus" />
     </TooltipTrigger>
-    <TooltipPortal to="body">
+    <TooltipPortal>
       <TooltipContent
         as-child :side-offset="5"
         class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"

--- a/playground/vue3/src/components/Demo/TooltipDemo.vue
+++ b/playground/vue3/src/components/Demo/TooltipDemo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { ref } from 'vue'
-import { TooltipArrow, TooltipContent, TooltipRoot, TooltipTrigger } from '@/Tooltip'
+import { TooltipArrow, TooltipContent, TooltipPortal, TooltipRoot, TooltipTrigger } from '@/Tooltip'
 
 const toggleState = ref(false)
 </script>
@@ -22,7 +22,7 @@ const toggleState = ref(false)
     >
       <Icon icon="radix-icons:plus" />
     </TooltipTrigger>
-    <Teleport to="body">
+    <TooltipPortal to="body">
       <TooltipContent
         as-child :side-offset="5"
         class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
@@ -32,6 +32,6 @@ const toggleState = ref(false)
           <TooltipArrow class="fill-white" />
         </ul>
       </TooltipContent>
-    </Teleport>
+    </TooltipPortal>
   </TooltipRoot>
 </template>


### PR DESCRIPTION
As we chat in Discord, we will recomend the use of `Teleport`.

Therefore, I just updated the demos for Tooltips