### PR TITLE
fix: allow AvatarImage to be reactive

### DIFF
--- a/packages/radix-vue/src/Avatar/Avatar.test.ts
+++ b/packages/radix-vue/src/Avatar/Avatar.test.ts
@@ -7,7 +7,7 @@ import { nextTick } from 'vue'
 import { findByAltText, findByRole, findByText } from '@testing-library/vue'
 
 const FALLBACK = 'CT'
-const DELAY = 300
+const DELAY = 301
 
 it('should pass axe accessibility tests', async () => {
   const wrapper = mount(Avatar)

--- a/packages/radix-vue/src/Avatar/Avatar.test.ts
+++ b/packages/radix-vue/src/Avatar/Avatar.test.ts
@@ -7,7 +7,7 @@ import { nextTick } from 'vue'
 import { findByAltText, findByRole, findByText } from '@testing-library/vue'
 
 const FALLBACK = 'CT'
-const DELAY = 301
+const DELAY = 350
 
 it('should pass axe accessibility tests', async () => {
   const wrapper = mount(Avatar)

--- a/packages/radix-vue/src/Avatar/AvatarFallback.vue
+++ b/packages/radix-vue/src/Avatar/AvatarFallback.vue
@@ -5,7 +5,7 @@ export interface AvatarFallbackProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { inject, ref } from 'vue'
+import { inject, ref, watch } from 'vue'
 import { Primitive, type PrimitiveProps } from '../Primitive'
 import { AVATAR_INJECTION_KEY } from './AvatarRoot.vue'
 
@@ -14,25 +14,30 @@ const props = withDefaults(defineProps<AvatarFallbackProps>(), {
   as: 'span',
 })
 
-const injectedValue = inject(AVATAR_INJECTION_KEY)
+const context = inject(AVATAR_INJECTION_KEY)
 
 const canRender = ref(false)
 let timeout: ReturnType<typeof setTimeout> | undefined
 
-if (props.delayMs) {
-  timeout = setTimeout(() => {
-    canRender.value = true
-    clearTimeout(timeout)
-  }, props.delayMs)
-}
-else {
-  canRender.value = true
-}
+watch(() => context?.imageLoadingStatus.value, (value) => {
+  if (value === 'loading') {
+    canRender.value = false
+    if (props.delayMs) {
+      timeout = setTimeout(() => {
+        canRender.value = true
+        clearTimeout(timeout)
+      }, props.delayMs)
+    }
+    else {
+      canRender.value = true
+    }
+  }
+}, { immediate: true })
 </script>
 
 <template>
   <Primitive
-    v-if="canRender && injectedValue?.imageLoadingStatus.value !== 'loaded'"
+    v-if="canRender && context?.imageLoadingStatus.value !== 'loaded'"
     :as-child="props.asChild"
     :as="as"
   >

--- a/packages/radix-vue/src/Avatar/AvatarImage.vue
+++ b/packages/radix-vue/src/Avatar/AvatarImage.vue
@@ -6,7 +6,7 @@ export interface AvatarImageProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { inject, useAttrs, watch } from 'vue'
+import { inject, onUpdated, ref, useAttrs, watch } from 'vue'
 import { Primitive, type PrimitiveProps } from '../Primitive'
 import { AVATAR_INJECTION_KEY } from './AvatarRoot.vue'
 import { type ImageLoadingStatus, useImageLoadingStatus } from './utils'
@@ -17,8 +17,12 @@ const emits = defineEmits<AvatarImageEmits>()
 
 const injectedValue = inject(AVATAR_INJECTION_KEY)
 
-const src = useAttrs().src as string
+const src = ref(useAttrs().src as string)
 const imageLoadingStatus = useImageLoadingStatus(src)
+
+onUpdated(() => {
+  src.value = useAttrs().src as string
+})
 
 watch(
   imageLoadingStatus,

--- a/packages/radix-vue/src/Avatar/AvatarImage.vue
+++ b/packages/radix-vue/src/Avatar/AvatarImage.vue
@@ -2,34 +2,31 @@
 export type AvatarImageEmits = {
   'loadingStatusChange': [value: ImageLoadingStatus]
 }
-export interface AvatarImageProps extends PrimitiveProps {}
+export interface AvatarImageProps extends PrimitiveProps {
+  src: string
+}
 </script>
 
 <script setup lang="ts">
-import { inject, onUpdated, ref, useAttrs, watch } from 'vue'
+import { inject, toRefs, watch } from 'vue'
 import { Primitive, type PrimitiveProps } from '../Primitive'
 import { AVATAR_INJECTION_KEY } from './AvatarRoot.vue'
 import { type ImageLoadingStatus, useImageLoadingStatus } from './utils'
 
 const props = withDefaults(defineProps<AvatarImageProps>(), { as: 'img' })
-
 const emits = defineEmits<AvatarImageEmits>()
 
-const injectedValue = inject(AVATAR_INJECTION_KEY)
+const { src } = toRefs(props)
+const context = inject(AVATAR_INJECTION_KEY)
 
-const src = ref(useAttrs().src as string)
 const imageLoadingStatus = useImageLoadingStatus(src)
-
-onUpdated(() => {
-  src.value = useAttrs().src as string
-})
 
 watch(
   imageLoadingStatus,
   (newValue) => {
     emits('loadingStatusChange', newValue)
     if (newValue !== 'idle')
-      injectedValue!.imageLoadingStatus.value = newValue
+      context!.imageLoadingStatus.value = newValue
   },
   { immediate: true },
 )
@@ -39,8 +36,9 @@ watch(
   <Primitive
     v-if="imageLoadingStatus === 'loaded'"
     role="img"
-    :as-child="props.asChild"
+    :as-child="asChild"
     :as="as"
+    :src="src"
   >
     <slot />
   </Primitive>

--- a/packages/radix-vue/src/Avatar/story/Avatar.story.vue
+++ b/packages/radix-vue/src/Avatar/story/Avatar.story.vue
@@ -1,5 +1,29 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import { AvatarFallback, AvatarImage, AvatarRoot } from '../'
+
+const PROFILES = [
+  {
+    src: 'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80',
+    alt: 'Colm Tuite',
+    fallback: 'CT',
+  },
+  {
+    src: '',
+    alt: '',
+    fallback: 'AD',
+  },
+]
+const index = ref(0)
+const profile = computed(() => {
+  return PROFILES[index.value]
+})
+function rotateIndex() {
+  if (index.value)
+    index.value = 0
+  else
+    index.value = 1
+}
 </script>
 
 <template>
@@ -55,6 +79,22 @@ import { AvatarFallback, AvatarImage, AvatarRoot } from '../'
           class="text-violet11 leading-1 flex h-full w-full items-center justify-center bg-white text-[15px] font-medium"
         >
           PD
+        </AvatarFallback>
+      </AvatarRoot>
+      <AvatarRoot
+        class="bg-blackA3 inline-flex h-[45px] w-[45px] select-none items-center justify-center overflow-hidden rounded-full align-middle"
+        @click.prevent="rotateIndex"
+      >
+        <AvatarImage
+          class="h-full w-full rounded-[inherit] object-cover"
+          :src="profile.src"
+          :alt="profile.alt"
+        />
+        <AvatarFallback
+          class="text-violet11 leading-1 flex h-full w-full items-center justify-center bg-white text-[15px] font-medium"
+          :delay-ms="600"
+        >
+          {{ profile.fallback }}
         </AvatarFallback>
       </AvatarRoot>
     </Variant>

--- a/packages/radix-vue/src/Avatar/utils.ts
+++ b/packages/radix-vue/src/Avatar/utils.ts
@@ -1,29 +1,31 @@
-import { onMounted, onUnmounted, ref } from 'vue'
+import { type Ref, onMounted, onUnmounted, ref, watch } from 'vue'
 
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error'
 
-export function useImageLoadingStatus(src?: string) {
+export function useImageLoadingStatus(src: Ref<string>) {
   const loadingStatus = ref<ImageLoadingStatus>('idle')
   const isMounted = ref(false)
-  onMounted(() => {
-    if (!src) {
-      loadingStatus.value = 'error'
-      return
-    }
 
-    isMounted.value = true
-    const image = new window.Image()
-
-    const updateStatus = (status: ImageLoadingStatus) => () => {
-      if (!isMounted.value)
-        return
+  const updateStatus = (status: ImageLoadingStatus) => () => {
+    if (isMounted.value)
       loadingStatus.value = status
-    }
+  }
 
-    loadingStatus.value = 'loading'
-    image.onload = updateStatus('loaded')
-    image.onerror = updateStatus('error')
-    image.src = src
+  watch(src, (value) => {
+    if (!value) {
+      loadingStatus.value = 'error'
+    }
+    else {
+      const image = new window.Image()
+      loadingStatus.value = 'loading'
+      image.onload = updateStatus('loaded')
+      image.onerror = updateStatus('error')
+      image.src = value
+    }
+  }, { immediate: true })
+
+  onMounted(() => {
+    isMounted.value = true
   })
 
   onUnmounted(() => {


### PR DESCRIPTION
## Use case

There is a list of users, and you want to select one from the list. When a user is selected, we display the selected user's avatar.

## Problem

1. We select A user, and A user has no avatar, it will show the Fallback avatar.
2. Then select B user, and B user has avatar, without reactive, it will still show the Fallback avatar.
