### PR TITLE
fix: add overflow to ensure dropdown menu is not cut off on smaller screens

### DIFF
--- a/packages/radix-vue/src/Popper/PopperContent.vue
+++ b/packages/radix-vue/src/Popper/PopperContent.vue
@@ -318,6 +318,7 @@ defineExpose({
         middlewareData.transformOrigin?.x,
         middlewareData.transformOrigin?.y,
       ].join(' '),
+      overflowY: 'auto',
     }"
   >
     <Primitive

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10234,7 +10234,6 @@ packages:
     resolution: {directory: packages/radix-vue, type: directory}
     id: file:packages/radix-vue
     name: radix-vue
-    version: 0.4.1
     dependencies:
       '@floating-ui/dom': 1.4.2
       '@floating-ui/vue': 1.0.1(vue@3.3.4)


### PR DESCRIPTION
![radix-452](https://github.com/radix-vue/radix-vue/assets/44473671/dc9f438d-a7c5-42a3-8bab-31770fb42e79)
