### PR TITLE
fix: fixes the overflow when a toast is displayed on mobile

### DIFF
--- a/packages/radix-vue/src/VisuallyHidden/VisuallyHidden.vue
+++ b/packages/radix-vue/src/VisuallyHidden/VisuallyHidden.vue
@@ -14,7 +14,8 @@ withDefaults(defineProps<VisuallyHiddenProps>(), { as: 'span' })
       // See: https://github.com/twbs/bootstrap/blob/master/scss/mixins/_screen-reader.scss
       position: 'absolute',
       border: 0,
-      width: 1,
+      width: '0px',
+      display: 'inline-block',
       height: 1,
       padding: 0,
       margin: -1,


### PR DESCRIPTION
On mobile, rendering the toast component would cause an overflow on the x axis.
After inspecting the DOM, I realised that adding a width of 0px and display of inline-block fixed the issue.