### PR TITLE
fix: lock body scroll on initial render

### DIFF
--- a/packages/radix-vue/src/Dialog/DialogOverlay.vue
+++ b/packages/radix-vue/src/Dialog/DialogOverlay.vue
@@ -20,6 +20,9 @@ const isLocked = useBodyScrollLock()
 watch(
   () => context?.open.value,
   n => (isLocked.value = n ?? false),
+  {
+    immediate: true,
+  },
 )
 </script>
 


### PR DESCRIPTION
Fixes #455 

Also tested in Nuxt (SSR), works fine.