### PR TITLE
fix: fix default radiogroup orientation

### DIFF
--- a/packages/radix-vue/src/RovingFocus/RovingFocusGroup.vue
+++ b/packages/radix-vue/src/RovingFocus/RovingFocusGroup.vue
@@ -58,7 +58,6 @@ import {
 const props = withDefaults(defineProps<RovingFocusGroupProps>(), {
   loop: false,
   dir: 'ltr',
-  orientation: 'horizontal',
 })
 const emits = defineEmits<RovingFocusGroupEmits>()
 const { loop, orientation, dir } = toRefs(props)


### PR DESCRIPTION
fixes #382 

removing default orientation allows bidirectional orientation