### PR TITLE
fix: handle `event.preventDefault()` for `TooltipTrigger` events

### DIFF
--- a/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
@@ -54,7 +54,8 @@ onMounted(() => {
       :data-state="rootContext.stateAttribute.value"
       :as="as"
       :as-child="props.asChild"
-      @pointermove="(event) => {
+      @pointermove="(event: PointerEvent) => {
+        if (event.defaultPrevented) return;
         if (event.pointerType === 'touch') return;
         if (
           !hasPointerMoveOpened && !providerContext.isPointerInTransitRef.value
@@ -63,16 +64,28 @@ onMounted(() => {
           hasPointerMoveOpened = true;
         }
       }"
-      @pointerleave="(event) => {
+      @pointerleave="(event: PointerEvent) => {
+        if (event.defaultPrevented) return;
         rootContext.onTriggerLeave();
         hasPointerMoveOpened = false;
       }"
-      @pointerdown="handlePointerDown"
-      @focus="() => {
+      @pointerdown="(event: PointerEvent) => {
+        if (!event.defaultPrevented) {
+          handlePointerDown()
+        }
+      }"
+      @focus="(event: FocusEvent) => {
+        if (event.defaultPrevented) return;
         if (!isPointerDown) rootContext.onOpen()
       }"
-      @blur="rootContext.onClose()"
-      @click="rootContext.onClose()"
+      @blur="(event: FocusEvent) => {
+        if (event.defaultPrevented) return;
+        rootContext.onClose()
+      }"
+      @click="(event: MouseEvent) => {
+        if (event.defaultPrevented) return;
+        rootContext.onClose()
+      }"
     >
       <slot />
     </Primitive>

--- a/packages/radix-vue/src/Tooltip/stories/Tooltip.story.vue
+++ b/packages/radix-vue/src/Tooltip/stories/Tooltip.story.vue
@@ -20,6 +20,7 @@ const toggleState = ref(false)
             <TooltipContent
               as-child
               :side-offset="5"
+              side="bottom"
               class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
             >
               <ul>


### PR DESCRIPTION
#377

I had a problem with preventing the default behavior of closing a tooltip on click trigger, because `TooltipTrigger` was not handling the defaultPrevented case. 