### PR TITLE
refactor: use `normal script` alongside the script setup for exposing type and interface

### DIFF
--- a/packages/radix-vue/src/Accordion/AccordionContent.vue
+++ b/packages/radix-vue/src/Accordion/AccordionContent.vue
@@ -1,10 +1,13 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface AccordionContentProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { CollapsibleContent } from '../Collapsible'
 import { injectAccordionItemContext } from './AccordionItem.vue'
 import { injectAccordionRootContext } from './AccordionRoot.vue'
-import type { PrimitiveProps } from '@/Primitive'
-
-export interface AccordionContentProps extends PrimitiveProps {}
 
 const props = defineProps<AccordionContentProps>()
 

--- a/packages/radix-vue/src/Accordion/AccordionHeader.vue
+++ b/packages/radix-vue/src/Accordion/AccordionHeader.vue
@@ -1,9 +1,13 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface AccordionHeaderProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { injectAccordionItemContext } from './AccordionItem.vue'
 import { injectAccordionRootContext } from './AccordionRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-
-export interface AccordionHeaderProps extends PrimitiveProps {}
+import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<AccordionHeaderProps>(), {
   as: 'h3',

--- a/packages/radix-vue/src/Accordion/AccordionItem.vue
+++ b/packages/radix-vue/src/Accordion/AccordionItem.vue
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts">
 import type { ComputedRef, VNodeRef } from 'vue'
 import type { CollapsibleRootProps } from '../Collapsible'
 import { injectAccordionRootContext } from './AccordionRoot.vue'

--- a/packages/radix-vue/src/Accordion/AccordionRoot.vue
+++ b/packages/radix-vue/src/Accordion/AccordionRoot.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { DataOrientation, Direction, Type } from '@/shared/types'
 import { createContext, useDirection } from '@/shared'
 
@@ -72,7 +73,6 @@ export const [injectAccordionRootContext, provideAccordionRootContext]
 <script setup lang="ts">
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { useSingleOrMultipleValue } from '@/shared/useSingleOrMultipleValue'

--- a/packages/radix-vue/src/Accordion/AccordionTrigger.vue
+++ b/packages/radix-vue/src/Accordion/AccordionTrigger.vue
@@ -1,10 +1,14 @@
+<script lang="ts">
+import { type PrimitiveProps } from '@/Primitive'
+
+export interface AccordionTriggerProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { injectAccordionItemContext } from './AccordionItem.vue'
 import { injectAccordionRootContext } from './AccordionRoot.vue'
-import { type PrimitiveProps } from '@/Primitive'
-import { CollapsibleTrigger } from '@/Collapsible'
 
-export interface AccordionTriggerProps extends PrimitiveProps {}
+import { CollapsibleTrigger } from '@/Collapsible'
 
 const props = defineProps<AccordionTriggerProps>()
 

--- a/packages/radix-vue/src/Accordion/AccordionTrigger.vue
+++ b/packages/radix-vue/src/Accordion/AccordionTrigger.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { type PrimitiveProps } from '@/Primitive'
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface AccordionTriggerProps extends PrimitiveProps {}
 </script>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogAction.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogAction.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { DialogClose, type DialogCloseProps } from '@/Dialog'
+<script lang="ts">
+import type { DialogCloseProps } from '@/Dialog'
 
 export interface AlertDialogActionProps extends DialogCloseProps {}
+</script>
+
+<script setup lang="ts">
+import { DialogClose } from '@/Dialog'
 
 const props = defineProps<AlertDialogActionProps>()
 </script>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogCancel.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogCancel.vue
@@ -1,10 +1,14 @@
+<script lang="ts">
+import { type DialogCloseProps } from '@/Dialog'
+
+export interface AlertDialogCancelProps extends DialogCloseProps {}
+</script>
+
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { injectAlertDialogContentContext } from './AlertDialogContent.vue'
-import { DialogClose, type DialogCloseProps } from '@/Dialog'
+import { DialogClose } from '@/Dialog'
 import { usePrimitiveElement } from '@/Primitive'
-
-export interface AlertDialogCancelProps extends DialogCloseProps {}
 
 const props = defineProps<AlertDialogCancelProps>()
 const contentContext = injectAlertDialogContentContext()

--- a/packages/radix-vue/src/AlertDialog/AlertDialogCancel.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogCancel.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { type DialogCloseProps } from '@/Dialog'
+import type { DialogCloseProps } from '@/Dialog'
 
 export interface AlertDialogCancelProps extends DialogCloseProps {}
 </script>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogContent.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogContent.vue
@@ -1,4 +1,8 @@
 <script lang="ts">
+import type {
+  DialogContentEmits,
+  DialogContentProps,
+} from '@/Dialog'
 import { createContext, useEmitAsProps } from '@/shared'
 
 interface AlertDialogContentContext {
@@ -8,16 +12,14 @@ interface AlertDialogContentContext {
 export const [injectAlertDialogContentContext, provideAlertDialogContentContext]
   = createContext<AlertDialogContentContext>('AlertDialogContent')
 
-export interface AlertDialogContentProps extends DialogContentProps {}
 export type AlertDialogContentEmits = DialogContentEmits
+export interface AlertDialogContentProps extends DialogContentProps {}
 </script>
 
 <script setup lang="ts">
 import { nextTick, ref } from 'vue'
 import {
   DialogContent,
-  type DialogContentEmits,
-  type DialogContentProps,
 } from '@/Dialog'
 
 const props = defineProps<AlertDialogContentProps>()

--- a/packages/radix-vue/src/AlertDialog/AlertDialogDescription.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogDescription.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { DialogDescription, type DialogDescriptionProps } from '@/Dialog'
+<script lang="ts">
+import type { DialogDescriptionProps } from '@/Dialog'
 
 export interface AlertDialogDescriptionProps extends DialogDescriptionProps {}
+</script>
+
+<script setup lang="ts">
+import { DialogDescription } from '@/Dialog'
 
 const props = defineProps<AlertDialogDescriptionProps>()
 </script>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogOverlay.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogOverlay.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { DialogOverlay, type DialogOverlayProps } from '@/Dialog'
+<script lang="ts">
+import type { DialogOverlayProps } from '@/Dialog'
 
 export interface AlertDialogOverlayProps extends DialogOverlayProps {}
+</script>
+
+<script setup lang="ts">
+import { DialogOverlay } from '@/Dialog'
 
 const props = defineProps<AlertDialogOverlayProps>()
 </script>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogPortal.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface AlertDialogPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<AlertDialogPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogRoot.vue
@@ -1,13 +1,16 @@
-<script setup lang="ts">
-import {
-  DialogRoot,
-  type DialogRootEmits,
-  type DialogRootProps,
+<script lang="ts">
+import type {
+  DialogRootEmits,
+  DialogRootProps,
 } from '@/Dialog'
-import { useForwardPropsEmits } from '@/shared'
 
-export interface AlertDialogProps extends Omit<DialogRootProps, 'modal'> {}
 export type AlertDialogEmits = DialogRootEmits
+export interface AlertDialogProps extends Omit<DialogRootProps, 'modal'> {}
+</script>
+
+<script setup lang="ts">
+import { DialogRoot } from '@/Dialog'
+import { useForwardPropsEmits } from '@/shared'
 
 const props = defineProps<AlertDialogProps>()
 const emits = defineEmits<AlertDialogEmits>()

--- a/packages/radix-vue/src/AlertDialog/AlertDialogTitle.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogTitle.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { DialogTitle, type DialogTitleProps } from '@/Dialog'
+<script lang="ts">
+import type { DialogTitleProps } from '@/Dialog'
 
 export interface AlertDialogTitleProps extends DialogTitleProps {}
+</script>
+
+<script setup lang="ts">
+import { DialogTitle } from '@/Dialog'
 
 const props = defineProps<AlertDialogTitleProps>()
 </script>

--- a/packages/radix-vue/src/AlertDialog/AlertDialogTrigger.vue
+++ b/packages/radix-vue/src/AlertDialog/AlertDialogTrigger.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { DialogTrigger, type DialogTriggerProps } from '@/Dialog'
+<script lang="ts">
+import type { DialogTriggerProps } from '@/Dialog'
 
 export interface AlertDialogTriggerProps extends DialogTriggerProps {}
+</script>
+
+<script setup lang="ts">
+import { DialogTrigger } from '@/Dialog'
 
 const props = defineProps<AlertDialogTriggerProps>()
 </script>

--- a/packages/radix-vue/src/AspectRatio/AspectRatio.vue
+++ b/packages/radix-vue/src/AspectRatio/AspectRatio.vue
@@ -1,16 +1,18 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface AspectRatioProps extends PrimitiveProps {
   ratio?: number
-}
-
-export default {
-  inheritAttrs: false,
 }
 </script>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<AspectRatioProps>(), {
   ratio: 1,

--- a/packages/radix-vue/src/Avatar/AvatarFallback.vue
+++ b/packages/radix-vue/src/Avatar/AvatarFallback.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface AvatarFallbackProps extends PrimitiveProps {
   delayMs?: number
 }
@@ -6,7 +8,7 @@ export interface AvatarFallbackProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { Primitive, type PrimitiveProps } from '../Primitive'
+import { Primitive } from '@/Primitive'
 import { injectAvatarRootContext } from './AvatarRoot.vue'
 
 const props = withDefaults(defineProps<AvatarFallbackProps>(), {

--- a/packages/radix-vue/src/Avatar/AvatarImage.vue
+++ b/packages/radix-vue/src/Avatar/AvatarImage.vue
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+import type { ImageLoadingStatus } from './utils'
+
 export type AvatarImageEmits = {
   'loadingStatusChange': [value: ImageLoadingStatus]
 }
@@ -9,9 +12,9 @@ export interface AvatarImageProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import { toRefs, watch } from 'vue'
-import { Primitive, type PrimitiveProps } from '../Primitive'
+import { Primitive } from '../Primitive'
 import { injectAvatarRootContext } from './AvatarRoot.vue'
-import { type ImageLoadingStatus, useImageLoadingStatus } from './utils'
+import { useImageLoadingStatus } from './utils'
 
 const props = withDefaults(defineProps<AvatarImageProps>(), { as: 'img' })
 const emits = defineEmits<AvatarImageEmits>()

--- a/packages/radix-vue/src/Avatar/AvatarRoot.vue
+++ b/packages/radix-vue/src/Avatar/AvatarRoot.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { ImageLoadingStatus } from './utils'
 import { createContext } from '@/shared'
 
@@ -15,7 +16,7 @@ export const [injectAvatarRootContext, provideAvatarRootContext]
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Primitive, type PrimitiveProps } from '../Primitive'
+import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<AvatarRootProps>(), {
   as: 'span',

--- a/packages/radix-vue/src/Checkbox/CheckboxIndicator.vue
+++ b/packages/radix-vue/src/Checkbox/CheckboxIndicator.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface CheckboxIndicatorProps extends PrimitiveProps {
   /**
    * Used to force mounting when more control is needed. Useful when
@@ -10,7 +12,7 @@ export interface CheckboxIndicatorProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import { injectCheckboxRootContext } from './CheckboxRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { Presence } from '@/Presence'
 import { getState, isIndeterminate } from './utils'
 

--- a/packages/radix-vue/src/Checkbox/CheckboxRoot.vue
+++ b/packages/radix-vue/src/Checkbox/CheckboxRoot.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 import type { Ref } from 'vue'
 import { useVModel } from '@vueuse/core'
 import { createContext, useFormControl } from '@/shared'
+import type { CheckedState } from './utils'
 
 export interface CheckboxRootProps extends PrimitiveProps {
   defaultChecked?: boolean
@@ -24,17 +26,16 @@ interface CheckboxRootContext {
 
 export const [injectCheckboxRootContext, provideCheckboxRootContext]
   = createContext<CheckboxRootContext>('CheckboxRoot')
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
 import { computed, toRefs } from 'vue'
-import { Primitive, type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
-import type { CheckedState } from './utils'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { getState, isIndeterminate } from './utils'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<CheckboxRootProps>(), {
   checked: undefined,

--- a/packages/radix-vue/src/Collapsible/CollapsibleContent.vue
+++ b/packages/radix-vue/src/Collapsible/CollapsibleContent.vue
@@ -1,13 +1,12 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface CollapsibleContentProps extends PrimitiveProps {
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
   forceMount?: boolean
-}
-export default {
-  inheritAttrs: false,
 }
 </script>
 
@@ -16,10 +15,13 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { injectCollapsibleRootContext } from './CollapsibleRoot.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { Presence } from '@/Presence'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = defineProps<CollapsibleContentProps>()
 

--- a/packages/radix-vue/src/Collapsible/CollapsibleRoot.vue
+++ b/packages/radix-vue/src/Collapsible/CollapsibleRoot.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 import type { Ref } from 'vue'
 import { createContext, useId } from '@/shared'
 
@@ -24,7 +25,7 @@ export const [injectCollapsibleRootContext, provideCollapsibleRootContext]
 </script>
 
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { useVModel } from '@vueuse/core'
 
 const props = withDefaults(defineProps<CollapsibleRootProps>(), {

--- a/packages/radix-vue/src/Collapsible/CollapsibleTrigger.vue
+++ b/packages/radix-vue/src/Collapsible/CollapsibleTrigger.vue
@@ -1,9 +1,11 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface CollapsibleTriggerProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '../Primitive'
+import { Primitive } from '@/Primitive'
 import { injectCollapsibleRootContext } from './CollapsibleRoot.vue'
 
 const props = withDefaults(defineProps<CollapsibleTriggerProps>(), {

--- a/packages/radix-vue/src/Combobox/ComboboxAnchor.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxAnchor.vue
@@ -1,8 +1,12 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { PopperAnchor } from '@/Popper'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxAnchorProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { PopperAnchor } from '@/Popper'
 
 defineProps<ComboboxAnchorProps>()
 </script>

--- a/packages/radix-vue/src/Combobox/ComboboxArrow.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxArrow.vue
@@ -1,13 +1,17 @@
+<script lang="ts">
+import type { PopperArrowProps } from '@/Popper'
+
+export interface ComboboxArrowProps extends PopperArrowProps {}
+</script>
+
 <script setup lang="ts">
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
 import { injectComboboxContentContext } from './ComboboxContentImpl.vue'
-import { PopperArrow, type PopperArrowProps } from '@/Popper'
+import { PopperArrow } from '@/Popper'
 
 const props = defineProps<ComboboxArrowProps>()
 const rootContext = injectComboboxRootContext()
 const contentContext = injectComboboxContentContext()
-
-export interface ComboboxArrowProps extends PopperArrowProps {}
 </script>
 
 <template>

--- a/packages/radix-vue/src/Combobox/ComboboxCancel.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxCancel.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { injectComboboxRootContext } from './ComboboxRoot.vue'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxCancelProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { injectComboboxRootContext } from './ComboboxRoot.vue'
+
 const props = withDefaults(defineProps<ComboboxCancelProps>(), {
   as: 'button',
 })

--- a/packages/radix-vue/src/Combobox/ComboboxContent.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxContent.vue
@@ -1,9 +1,7 @@
-<script setup lang="ts">
-import { injectComboboxRootContext } from './ComboboxRoot.vue'
-import ComboboxContentImpl, { type ComboboxContentImplEmits, type ComboboxContentImplProps } from './ComboboxContentImpl.vue'
-import { Presence } from '@/Presence'
-import { useForwardPropsEmits } from '@/shared'
+<script lang="ts">
+import type { ComboboxContentImplEmits, ComboboxContentImplProps } from './ComboboxContentImpl.vue'
 
+export type ComboboxContentEmits = ComboboxContentImplEmits
 export interface ComboboxContentProps extends ComboboxContentImplProps {
   /**
    * Used to force mounting when more control is needed. Useful when
@@ -11,7 +9,13 @@ export interface ComboboxContentProps extends ComboboxContentImplProps {
    */
   forceMount?: boolean
 }
-export type ComboboxContentEmits = ComboboxContentImplEmits
+</script>
+
+<script setup lang="ts">
+import { injectComboboxRootContext } from './ComboboxRoot.vue'
+import ComboboxContentImpl from './ComboboxContentImpl.vue'
+import { Presence } from '@/Presence'
+import { useForwardPropsEmits } from '@/shared'
 
 const props = defineProps<ComboboxContentProps>()
 const emits = defineEmits<ComboboxContentEmits>()

--- a/packages/radix-vue/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxContentImpl.vue
@@ -1,9 +1,12 @@
 <script lang="ts">
+import type { Ref } from 'vue'
 import {
   createContext,
   useBodyScrollLock,
   useHideOthers,
 } from '@/shared'
+import type { PointerDownOutsideEvent } from '@/DismissableLayer'
+import type { PopperContentProps } from '@/Popper'
 
 export type ComboboxContentImplEmits = {
   closeAutoFocus: [event: Event]
@@ -33,17 +36,13 @@ export const [injectComboboxContentContext, provideComboboxContentContext]
 
 <script setup lang="ts">
 import {
-  type Ref,
   computed,
   onMounted,
   toRefs,
 } from 'vue'
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
-import {
-  DismissableLayer,
-  type PointerDownOutsideEvent,
-} from '@/DismissableLayer'
-import { PopperContent, type PopperContentProps } from '@/Popper'
+import { DismissableLayer } from '@/DismissableLayer'
+import { PopperContent } from '@/Popper'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<ComboboxContentImplProps>(), {

--- a/packages/radix-vue/src/Combobox/ComboboxEmpty.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxEmpty.vue
@@ -1,9 +1,14 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface ComboboxEmptyProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { computed } from 'vue'
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
 
-export interface ComboboxEmptyProps extends PrimitiveProps {}
 const props = defineProps<ComboboxEmptyProps>()
 
 const rootContext = injectComboboxRootContext()

--- a/packages/radix-vue/src/Combobox/ComboboxGroup.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxGroup.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useId } from '@/shared'
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
 
@@ -14,8 +16,8 @@ export const [injectComboboxGroupContext, provideComboboxGroupContext]
 </script>
 
 <script setup lang="ts">
-import { type Ref, computed, ref } from 'vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { computed, ref } from 'vue'
+import { Primitive } from '@/Primitive'
 
 const props = defineProps<ComboboxGroupProps>()
 

--- a/packages/radix-vue/src/Combobox/ComboboxInput.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxInput.vue
@@ -1,12 +1,14 @@
-<script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { injectComboboxRootContext } from './ComboboxRoot.vue'
-
+<script lang="ts">
 export interface ComboboxInputProps {
   type?: string
   disabled?: boolean
   autoFocus?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { injectComboboxRootContext } from './ComboboxRoot.vue'
 
 const props = withDefaults(defineProps<ComboboxInputProps>(), {
   type: 'text',

--- a/packages/radix-vue/src/Combobox/ComboboxItem.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxItem.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, handleAndDispatchCustomEvent, useId } from '@/shared'
 
 export type SelectEvent = CustomEvent<{ originalEvent: PointerEvent; value?: string | object }>
@@ -24,7 +26,6 @@ const COMBOBOX_SELECT = 'combobox.select'
 
 <script setup lang="ts">
 import {
-  type Ref,
   computed,
   getCurrentInstance,
   nextTick,
@@ -35,10 +36,8 @@ import {
 } from 'vue'
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
 import { injectComboboxGroupContext } from './ComboboxGroup.vue'
-
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 

--- a/packages/radix-vue/src/Combobox/ComboboxItemIndicator.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxItemIndicator.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { injectComboboxItemContext } from './ComboboxItem.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxItemIndicatorProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { injectComboboxItemContext } from './ComboboxItem.vue'
+import { Primitive } from '@/Primitive'
+
 const props = withDefaults(defineProps<ComboboxItemIndicatorProps>(), {
   as: 'span',
 })

--- a/packages/radix-vue/src/Combobox/ComboboxLabel.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxLabel.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxLabelProps extends PrimitiveProps {
   for?: string
@@ -7,6 +7,7 @@ export interface ComboboxLabelProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
+import { Primitive } from '@/Primitive'
 import { injectComboboxGroupContext } from './ComboboxGroup.vue'
 
 const props = withDefaults(defineProps<ComboboxLabelProps>(), {

--- a/packages/radix-vue/src/Combobox/ComboboxPortal.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface ComboboxPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<ComboboxPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { ComponentInternalInstance, ComputedRef, Ref } from 'vue'
+import type { Direction } from '@/shared/types'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useCollection, useDirection, useFormControl, useId } from '@/shared'
 
 type ComboboxRootContext = {
@@ -50,10 +53,9 @@ export interface ComboboxRootProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import { PopperRoot } from '@/Popper'
-import { Primitive, type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
-import type { Direction } from '@/shared/types'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { computedWithControl, useVModel } from '@vueuse/core'
-import { type ComponentInternalInstance, type ComputedRef, type Ref, computed, nextTick, ref, toRaw, toRefs, watch } from 'vue'
+import { computed, nextTick, ref, toRaw, toRefs, watch } from 'vue'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
 
 const props = withDefaults(defineProps<ComboboxRootProps>(), {

--- a/packages/radix-vue/src/Combobox/ComboboxSeparator.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxSeparator.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxSeparatorProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 const props = defineProps<ComboboxSeparatorProps>()
 </script>
 

--- a/packages/radix-vue/src/Combobox/ComboboxTrigger.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxTrigger.vue
@@ -1,11 +1,15 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { computed } from 'vue'
-import { injectComboboxRootContext } from './ComboboxRoot.vue'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxTriggerProps extends PrimitiveProps {
   disabled?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { computed } from 'vue'
+import { injectComboboxRootContext } from './ComboboxRoot.vue'
 
 const props = withDefaults(defineProps<ComboboxTriggerProps>(), {
   as: 'button',

--- a/packages/radix-vue/src/Combobox/ComboboxViewport.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxViewport.vue
@@ -1,10 +1,12 @@
-<script setup lang="ts">
-import {
-  Primitive,
-  type PrimitiveProps,
-} from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxViewportProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 const props = defineProps<ComboboxViewportProps>()
 </script>
 

--- a/packages/radix-vue/src/ConfigProvider/ConfigProvider.vue
+++ b/packages/radix-vue/src/ConfigProvider/ConfigProvider.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { createContext } from '@/shared'
 import type { Direction, ScrollBodyOption } from '@/shared/types'
-import { type Ref, toRefs } from 'vue'
+import type { Ref } from 'vue'
+import { createContext } from '@/shared'
 
 interface ConfigProviderContextValue {
   dir?: Ref<Direction>
@@ -26,6 +26,8 @@ export interface ConfigProviderProps {
 </script>
 
 <script setup lang="ts">
+import { toRefs } from 'vue'
+
 const props = withDefaults(defineProps<ConfigProviderProps>(), {
   dir: 'ltr',
   scrollBody: true,

--- a/packages/radix-vue/src/ContextMenu/ContextMenuArrow.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuArrow.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuArrow, type MenuArrowProps } from '@/Menu'
+<script lang="ts">
+import type { MenuArrowProps } from '@/Menu'
 
 export interface ContextMenuArrowProps extends MenuArrowProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuArrow } from '@/Menu'
+
 const props = defineProps<ContextMenuArrowProps>()
 </script>
 

--- a/packages/radix-vue/src/ContextMenu/ContextMenuCheckboxItem.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuCheckboxItem.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  MenuCheckboxItem,
-  type MenuCheckboxItemEmits,
-  type MenuCheckboxItemProps,
+<script lang="ts">
+import type {
+  MenuCheckboxItemEmits,
+  MenuCheckboxItemProps,
 } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+
+export type ContextMenuCheckboxItemEmits = MenuCheckboxItemEmits
 
 export interface ContextMenuCheckboxItemProps extends MenuCheckboxItemProps {}
-export type ContextMenuCheckboxItemEmits = MenuCheckboxItemEmits
+</script>
+
+<script setup lang="ts">
+import { MenuCheckboxItem } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<ContextMenuCheckboxItemProps>()
 const emits = defineEmits<ContextMenuCheckboxItemEmits>()

--- a/packages/radix-vue/src/ContextMenu/ContextMenuContent.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuContent.vue
@@ -1,11 +1,10 @@
-<script setup lang="ts">
-import { ref } from 'vue'
-import { injectContextMenuRootContext } from './ContextMenuRoot.vue'
-import {
-  MenuContent,
-  type MenuContentEmits,
-  type MenuContentProps,
+<script lang="ts">
+import type {
+  MenuContentEmits,
+  MenuContentProps,
 } from '@/Menu'
+
+export type ContextMenuContentEmits = MenuContentEmits
 
 export interface ContextMenuContentProps
   extends Omit<
@@ -17,7 +16,12 @@ export interface ContextMenuContentProps
     | 'updatePositionStrategy'
     | 'prioritizePosition'
   > {}
-export type ContextMenuContentEmits = MenuContentEmits
+</script>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { injectContextMenuRootContext } from './ContextMenuRoot.vue'
+import { MenuContent } from '@/Menu'
 
 const props = withDefaults(defineProps<ContextMenuContentProps>(), {
   alignOffset: 0,

--- a/packages/radix-vue/src/ContextMenu/ContextMenuGroup.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuGroup.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuGroup, type MenuGroupProps } from '@/Menu'
+<script lang="ts">
+import type { MenuGroupProps } from '@/Menu'
 
 export interface ContextMenuGroupProps extends MenuGroupProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuGroup } from '@/Menu'
+
 const props = defineProps<ContextMenuGroupProps>()
 </script>
 

--- a/packages/radix-vue/src/ContextMenu/ContextMenuItem.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuItem.vue
@@ -1,9 +1,14 @@
-<script setup lang="ts">
-import { MenuItem, type MenuItemEmits, type MenuItemProps } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+<script lang="ts">
+import type { MenuItemEmits, MenuItemProps } from '@/Menu'
+
+export type ContextMenuItemEmits = MenuItemEmits
 
 export interface ContextMenuItemProps extends MenuItemProps {}
-export type ContextMenuItemEmits = MenuItemEmits
+</script>
+
+<script setup lang="ts">
+import { MenuItem } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<MenuItemProps>()
 const emits = defineEmits<MenuItemEmits>()

--- a/packages/radix-vue/src/ContextMenu/ContextMenuItemIndicator.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuItemIndicator.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuItemIndicator, type MenuItemIndicatorProps } from '@/Menu'
+<script lang="ts">
+import type { MenuItemIndicatorProps } from '@/Menu'
 
 export interface ContextMenuItemIndicatorProps extends MenuItemIndicatorProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuItemIndicator } from '@/Menu'
+
 const props = defineProps<ContextMenuItemIndicatorProps>()
 </script>
 

--- a/packages/radix-vue/src/ContextMenu/ContextMenuLabel.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuLabel.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuLabel, type MenuLabelProps } from '@/Menu'
+<script lang="ts">
+import type { MenuLabelProps } from '@/Menu'
 
 export interface ContextMenuLabelProps extends MenuLabelProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuLabel } from '@/Menu'
+
 const props = defineProps<ContextMenuLabelProps>()
 </script>
 

--- a/packages/radix-vue/src/ContextMenu/ContextMenuRadioGroup.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuRadioGroup.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  MenuRadioGroup,
-  type MenuRadioGroupEmits,
-  type MenuRadioGroupProps,
+<script lang="ts">
+import type {
+  MenuRadioGroupEmits,
+  MenuRadioGroupProps,
 } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+
+export type ContextMenuRadioGroupEmits = MenuRadioGroupEmits
 
 export interface ContextMenuRadioGroupProps extends MenuRadioGroupProps {}
-export type ContextMenuRadioGroupEmits = MenuRadioGroupEmits
+</script>
+
+<script setup lang="ts">
+import { MenuRadioGroup } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<ContextMenuRadioGroupProps>()
 const emits = defineEmits<ContextMenuRadioGroupEmits>()

--- a/packages/radix-vue/src/ContextMenu/ContextMenuRadioItem.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuRadioItem.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  type MenuItemEmits,
-  MenuRadioItem,
-  type MenuRadioItemProps,
+<script lang="ts">
+import type {
+  MenuItemEmits,
+  MenuRadioItemProps,
 } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+
+export type ContextMenuRadioItemEmits = MenuItemEmits
 
 export interface ContextMenuRadioItemProps extends MenuRadioItemProps {}
-export type ContextMenuRadioItemEmits = MenuItemEmits
+</script>
+
+<script setup lang="ts">
+import { MenuRadioItem } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<ContextMenuRadioItemProps>()
 const emits = defineEmits<ContextMenuRadioItemEmits>()

--- a/packages/radix-vue/src/ContextMenu/ContextMenuRoot.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuRoot.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { Ref } from 'vue'
-import type { Direction } from '../shared/types'
+import type { Direction } from '@/shared/types'
 import { createContext, useDirection } from '@/shared'
 
 type ContextMenuRootContext = {
@@ -10,9 +10,6 @@ type ContextMenuRootContext = {
   dir: Ref<Direction>
 }
 
-export const [injectContextMenuRootContext, provideContextMenuRootContext]
-  = createContext<ContextMenuRootContext>('ContextMenuRoot')
-
 export interface ContextMenuRootProps {
   dir?: Direction
   modal?: boolean
@@ -20,6 +17,9 @@ export interface ContextMenuRootProps {
 export type ContextMenuRootEmits = {
   'update:open': [value: boolean]
 }
+
+export const [injectContextMenuRootContext, provideContextMenuRootContext]
+  = createContext<ContextMenuRootContext>('ContextMenuRoot')
 </script>
 
 <script setup lang="ts">

--- a/packages/radix-vue/src/ContextMenu/ContextMenuSeparator.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuSeparator.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuSeparator, type MenuSeparatorProps } from '@/Menu'
+<script lang="ts">
+import type { MenuSeparatorProps } from '@/Menu'
 
 export interface ContextMenuSeparatorProps extends MenuSeparatorProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuSeparator } from '@/Menu'
+
 const props = defineProps<ContextMenuSeparatorProps>()
 </script>
 

--- a/packages/radix-vue/src/ContextMenu/ContextMenuSubContent.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuSubContent.vue
@@ -1,13 +1,16 @@
-<script setup lang="ts">
-import {
-  MenuSubContent,
-  type MenuSubContentEmits,
-  type MenuSubContentProps,
+<script lang="ts">
+import type {
+  MenuSubContentEmits,
+  MenuSubContentProps,
 } from '@/Menu'
-import { useForwardPropsEmits } from '@/shared'
 
-export interface ContextMenuSubContentProps extends MenuSubContentProps {}
 export type ContextMenuSubContentEmits = MenuSubContentEmits
+export interface ContextMenuSubContentProps extends MenuSubContentProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuSubContent } from '@/Menu'
+import { useForwardPropsEmits } from '@/shared'
 
 const props = defineProps<ContextMenuSubContentProps>()
 

--- a/packages/radix-vue/src/ContextMenu/ContextMenuSubTrigger.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuSubTrigger.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuSubTrigger, type MenuSubTriggerProps } from '@/Menu'
+<script lang="ts">
+import type { MenuSubTriggerProps } from '@/Menu'
 
 export interface ContextMenuSubTriggerProps extends MenuSubTriggerProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuSubTrigger } from '@/Menu'
+
 const props = defineProps<ContextMenuSubTriggerProps>()
 </script>
 

--- a/packages/radix-vue/src/ContextMenu/ContextMenuTrigger.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuTrigger.vue
@@ -1,9 +1,8 @@
 <script lang="ts">
+import type { Point } from '@/Menu/utils'
+
 export interface ContextMenuTriggerProps extends PrimitiveProps {
   disabled?: boolean
-}
-export default {
-  inheritAttrs: false,
 }
 </script>
 
@@ -13,7 +12,10 @@ import { injectContextMenuRootContext } from './ContextMenuRoot.vue'
 import { isTouchOrPen } from './utils'
 import { Primitive, type PrimitiveProps } from '@/Primitive'
 import { MenuAnchor } from '@/Menu'
-import type { Point } from '@/Menu/utils'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<ContextMenuTriggerProps>(), {
   as: 'span',

--- a/packages/radix-vue/src/ContextMenu/ContextMenuTrigger.vue
+++ b/packages/radix-vue/src/ContextMenu/ContextMenuTrigger.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Point } from '@/Menu/utils'
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ContextMenuTriggerProps extends PrimitiveProps {
   disabled?: boolean
@@ -10,7 +11,7 @@ export interface ContextMenuTriggerProps extends PrimitiveProps {
 import { computed, nextTick, ref, toRefs } from 'vue'
 import { injectContextMenuRootContext } from './ContextMenuRoot.vue'
 import { isTouchOrPen } from './utils'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { MenuAnchor } from '@/Menu'
 
 defineOptions({

--- a/packages/radix-vue/src/Dialog/DialogClose.vue
+++ b/packages/radix-vue/src/Dialog/DialogClose.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { injectDialogRootContext } from './DialogRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface DialogCloseProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { injectDialogRootContext } from './DialogRoot.vue'
+import { Primitive } from '@/Primitive'
+
 const props = withDefaults(defineProps<DialogCloseProps>(), {
   as: 'button',
 })

--- a/packages/radix-vue/src/Dialog/DialogContent.vue
+++ b/packages/radix-vue/src/Dialog/DialogContent.vue
@@ -1,19 +1,10 @@
-<script setup lang="ts">
-import DialogContentModal from './DialogContentModal.vue'
-import DialogContentNonModal from './DialogContentNonModal.vue'
-import {
-  type DialogContentImplEmits,
-  type DialogContentImplProps,
+<script lang="ts">
+import type {
+  DialogContentImplEmits,
+  DialogContentImplProps,
 } from './DialogContentImpl.vue'
-import { injectDialogRootContext } from './DialogRoot.vue'
-import { Presence } from '@/Presence'
-import { useEmitAsProps } from '@/shared'
 
-const props = defineProps<DialogContentProps>()
-
-const emits = defineEmits<DialogContentEmits>()
-
-const rootContext = injectDialogRootContext()
+export type DialogContentEmits = DialogContentImplEmits
 
 export interface DialogContentProps extends DialogContentImplProps {
   /**
@@ -22,7 +13,19 @@ export interface DialogContentProps extends DialogContentImplProps {
    */
   forceMount?: boolean
 }
-export type DialogContentEmits = DialogContentImplEmits
+</script>
+
+<script setup lang="ts">
+import DialogContentModal from './DialogContentModal.vue'
+import DialogContentNonModal from './DialogContentNonModal.vue'
+import { injectDialogRootContext } from './DialogRoot.vue'
+import { Presence } from '@/Presence'
+import { useEmitAsProps } from '@/shared'
+
+const props = defineProps<DialogContentProps>()
+const emits = defineEmits<DialogContentEmits>()
+
+const rootContext = injectDialogRootContext()
 
 const emitsAsProps = useEmitAsProps(emits)
 </script>

--- a/packages/radix-vue/src/Dialog/DialogContentImpl.vue
+++ b/packages/radix-vue/src/Dialog/DialogContentImpl.vue
@@ -1,15 +1,21 @@
-<script setup lang="ts">
-import { injectDialogRootContext } from './DialogRoot.vue'
-import {
-  DismissableLayer,
-  type DismissableLayerEmits,
-  type DismissableLayerProps,
+<script lang="ts">
+import type {
+  DismissableLayerEmits,
+  DismissableLayerProps,
 } from '@/DismissableLayer'
-import { FocusScope } from '@/FocusScope'
-import { getOpenState } from '@/Menu/utils'
-import { useWarning } from './utils'
-import { usePrimitiveElement } from '@/Primitive'
-import { onMounted } from 'vue'
+
+export type DialogContentImplEmits = DismissableLayerEmits & {
+  /**
+   * Event handler called when auto-focusing on open.
+   * Can be prevented.
+   */
+  'openAutoFocus': [event: Event]
+  /**
+   * Event handler called when auto-focusing on close.
+   * Can be prevented.
+   */
+  'closeAutoFocus': [ event: Event]
+}
 
 export interface DialogContentImplProps extends DismissableLayerProps {
   /**
@@ -24,19 +30,16 @@ export interface DialogContentImplProps extends DismissableLayerProps {
    */
   trapFocus?: boolean
 }
+</script>
 
-export type DialogContentImplEmits = DismissableLayerEmits & {
-  /**
-   * Event handler called when auto-focusing on open.
-   * Can be prevented.
-   */
-  'openAutoFocus': [event: Event]
-  /**
-   * Event handler called when auto-focusing on close.
-   * Can be prevented.
-   */
-  'closeAutoFocus': [ event: Event]
-}
+<script setup lang="ts">
+import { injectDialogRootContext } from './DialogRoot.vue'
+import { DismissableLayer } from '@/DismissableLayer'
+import { FocusScope } from '@/FocusScope'
+import { getOpenState } from '@/Menu/utils'
+import { useWarning } from './utils'
+import { usePrimitiveElement } from '@/Primitive'
+import { onMounted } from 'vue'
 
 const props = defineProps<DialogContentImplProps>()
 const emits = defineEmits<DialogContentImplEmits>()

--- a/packages/radix-vue/src/Dialog/DialogDescription.vue
+++ b/packages/radix-vue/src/Dialog/DialogDescription.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { injectDialogRootContext } from './DialogRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface DialogDescriptionProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { injectDialogRootContext } from './DialogRoot.vue'
+import { Primitive } from '@/Primitive'
+
 const props = withDefaults(defineProps<DialogDescriptionProps>(), { as: 'p' })
 
 const rootContext = injectDialogRootContext()

--- a/packages/radix-vue/src/Dialog/DialogOverlay.vue
+++ b/packages/radix-vue/src/Dialog/DialogOverlay.vue
@@ -1,9 +1,5 @@
-<script setup lang="ts">
-import { watch } from 'vue'
-import { injectDialogRootContext } from './DialogRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { Presence } from '@/Presence'
-import { useBodyScrollLock } from '@/shared'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface DialogOverlayProps extends PrimitiveProps {
   /**
@@ -12,6 +8,14 @@ export interface DialogOverlayProps extends PrimitiveProps {
    */
   forceMount?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { watch } from 'vue'
+import { injectDialogRootContext } from './DialogRoot.vue'
+import { Primitive } from '@/Primitive'
+import { Presence } from '@/Presence'
+import { useBodyScrollLock } from '@/shared'
 
 defineProps<DialogOverlayProps>()
 const rootContext = injectDialogRootContext()

--- a/packages/radix-vue/src/Dialog/DialogPortal.vue
+++ b/packages/radix-vue/src/Dialog/DialogPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface DialogPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<DialogPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/Dialog/DialogTitle.vue
+++ b/packages/radix-vue/src/Dialog/DialogTitle.vue
@@ -1,10 +1,14 @@
-<script setup lang="ts">
-import { injectDialogRootContext } from './DialogRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface DialogTitleProps extends PrimitiveProps {}
-const props = withDefaults(defineProps<DialogTitleProps>(), { as: 'h2' })
+</script>
 
+<script setup lang="ts">
+import { injectDialogRootContext } from './DialogRoot.vue'
+import { Primitive } from '@/Primitive'
+
+const props = withDefaults(defineProps<DialogTitleProps>(), { as: 'h2' })
 const rootContext = injectDialogRootContext()
 </script>
 

--- a/packages/radix-vue/src/Dialog/DialogTrigger.vue
+++ b/packages/radix-vue/src/Dialog/DialogTrigger.vue
@@ -1,13 +1,13 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface DialogTriggerProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { injectDialogRootContext } from './DialogRoot.vue'
-import {
-  Primitive,
-  type PrimitiveProps,
-  usePrimitiveElement,
-} from '@/Primitive'
-
-export interface DialogTriggerProps extends PrimitiveProps {}
+import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<DialogTriggerProps>(), {
   as: 'button',

--- a/packages/radix-vue/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/radix-vue/src/DismissableLayer/DismissableLayer.vue
@@ -6,6 +6,12 @@ import {
   watchEffect,
 } from 'vue'
 
+import type { PrimitiveProps } from '@/Primitive'
+import type {
+  FocusOutsideEvent,
+  PointerDownOutsideEvent,
+} from './utils'
+
 export interface DismissableLayerProps extends PrimitiveProps {
   /**
    * When `true`, hover/focus/click interactions will be disabled on elements outside
@@ -53,14 +59,11 @@ export const context = reactive({
 <script setup lang="ts">
 import { onKeyStroke } from '@vueuse/core'
 import {
-  type FocusOutsideEvent,
-  type PointerDownOutsideEvent,
   useFocusOutside,
   usePointerDownOutside,
 } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 

--- a/packages/radix-vue/src/DismissableLayer/DismissableLayerBranch.vue
+++ b/packages/radix-vue/src/DismissableLayer/DismissableLayerBranch.vue
@@ -1,9 +1,14 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface DismissableLayerBranchProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { onMounted, onUnmounted } from 'vue'
 import { context } from './DismissableLayer.vue'
 
-export interface DismissableLayerBranchProps extends PrimitiveProps {}
 const props = defineProps<DismissableLayerBranchProps>()
 
 const { primitiveElement, currentElement } = usePrimitiveElement()

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuArrow.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuArrow.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuArrow, type MenuArrowProps } from '@/Menu'
+<script lang="ts">
+import type { MenuArrowProps } from '@/Menu'
 
 export interface DropdownMenuArrowProps extends MenuArrowProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuArrow } from '@/Menu'
+
 const props = withDefaults(defineProps<DropdownMenuArrowProps>(), {
   width: 10,
   height: 5,

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuCheckboxItem.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuCheckboxItem.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  MenuCheckboxItem,
-  type MenuCheckboxItemEmits,
-  type MenuCheckboxItemProps,
+<script lang="ts">
+import type {
+  MenuCheckboxItemEmits,
+  MenuCheckboxItemProps,
 } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+
+export type DropdownMenuCheckboxItemEmits = MenuCheckboxItemEmits
 
 export interface DropdownMenuCheckboxItemProps extends MenuCheckboxItemProps {}
-export type DropdownMenuCheckboxItemEmits = MenuCheckboxItemEmits
+</script>
+
+<script setup lang="ts">
+import { MenuCheckboxItem } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<DropdownMenuCheckboxItemProps>()
 const emits = defineEmits<DropdownMenuCheckboxItemEmits>()

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuContent.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuContent.vue
@@ -1,15 +1,19 @@
+<script lang="ts">
+import type {
+  MenuContentEmits,
+  MenuContentProps,
+} from '@/Menu'
+
+export type DropdownMenuContentEmits = MenuContentEmits
+
+export interface DropdownMenuContentProps extends MenuContentProps {}
+</script>
+
 <script setup lang="ts">
 import { ref } from 'vue'
 import { injectDropdownMenuRootContext } from './DropdownMenuRoot.vue'
-import {
-  MenuContent,
-  type MenuContentEmits,
-  type MenuContentProps,
-} from '@/Menu'
+import { MenuContent } from '@/Menu'
 import { useForwardPropsEmits } from '@/shared'
-
-export interface DropdownMenuContentProps extends MenuContentProps {}
-export type DropdownMenuContentEmits = MenuContentEmits
 
 const props = defineProps<DropdownMenuContentProps>()
 const emits = defineEmits<DropdownMenuContentEmits>()

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuGroup.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuGroup.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuGroup, type MenuGroupProps } from '@/Menu'
+<script lang="ts">
+import type { MenuGroupProps } from '@/Menu'
 
 export interface DropdownMenuGroupProps extends MenuGroupProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuGroup } from '@/Menu'
+
 const props = defineProps<DropdownMenuGroupProps>()
 </script>
 

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuItem.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuItem.vue
@@ -1,9 +1,14 @@
-<script setup lang="ts">
-import { MenuItem, type MenuItemEmits, type MenuItemProps } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+<script lang="ts">
+import type { MenuItemEmits, MenuItemProps } from '@/Menu'
+
+export type DropdownMenuItemEmits = MenuItemEmits
 
 export interface DropdownMenuItemProps extends MenuItemProps {}
-export type DropdownMenuItemEmits = MenuItemEmits
+</script>
+
+<script setup lang="ts">
+import { MenuItem } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<DropdownMenuItemProps>()
 const emits = defineEmits<DropdownMenuItemEmits>()

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuItemIndicator.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuItemIndicator.vue
@@ -1,8 +1,12 @@
-<script setup lang="ts">
-import { MenuItemIndicator, type MenuItemIndicatorProps } from '@/Menu'
+<script lang="ts">
+import type { MenuItemIndicatorProps } from '@/Menu'
 
-export interface DropdownMenuItemIndicatorProps
-  extends MenuItemIndicatorProps {}
+export interface DropdownMenuItemIndicatorProps extends MenuItemIndicatorProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuItemIndicator } from '@/Menu'
+
 const props = defineProps<DropdownMenuItemIndicatorProps>()
 </script>
 

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuLabel.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuLabel.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuLabel, type MenuLabelProps } from '@/Menu'
+<script lang="ts">
+import type { MenuLabelProps } from '@/Menu'
 
 export interface DropdownMenuLabelProps extends MenuLabelProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuLabel } from '@/Menu'
+
 const props = defineProps<DropdownMenuLabelProps>()
 </script>
 

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuPortal.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuPortal, type MenuPortalProps } from '@/Menu'
+<script lang="ts">
+import type { MenuPortalProps } from '@/Menu'
 
 export interface DropdownMenuPortalProps extends MenuPortalProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuPortal } from '@/Menu'
+
 const props = defineProps<DropdownMenuPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuRadioGroup.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuRadioGroup.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  MenuRadioGroup,
-  type MenuRadioGroupEmits,
-  type MenuRadioGroupProps,
+<script lang="ts">
+import type {
+  MenuRadioGroupEmits,
+  MenuRadioGroupProps,
 } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+
+export type DropdownMenuRadioGroupEmits = MenuRadioGroupEmits
 
 export interface DropdownMenuRadioGroupProps extends MenuRadioGroupProps {}
-export type DropdownMenuRadioGroupEmits = MenuRadioGroupEmits
+</script>
+
+<script setup lang="ts">
+import { MenuRadioGroup } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<MenuRadioGroupProps>()
 const emits = defineEmits<MenuRadioGroupEmits>()

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuRadioItem.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuRadioItem.vue
@@ -1,12 +1,16 @@
-<script setup lang="ts">
-import {
-  MenuRadioItem,
-  type MenuRadioItemEmits,
-  type MenuRadioItemProps,
+<script lang="ts">
+import type {
+  MenuRadioItemEmits,
+  MenuRadioItemProps,
 } from '@/Menu'
 
-export interface DropdownMenuRadioItemProps extends MenuRadioItemProps {}
 export type DropdownMenuRadioItemEmits = MenuRadioItemEmits
+
+export interface DropdownMenuRadioItemProps extends MenuRadioItemProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuRadioItem } from '@/Menu'
 
 const props = defineProps<DropdownMenuRadioItemProps>()
 const emits = defineEmits<DropdownMenuRadioItemEmits>()

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuSeparator.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuSeparator.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuSeparator, type MenuSeparatorProps } from '@/Menu'
+<script lang="ts">
+import type { MenuSeparatorProps } from '@/Menu'
 
 export interface DropdownMenuSeparatorProps extends MenuSeparatorProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuSeparator } from '@/Menu'
+
 const props = defineProps<DropdownMenuSeparatorProps>()
 </script>
 

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuSub.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuSub.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
+export type DropdownMenuSubEmits = {
+  'update:open': [value: boolean]
+}
+
 export interface DropdownMenuSubProps {
   open?: boolean
   defaultOpen?: boolean
-}
-
-export type DropdownMenuSubEmits = {
-  'update:open': [value: boolean]
 }
 </script>
 

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuSubContent.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuSubContent.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  MenuSubContent,
-  type MenuSubContentEmits,
-  type MenuSubContentProps,
+<script lang="ts">
+import type {
+  MenuSubContentEmits,
+  MenuSubContentProps,
 } from '@/Menu'
-import { useForwardPropsEmits } from '..'
+
+export type DropdownMenuSubContentEmits = MenuSubContentEmits
 
 export interface DropdownMenuSubContentProps extends MenuSubContentProps {}
-export type DropdownMenuSubContentEmits = MenuSubContentEmits
+</script>
+
+<script setup lang="ts">
+import { MenuSubContent } from '@/Menu'
+import { useForwardPropsEmits } from '..'
 
 const props = defineProps<DropdownMenuSubContentProps>()
 const emits = defineEmits<DropdownMenuSubContentEmits>()

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuSubTrigger.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuSubTrigger.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuSubTrigger, type MenuSubTriggerProps } from '@/Menu'
+<script lang="ts">
+import type { MenuSubTriggerProps } from '@/Menu'
 
 export interface DropdownMenuSubTriggerProps extends MenuSubTriggerProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuSubTrigger } from '@/Menu'
+
 const props = defineProps<DropdownMenuSubTriggerProps>()
 </script>
 

--- a/packages/radix-vue/src/DropdownMenu/DropdownMenuTrigger.vue
+++ b/packages/radix-vue/src/DropdownMenu/DropdownMenuTrigger.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface DropdownMenuTriggerProps extends PrimitiveProps {
   disabled?: boolean
 }
@@ -9,7 +11,6 @@ import { nextTick, onMounted } from 'vue'
 import { injectDropdownMenuRootContext } from './DropdownMenuRoot.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { MenuAnchor } from '@/Menu'

--- a/packages/radix-vue/src/FocusScope/FocusScope.vue
+++ b/packages/radix-vue/src/FocusScope/FocusScope.vue
@@ -1,21 +1,19 @@
-<script setup lang="ts">
-import { nextTick, reactive, ref, watchEffect } from 'vue'
-import { isClient } from '@vueuse/shared'
-import {
-  AUTOFOCUS_ON_MOUNT,
-  AUTOFOCUS_ON_UNMOUNT,
-  EVENT_OPTIONS,
-  focus,
-  focusFirst,
-  getTabbableCandidates,
-  getTabbableEdges,
-} from './utils'
-import { createFocusScopesStack, removeLinks } from './stack'
-import {
-  Primitive,
-  type PrimitiveProps,
-  usePrimitiveElement,
-} from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export type FocusScopeEmits = {
+  /**
+   * Event handler called when auto-focusing on mount.
+   * Can be prevented.
+   */
+  'mountAutoFocus': [event: Event]
+
+  /**
+   * Event handler called when auto-focusing on unmount.
+   * Can be prevented.
+   */
+  'unmountAutoFocus': [event: Event]
+}
 
 export interface FocusScopeProps extends PrimitiveProps {
   /**
@@ -32,20 +30,25 @@ export interface FocusScopeProps extends PrimitiveProps {
    */
   trapped?: boolean
 }
+</script>
 
-export type FocusScopeEmits = {
-  /**
-   * Event handler called when auto-focusing on mount.
-   * Can be prevented.
-   */
-  'mountAutoFocus': [event: Event]
-
-  /**
-   * Event handler called when auto-focusing on unmount.
-   * Can be prevented.
-   */
-  'unmountAutoFocus': [event: Event]
-}
+<script setup lang="ts">
+import { nextTick, reactive, ref, watchEffect } from 'vue'
+import { isClient } from '@vueuse/shared'
+import {
+  AUTOFOCUS_ON_MOUNT,
+  AUTOFOCUS_ON_UNMOUNT,
+  EVENT_OPTIONS,
+  focus,
+  focusFirst,
+  getTabbableCandidates,
+  getTabbableEdges,
+} from './utils'
+import { createFocusScopesStack, removeLinks } from './stack'
+import {
+  Primitive,
+  usePrimitiveElement,
+} from '@/Primitive'
 
 const props = withDefaults(defineProps<FocusScopeProps>(), {
   loop: false,

--- a/packages/radix-vue/src/HoverCard/HoverCardArrow.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardArrow.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { PopperArrow, type PopperArrowProps } from '@/Popper'
+<script lang="ts">
+import type { PopperArrowProps } from '@/Popper'
 
 export interface HoverCardArrowProps extends PopperArrowProps {}
+</script>
+
+<script setup lang="ts">
+import { PopperArrow } from '@/Popper'
+
 const props = defineProps<HoverCardArrowProps>()
 </script>
 

--- a/packages/radix-vue/src/HoverCard/HoverCardContent.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardContent.vue
@@ -1,11 +1,7 @@
-<script setup lang="ts">
-import {
-  injectHoverCardRootContext,
-} from './HoverCardRoot.vue'
-import { excludeTouch } from './utils'
-import { Presence } from '@/Presence'
-import HoverCardContentImpl, { type HoverCardContentImplEmits, type HoverCardContentImplProps } from './HoverCardContentImpl.vue'
-import { useForwardPropsEmits } from '@/shared'
+<script lang="ts">
+import type { HoverCardContentImplEmits, HoverCardContentImplProps } from './HoverCardContentImpl.vue'
+
+export type HoverCardContentEmits = HoverCardContentImplEmits
 
 export interface HoverCardContentProps extends HoverCardContentImplProps {
   /**
@@ -14,7 +10,14 @@ export interface HoverCardContentProps extends HoverCardContentImplProps {
    */
   forceMount?: boolean
 }
-export type HoverCardContentEmits = HoverCardContentImplEmits
+</script>
+
+<script setup lang="ts">
+import { injectHoverCardRootContext } from './HoverCardRoot.vue'
+import { excludeTouch } from './utils'
+import { Presence } from '@/Presence'
+import HoverCardContentImpl from './HoverCardContentImpl.vue'
+import { useForwardPropsEmits } from '@/shared'
 
 const props = defineProps<HoverCardContentProps>()
 const emits = defineEmits<HoverCardContentEmits>()

--- a/packages/radix-vue/src/HoverCard/HoverCardContentImpl.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardContentImpl.vue
@@ -1,16 +1,19 @@
+<script lang="ts">
+import type { PopperContentProps } from '@/Popper'
+import type { DismissableLayerEmits } from '@/DismissableLayer'
+
+export type HoverCardContentImplEmits = DismissableLayerEmits
+export interface HoverCardContentImplProps extends PopperContentProps {}
+</script>
+
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, watchEffect } from 'vue'
-import {
-  injectHoverCardRootContext,
-} from './HoverCardRoot.vue'
-import { PopperContent, type PopperContentProps } from '@/Popper'
-import { DismissableLayer, type DismissableLayerEmits } from '@/DismissableLayer'
+import { injectHoverCardRootContext } from './HoverCardRoot.vue'
+import { PopperContent } from '@/Popper'
+import { DismissableLayer } from '@/DismissableLayer'
 import { usePrimitiveElement } from '@/Primitive'
 import { getTabbableNodes } from './utils'
 import { useForwardProps } from '..'
-
-export interface HoverCardContentImplProps extends PopperContentProps {}
-export type HoverCardContentImplEmits = DismissableLayerEmits
 
 const props = defineProps<HoverCardContentImplProps>()
 const emits = defineEmits<HoverCardContentImplEmits>()

--- a/packages/radix-vue/src/HoverCard/HoverCardPortal.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface HoverCardPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<HoverCardPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -1,15 +1,14 @@
-<script setup lang="ts">
-import {
-  injectHoverCardRootContext,
-} from './HoverCardRoot.vue'
-import {
-  Primitive,
-  type PrimitiveProps,
-} from '@/Primitive'
-import { PopperAnchor } from '@/Popper'
-import { excludeTouch } from './utils'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface HoverCardTriggerProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { injectHoverCardRootContext } from './HoverCardRoot.vue'
+import { Primitive } from '@/Primitive'
+import { PopperAnchor } from '@/Popper'
+import { excludeTouch } from './utils'
 
 withDefaults(defineProps<HoverCardTriggerProps>(), {
   as: 'a',

--- a/packages/radix-vue/src/Label/Label.vue
+++ b/packages/radix-vue/src/Label/Label.vue
@@ -1,9 +1,13 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface LabelProps extends PrimitiveProps {
   for?: string
 }
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<LabelProps>(), {
   as: 'label',

--- a/packages/radix-vue/src/Menu/MenuArrow.vue
+++ b/packages/radix-vue/src/Menu/MenuArrow.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { PopperArrow, type PopperArrowProps } from '@/Popper'
+<script lang="ts">
+import type { PopperArrowProps } from '@/Popper'
 
 export interface MenuArrowProps extends PopperArrowProps {}
+</script>
+
+<script setup lang="ts">
+import { PopperArrow } from '@/Popper'
 
 const props = defineProps<MenuArrowProps>()
 </script>

--- a/packages/radix-vue/src/Menu/MenuCheckboxItem.vue
+++ b/packages/radix-vue/src/Menu/MenuCheckboxItem.vue
@@ -1,18 +1,24 @@
-<script setup lang="ts">
-import { useVModel } from '@vueuse/core'
-import { type CheckedState, getCheckedState, isIndeterminate } from './utils'
-import MenuItem, {
-  type MenuItemEmits,
-  type MenuItemProps,
+<script lang="ts">
+import type { CheckedState } from './utils'
+import type {
+  MenuItemEmits,
+  MenuItemProps,
 } from './MenuItem.vue'
-import { provideMenuItemIndicatorContext } from './MenuItemIndicator.vue'
+
+export type MenuCheckboxItemEmits = MenuItemEmits & {
+  'update:checked': [payload: boolean]
+}
 
 export interface MenuCheckboxItemProps extends MenuItemProps {
   checked?: CheckedState
 }
-export type MenuCheckboxItemEmits = MenuItemEmits & {
-  'update:checked': [payload: boolean]
-}
+</script>
+
+<script setup lang="ts">
+import { useVModel } from '@vueuse/core'
+import { getCheckedState, isIndeterminate } from './utils'
+import MenuItem from './MenuItem.vue'
+import { provideMenuItemIndicatorContext } from './MenuItemIndicator.vue'
 
 const props = withDefaults(defineProps<MenuCheckboxItemProps>(), {
   checked: false,

--- a/packages/radix-vue/src/Menu/MenuContent.vue
+++ b/packages/radix-vue/src/Menu/MenuContent.vue
@@ -1,13 +1,10 @@
-<script setup lang="ts">
-import MenuRootContentModal from './MenuRootContentModal.vue'
-import MenuRootContentNonModal from './MenuRootContentNonModal.vue'
-import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
-import {
-  type MenuContentImplEmits,
-  type MenuRootContentProps,
+<script lang="ts">
+import type {
+  MenuContentImplEmits,
+  MenuRootContentProps,
 } from './MenuContentImpl.vue'
-import { Presence } from '@/Presence'
-import { useEmitAsProps } from '@/shared'
+
+export type MenuContentEmits = MenuContentImplEmits
 
 export interface MenuContentProps extends MenuRootContentProps {
   /**
@@ -16,7 +13,14 @@ export interface MenuContentProps extends MenuRootContentProps {
    */
   forceMount?: boolean
 }
-export type MenuContentEmits = MenuContentImplEmits
+</script>
+
+<script setup lang="ts">
+import MenuRootContentModal from './MenuRootContentModal.vue'
+import MenuRootContentNonModal from './MenuRootContentNonModal.vue'
+import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
+import { Presence } from '@/Presence'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<MenuContentProps>()
 const emits = defineEmits<MenuContentEmits>()

--- a/packages/radix-vue/src/Menu/MenuContentImpl.vue
+++ b/packages/radix-vue/src/Menu/MenuContentImpl.vue
@@ -1,4 +1,17 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type {
+  GraceIntent,
+  Side,
+} from './utils'
+import type { FocusScopeProps } from '@/FocusScope'
+import type { RovingFocusGroupEmits } from '@/RovingFocus'
+import type {
+  DismissableLayerEmits,
+  DismissableLayerProps,
+} from '@/DismissableLayer'
+import type { PopperContentProps } from '@/Popper'
+
 import {
   createContext,
   useArrowNavigation,
@@ -67,7 +80,6 @@ export interface MenuRootContentProps
 
 <script setup lang="ts">
 import {
-  type Ref,
   onUnmounted,
   ref,
   toRefs,
@@ -76,27 +88,20 @@ import {
 import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
 import {
   FIRST_LAST_KEYS,
-  type GraceIntent,
   LAST_KEYS,
-  type Side,
   focusFirst,
   getOpenState,
   isMouseEvent,
   isPointerInGraceArea,
 } from './utils'
-import { FocusScope, type FocusScopeProps } from '@/FocusScope'
-import {
-  DismissableLayer,
-  type DismissableLayerEmits,
-  type DismissableLayerProps,
-} from '@/DismissableLayer'
+import { FocusScope } from '@/FocusScope'
+import { DismissableLayer } from '@/DismissableLayer'
 import {
   PopperContent,
-  type PopperContentProps,
   PopperContentPropsDefaultValue,
 } from '@/Popper'
 import { usePrimitiveElement } from '@/Primitive'
-import { RovingFocusGroup, type RovingFocusGroupEmits } from '@/RovingFocus'
+import { RovingFocusGroup } from '@/RovingFocus'
 
 const props = withDefaults(defineProps<MenuContentImplProps>(), {
   ...PopperContentPropsDefaultValue,

--- a/packages/radix-vue/src/Menu/MenuGroup.vue
+++ b/packages/radix-vue/src/Menu/MenuGroup.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface MenuGroupProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
 
 const props = defineProps<MenuGroupProps>()
 </script>

--- a/packages/radix-vue/src/Menu/MenuItem.vue
+++ b/packages/radix-vue/src/Menu/MenuItem.vue
@@ -1,13 +1,16 @@
 <script lang="ts">
+import type { MenuItemImplProps } from './MenuItemImpl.vue'
+
 export type MenuItemEmits = {
   'select': [event: Event]
 }
+
 export interface MenuItemProps extends MenuItemImplProps {}
 </script>
 
 <script setup lang="ts">
 import { nextTick, ref } from 'vue'
-import MenuItemImpl, { type MenuItemImplProps } from './MenuItemImpl.vue'
+import MenuItemImpl from './MenuItemImpl.vue'
 import { injectMenuRootContext } from './MenuRoot.vue'
 import { injectMenuContentContext } from './MenuContentImpl.vue'
 import { ITEM_SELECT, SELECTION_KEYS } from './utils'

--- a/packages/radix-vue/src/Menu/MenuItemImpl.vue
+++ b/packages/radix-vue/src/Menu/MenuItemImpl.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { isMouseEvent } from './utils'
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface MenuItemImplProps extends PrimitiveProps {
   disabled?: boolean
@@ -8,13 +8,13 @@ export interface MenuItemImplProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
+import { nextTick, ref } from 'vue'
+import { isMouseEvent } from './utils'
 import { injectMenuContentContext } from './MenuContentImpl.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
-import { nextTick, ref } from 'vue'
 
 const props = defineProps<MenuItemImplProps>()
 

--- a/packages/radix-vue/src/Menu/MenuItemIndicator.vue
+++ b/packages/radix-vue/src/Menu/MenuItemIndicator.vue
@@ -1,8 +1,19 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext } from '@/shared'
+import type { CheckedState } from './utils'
 
 interface MenuItemIndicatorContext {
   checked: Ref<CheckedState>
+}
+
+export interface MenuItemIndicatorProps extends PrimitiveProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with Vue animation libraries.
+   */
+  forceMount?: boolean
 }
 
 export const [injectMenuItemIndicatorContext, provideMenuItemIndicatorContext]
@@ -12,18 +23,10 @@ export const [injectMenuItemIndicatorContext, provideMenuItemIndicatorContext]
 </script>
 
 <script setup lang="ts">
-import { type Ref, ref } from 'vue'
-import { type CheckedState, getCheckedState, isIndeterminate } from './utils'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { ref } from 'vue'
+import { getCheckedState, isIndeterminate } from './utils'
+import { Primitive } from '@/Primitive'
 import { Presence } from '@/Presence'
-
-export interface MenuItemIndicatorProps extends PrimitiveProps {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with Vue animation libraries.
-   */
-  forceMount?: boolean
-}
 
 withDefaults(defineProps<MenuItemIndicatorProps>(), {
   as: 'span',

--- a/packages/radix-vue/src/Menu/MenuLabel.vue
+++ b/packages/radix-vue/src/Menu/MenuLabel.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface MenuLabelProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 const props = withDefaults(defineProps<MenuLabelProps>(), {
   as: 'label',
 })

--- a/packages/radix-vue/src/Menu/MenuPortal.vue
+++ b/packages/radix-vue/src/Menu/MenuPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface MenuPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<MenuPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/Menu/MenuRadioGroup.vue
+++ b/packages/radix-vue/src/Menu/MenuRadioGroup.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { MenuGroupProps } from './MenuGroup.vue'
 import { createContext } from '@/shared'
 
 interface MenuRadioGroupContext {
@@ -6,21 +8,21 @@ interface MenuRadioGroupContext {
   onValueChange: (payload: string) => void
 }
 
+export interface MenuRadioGroupProps extends MenuGroupProps {
+  modelValue?: string
+}
+
+export type MenuRadioGroupEmits = {
+  'update:modelValue': [payload: boolean]
+}
+
 export const [injectMenuRadioGroupContext, provideMenuRadioGroupContext]
   = createContext<MenuRadioGroupContext>('MenuRadioGroup')
 </script>
 
 <script setup lang="ts">
-import { type Ref } from 'vue'
 import { useVModel } from '@vueuse/core'
-import MenuGroup, { type MenuGroupProps } from './MenuGroup.vue'
-
-export interface MenuRadioGroupProps extends MenuGroupProps {
-  modelValue?: string
-}
-export type MenuRadioGroupEmits = {
-  'update:modelValue': [payload: boolean]
-}
+import MenuGroup from './MenuGroup.vue'
 
 const props = withDefaults(defineProps<MenuRadioGroupProps>(), {
   modelValue: '',

--- a/packages/radix-vue/src/Menu/MenuRadioItem.vue
+++ b/packages/radix-vue/src/Menu/MenuRadioItem.vue
@@ -1,17 +1,22 @@
-<script setup lang="ts">
-import { computed, toRefs } from 'vue'
-import { getCheckedState } from './utils'
-import MenuItem, {
-  type MenuItemEmits,
-  type MenuItemProps,
+<script lang="ts">
+import type {
+  MenuItemEmits,
+  MenuItemProps,
 } from './MenuItem.vue'
-import { injectMenuRadioGroupContext } from './MenuRadioGroup.vue'
-import { provideMenuItemIndicatorContext } from './MenuItemIndicator.vue'
+
+export type MenuRadioItemEmits = MenuItemEmits
 
 export interface MenuRadioItemProps extends MenuItemProps {
   value: string
 }
-export type MenuRadioItemEmits = MenuItemEmits
+</script>
+
+<script setup lang="ts">
+import { computed, toRefs } from 'vue'
+import { getCheckedState } from './utils'
+import MenuItem from './MenuItem.vue'
+import { injectMenuRadioGroupContext } from './MenuRadioGroup.vue'
+import { provideMenuItemIndicatorContext } from './MenuItemIndicator.vue'
 
 const props = defineProps<MenuRadioItemProps>()
 const emits = defineEmits<MenuRadioItemEmits>()

--- a/packages/radix-vue/src/Menu/MenuRoot.vue
+++ b/packages/radix-vue/src/Menu/MenuRoot.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { Direction } from './utils'
 import { createContext, useDirection } from '@/shared'
 
 export interface MenuContext {
@@ -31,14 +33,12 @@ export const [injectMenuRootContext, provideMenuRootContext]
 
 <script setup lang="ts">
 import {
-  type Ref,
   ref,
   toRefs,
   watchEffect,
 } from 'vue'
 import { isClient } from '@vueuse/shared'
 import { useVModel } from '@vueuse/core'
-import { type Direction } from './utils'
 import { PopperRoot } from '@/Popper'
 
 const props = withDefaults(defineProps<MenuProps>(), {

--- a/packages/radix-vue/src/Menu/MenuSeparator.vue
+++ b/packages/radix-vue/src/Menu/MenuSeparator.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface MenuSeparatorProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
 
 const props = defineProps<MenuSeparatorProps>()
 </script>

--- a/packages/radix-vue/src/Menu/MenuSub.vue
+++ b/packages/radix-vue/src/Menu/MenuSub.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { MenuContext } from './MenuRoot.vue'
 import { createContext, useId } from '@/shared'
 
 export interface MenuSubContext {
@@ -19,12 +21,11 @@ export interface MenuSubProps {
 
 <script setup lang="ts">
 import {
-  type Ref,
   ref,
   watchEffect,
 } from 'vue'
 import { useVModel } from '@vueuse/core'
-import { type MenuContext, injectMenuContext, provideMenuContext } from './MenuRoot.vue'
+import { injectMenuContext, provideMenuContext } from './MenuRoot.vue'
 import { PopperRoot } from '@/Popper'
 
 const props = withDefaults(defineProps<MenuSubProps>(), {

--- a/packages/radix-vue/src/Menu/MenuSubContent.vue
+++ b/packages/radix-vue/src/Menu/MenuSubContent.vue
@@ -1,14 +1,10 @@
-<script setup lang="ts">
-import MenuContentImpl, {
-  type MenuContentImplEmits,
-  type MenuContentImplProps,
+<script lang="ts">
+import type {
+  MenuContentImplEmits,
+  MenuContentImplProps,
 } from './MenuContentImpl.vue'
-import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
-import { injectMenuSubContext } from './MenuSub.vue'
-import { SUB_CLOSE_KEYS } from './utils'
-import { Presence } from '@/Presence'
-import { usePrimitiveElement } from '@/Primitive'
-import { useForwardPropsEmits } from '@/shared'
+
+export type MenuSubContentEmits = MenuContentImplEmits
 
 export interface MenuSubContentProps extends MenuContentImplProps {
   /**
@@ -17,7 +13,16 @@ export interface MenuSubContentProps extends MenuContentImplProps {
    */
   forceMount?: boolean
 }
-export type MenuSubContentEmits = MenuContentImplEmits
+</script>
+
+<script setup lang="ts">
+import MenuContentImpl from './MenuContentImpl.vue'
+import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
+import { injectMenuSubContext } from './MenuSub.vue'
+import { SUB_CLOSE_KEYS } from './utils'
+import { Presence } from '@/Presence'
+import { usePrimitiveElement } from '@/Primitive'
+import { useForwardPropsEmits } from '@/shared'
 
 const props = defineProps<MenuSubContentProps>()
 const emits = defineEmits<MenuSubContentEmits>()

--- a/packages/radix-vue/src/Menu/MenuSubTrigger.vue
+++ b/packages/radix-vue/src/Menu/MenuSubTrigger.vue
@@ -1,13 +1,18 @@
+<script lang="ts">
+import type { MenuItemImplProps } from './MenuItemImpl.vue'
+import type { Side } from './utils'
+
+export interface MenuSubTriggerProps extends MenuItemImplProps {}
+</script>
+
 <script setup lang="ts">
 import { computed, nextTick, onUnmounted, ref } from 'vue'
-import MenuItemImpl, { type MenuItemImplProps } from './MenuItemImpl.vue'
+import MenuItemImpl from './MenuItemImpl.vue'
 import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
 import { injectMenuSubContext } from './MenuSub.vue'
 import { injectMenuContentContext } from './MenuContentImpl.vue'
 import MenuAnchor from './MenuAnchor.vue'
-import { SUB_OPEN_KEYS, type Side, getOpenState, isMouseEvent } from './utils'
-
-export interface MenuSubTriggerProps extends MenuItemImplProps {}
+import { SUB_OPEN_KEYS, getOpenState, isMouseEvent } from './utils'
 
 const props = defineProps<MenuSubTriggerProps>()
 

--- a/packages/radix-vue/src/Menubar/MenubarArrow.vue
+++ b/packages/radix-vue/src/Menubar/MenubarArrow.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuArrow, type MenuArrowProps } from '@/Menu'
+<script lang="ts">
+import type { MenuArrowProps } from '@/Menu'
 
 export interface MenubarArrowProps extends MenuArrowProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuArrow } from '@/Menu'
+
 const props = withDefaults(defineProps<MenubarArrowProps>(), {
   width: 10,
   height: 5,

--- a/packages/radix-vue/src/Menubar/MenubarCheckboxItem.vue
+++ b/packages/radix-vue/src/Menubar/MenubarCheckboxItem.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  MenuCheckboxItem,
-  type MenuCheckboxItemEmits,
-  type MenuCheckboxItemProps,
+<script lang="ts">
+import type {
+  MenuCheckboxItemEmits,
+  MenuCheckboxItemProps,
 } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+
+export type MenubarCheckboxItemEmits = MenuCheckboxItemEmits
 
 export interface MenubarCheckboxItemProps extends MenuCheckboxItemProps {}
-export type MenubarCheckboxItemEmits = MenuCheckboxItemEmits
+</script>
+
+<script setup lang="ts">
+import { MenuCheckboxItem } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<MenubarCheckboxItemProps>()
 const emits = defineEmits<MenubarCheckboxItemEmits>()

--- a/packages/radix-vue/src/Menubar/MenubarContent.vue
+++ b/packages/radix-vue/src/Menubar/MenubarContent.vue
@@ -1,13 +1,18 @@
+<script lang="ts">
+import type { MenuContentEmits, MenuContentProps } from '@/Menu'
+
+export type MenubarContentEmits = MenuContentEmits
+
+export interface MenubarContentProps extends MenuContentProps {}
+</script>
+
 <script setup lang="ts">
 import { ref } from 'vue'
 import { injectMenubarRootContext } from './MenubarRoot.vue'
 import { injectMenubarMenuContext } from './MenubarMenu.vue'
-import { MenuContent, type MenuContentEmits, type MenuContentProps } from '@/Menu'
+import { MenuContent } from '@/Menu'
 import { useCollection, useForwardPropsEmits } from '@/shared'
 import { wrapArray } from '@/shared/useTypeahead'
-
-export interface MenubarContentProps extends MenuContentProps {}
-export type MenubarContentEmits = MenuContentEmits
 
 const props = withDefaults(defineProps<MenubarContentProps>(), {
   align: 'start',

--- a/packages/radix-vue/src/Menubar/MenubarGroup.vue
+++ b/packages/radix-vue/src/Menubar/MenubarGroup.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuGroup, type MenuGroupProps } from '@/Menu'
+<script lang="ts">
+import type { MenuGroupProps } from '@/Menu'
 
 export interface MenubarGroupProps extends MenuGroupProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuGroup } from '@/Menu'
+
 const props = defineProps<MenubarGroupProps>()
 </script>
 

--- a/packages/radix-vue/src/Menubar/MenubarItem.vue
+++ b/packages/radix-vue/src/Menubar/MenubarItem.vue
@@ -1,9 +1,14 @@
-<script setup lang="ts">
-import { MenuItem, type MenuItemEmits, type MenuItemProps } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+<script lang="ts">
+import type { MenuItemEmits, MenuItemProps } from '@/Menu'
+
+export type MenubarItemEmits = MenuItemEmits
 
 export interface MenubarItemProps extends MenuItemProps {}
-export type MenubarItemEmits = MenuItemEmits
+</script>
+
+<script setup lang="ts">
+import { MenuItem } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<MenubarItemProps>()
 const emits = defineEmits<MenubarItemEmits>()

--- a/packages/radix-vue/src/Menubar/MenubarItemIndicator.vue
+++ b/packages/radix-vue/src/Menubar/MenubarItemIndicator.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuItemIndicator, type MenuItemIndicatorProps } from '@/Menu'
+<script lang="ts">
+import type { MenuItemIndicatorProps } from '@/Menu'
 
 export interface MenubarItemIndicatorProps extends MenuItemIndicatorProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuItemIndicator } from '@/Menu'
+
 const props = defineProps<MenubarItemIndicatorProps>()
 </script>
 

--- a/packages/radix-vue/src/Menubar/MenubarLabel.vue
+++ b/packages/radix-vue/src/Menubar/MenubarLabel.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuLabel, type MenuLabelProps } from '@/Menu'
+<script lang="ts">
+import type { MenuLabelProps } from '@/Menu'
 
 export interface MenubarLabelProps extends MenuLabelProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuLabel } from '@/Menu'
+
 const props = defineProps<MenubarLabelProps>()
 </script>
 

--- a/packages/radix-vue/src/Menubar/MenubarPortal.vue
+++ b/packages/radix-vue/src/Menubar/MenubarPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuPortal, type MenuPortalProps } from '@/Menu'
+<script lang="ts">
+import type { MenuPortalProps } from '@/Menu'
 
 export interface MenubarPortalProps extends MenuPortalProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuPortal } from '@/Menu'
+
 const props = defineProps<MenubarPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/Menubar/MenubarRadioGroup.vue
+++ b/packages/radix-vue/src/Menubar/MenubarRadioGroup.vue
@@ -1,13 +1,17 @@
-<script setup lang="ts">
-import {
-  MenuRadioGroup,
-  type MenuRadioGroupEmits,
-  type MenuRadioGroupProps,
+<script lang="ts">
+import type {
+  MenuRadioGroupEmits,
+  MenuRadioGroupProps,
 } from '@/Menu'
-import { useEmitAsProps } from '@/shared'
+
+export type MenubarRadioGroupEmits = MenuRadioGroupEmits
 
 export interface MenubarRadioGroupProps extends MenuRadioGroupProps {}
-export type MenubarRadioGroupEmits = MenuRadioGroupEmits
+</script>
+
+<script setup lang="ts">
+import { MenuRadioGroup } from '@/Menu'
+import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<MenubarRadioGroupProps>()
 const emits = defineEmits<MenubarRadioGroupEmits>()

--- a/packages/radix-vue/src/Menubar/MenubarRadioItem.vue
+++ b/packages/radix-vue/src/Menubar/MenubarRadioItem.vue
@@ -1,12 +1,16 @@
-<script setup lang="ts">
-import {
-  MenuRadioItem,
-  type MenuRadioItemEmits,
-  type MenuRadioItemProps,
+<script lang="ts">
+import type {
+  MenuRadioItemEmits,
+  MenuRadioItemProps,
 } from '@/Menu'
 
-export interface MenubarRadioItemProps extends MenuRadioItemProps {}
 export type MenubarRadioItemEmits = MenuRadioItemEmits
+
+export interface MenubarRadioItemProps extends MenuRadioItemProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuRadioItem } from '@/Menu'
 
 const props = defineProps<MenuRadioItemProps>()
 const emits = defineEmits<MenuRadioItemEmits>()

--- a/packages/radix-vue/src/Menubar/MenubarSeparator.vue
+++ b/packages/radix-vue/src/Menubar/MenubarSeparator.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuSeparator, type MenuSeparatorProps } from '@/Menu'
+<script lang="ts">
+import type { MenuSeparatorProps } from '@/Menu'
 
 export interface MenubarSeparatorProps extends MenuSeparatorProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuSeparator } from '@/Menu'
+
 const props = defineProps<MenubarSeparatorProps>()
 </script>
 

--- a/packages/radix-vue/src/Menubar/MenubarSubContent.vue
+++ b/packages/radix-vue/src/Menubar/MenubarSubContent.vue
@@ -1,16 +1,20 @@
+<script lang="ts">
+import type {
+  MenuSubContentEmits,
+  MenuSubContentProps,
+} from '@/Menu'
+
+export type MenubarSubContentEmits = MenuSubContentEmits
+
+export interface MenubarSubContentProps extends MenuSubContentProps {}
+</script>
+
 <script setup lang="ts">
 import { injectMenubarRootContext } from './MenubarRoot.vue'
 import { injectMenubarMenuContext } from './MenubarMenu.vue'
-import {
-  MenuSubContent,
-  type MenuSubContentEmits,
-  type MenuSubContentProps,
-} from '@/Menu'
+import { MenuSubContent } from '@/Menu'
 import { useCollection, useForwardPropsEmits } from '@/shared'
 import { wrapArray } from '@/shared/useTypeahead'
-
-export interface MenubarSubContentProps extends MenuSubContentProps {}
-export type MenubarSubContentEmits = MenuSubContentEmits
 
 const props = defineProps<MenubarSubContentProps>()
 const emits = defineEmits<MenubarSubContentEmits>()

--- a/packages/radix-vue/src/Menubar/MenubarSubTrigger.vue
+++ b/packages/radix-vue/src/Menubar/MenubarSubTrigger.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { MenuSubTrigger, type MenuSubTriggerProps } from '@/Menu'
+<script lang="ts">
+import type { MenuSubTriggerProps } from '@/Menu'
 
 export interface MenubarSubTriggerProps extends MenuSubTriggerProps {}
+</script>
+
+<script setup lang="ts">
+import { MenuSubTrigger } from '@/Menu'
+
 const props = defineProps<MenubarSubTriggerProps>()
 </script>
 

--- a/packages/radix-vue/src/Menubar/MenubarTrigger.vue
+++ b/packages/radix-vue/src/Menubar/MenubarTrigger.vue
@@ -1,18 +1,21 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface MenubarTriggerProps extends PrimitiveProps {
+  disabled?: boolean
+}
+</script>
+
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { injectMenubarRootContext } from './MenubarRoot.vue'
 import { injectMenubarMenuContext } from './MenubarMenu.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { MenuAnchor } from '@/Menu'
 import { RovingFocusItem } from '@/RovingFocus'
-
-export interface MenubarTriggerProps extends PrimitiveProps {
-  disabled?: boolean
-}
 
 withDefaults(defineProps<MenubarTriggerProps>(), {
   as: 'button',

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuContent.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuContent.vue
@@ -1,13 +1,8 @@
-<script setup lang="ts">
-import { computed } from 'vue'
-import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
-import { injectNavigationMenuItemContext } from './NavigationMenuItem.vue'
-import { getOpenState } from './utils'
-import { Presence } from '@/Presence'
-import { type PointerDownOutsideEvent } from '@/DismissableLayer'
-import NavigationMenuContentImpl, { type NavigationMenuContentImplEmits, type NavigationMenuContentImplProps } from './NavigationMenuContentImpl.vue'
-import { useEmitAsProps } from '@/shared'
-import { useMounted } from '@vueuse/core'
+<script lang="ts">
+import type { PointerDownOutsideEvent } from '@/DismissableLayer'
+import type { NavigationMenuContentImplEmits, NavigationMenuContentImplProps } from './NavigationMenuContentImpl.vue'
+
+export type NavigationMenuContentEmits = NavigationMenuContentImplEmits
 
 export interface NavigationMenuContentProps extends NavigationMenuContentImplProps {
   /**
@@ -16,7 +11,21 @@ export interface NavigationMenuContentProps extends NavigationMenuContentImplPro
    */
   forceMount?: boolean
 }
-export type NavigationMenuContentEmits = NavigationMenuContentImplEmits
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
+import { injectNavigationMenuItemContext } from './NavigationMenuItem.vue'
+import { getOpenState } from './utils'
+import { Presence } from '@/Presence'
+import NavigationMenuContentImpl from './NavigationMenuContentImpl.vue'
+import { useEmitAsProps } from '@/shared'
+import { useMounted } from '@vueuse/core'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = defineProps<NavigationMenuContentProps>()
 const emits = defineEmits<NavigationMenuContentEmits>()
@@ -41,12 +50,6 @@ function handlePointerDown(ev: PointerDownOutsideEvent) {
   emits('pointerDownOutside', ev)
   if (!ev.preventDefault)
     menuContext.onContentLeave()
-}
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 }
 </script>
 

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuContentImpl.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuContentImpl.vue
@@ -1,8 +1,16 @@
 <script lang="ts">
+import type {
+  DismissableLayerEmits,
+  DismissableLayerProps,
+  FocusOutsideEvent,
+} from '@/DismissableLayer'
+import type { PointerDownOutsideEvent } from '@/DismissableLayer/utils'
+
 type MotionAttribute = 'to-start' | 'to-end' | 'from-start' | 'from-end'
 
-export interface NavigationMenuContentImplProps extends DismissableLayerProps {}
 export type NavigationMenuContentImplEmits = DismissableLayerEmits
+
+export interface NavigationMenuContentImplProps extends DismissableLayerProps {}
 </script>
 
 <script setup lang="ts">
@@ -16,15 +24,9 @@ import {
   makeContentId,
   makeTriggerId,
 } from './utils'
-import {
-  DismissableLayer,
-  type DismissableLayerEmits,
-  type DismissableLayerProps,
-  type FocusOutsideEvent,
-} from '@/DismissableLayer'
+import { DismissableLayer } from '@/DismissableLayer'
 import { usePrimitiveElement } from '@/Primitive'
 import { useArrowNavigation, useCollection } from '@/shared'
-import type { PointerDownOutsideEvent } from '@/DismissableLayer/utils'
 import { injectNavigationMenuItemContext } from './NavigationMenuItem.vue'
 
 const props = defineProps<NavigationMenuContentImplProps>()

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuIndicator.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuIndicator.vue
@@ -1,10 +1,5 @@
-<script setup lang="ts">
-import { computed, ref, watchEffect } from 'vue'
-import { useResizeObserver } from '@vueuse/core'
-import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
-import { useCollection } from '@/shared'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { Presence } from '@/Presence'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface NavigationMenuIndicatorProps extends PrimitiveProps {
   /**
@@ -13,6 +8,20 @@ export interface NavigationMenuIndicatorProps extends PrimitiveProps {
    */
   forceMount?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { computed, ref, watchEffect } from 'vue'
+import { useResizeObserver } from '@vueuse/core'
+import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
+import { useCollection } from '@/shared'
+import { Primitive } from '@/Primitive'
+import { Presence } from '@/Presence'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = defineProps<NavigationMenuIndicatorProps>()
 
 const { injectCollection } = useCollection('nav')
@@ -52,12 +61,6 @@ watchEffect(() => {
 
 useResizeObserver(activeTrigger, handlePositionChange)
 useResizeObserver(menuContext.indicatorTrack, handlePositionChange)
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <template>

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuItem.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuItem.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useArrowNavigation, useCollection, useId } from '@/shared'
 
 export interface NavigationMenuItemProps extends PrimitiveProps {
@@ -22,15 +24,15 @@ export const [injectNavigationMenuItemContext, provideNavigationMenuItemContext]
 </script>
 
 <script setup lang="ts">
-import { type Ref, ref } from 'vue'
+import { ref } from 'vue'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
+import { Primitive } from '@/Primitive'
 import {
   focusFirst,
   getTabbableCandidates,
   makeContentId,
   removeFromTabOrder,
 } from './utils'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
 
 const props = withDefaults(defineProps<NavigationMenuItemProps>(), {
   as: 'li',

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuLink.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuLink.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export type NavigationMenuLinkEmits = {
   'select': [payload: MouseEvent]
 }
@@ -9,8 +11,8 @@ export interface NavigationMenuLinkProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import { nextTick } from 'vue'
+import { Primitive } from '@/Primitive'
 import { EVENT_ROOT_CONTENT_DISMISS } from './utils'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
 
 // const LINK_SELECT = "navigationMenu.linkSelect";
 

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuList.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuList.vue
@@ -1,13 +1,21 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface NavigationMenuListProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 
-export interface NavigationMenuListProps extends PrimitiveProps {}
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = withDefaults(defineProps<NavigationMenuListProps>(), {
   as: 'ul',
 })
@@ -18,12 +26,6 @@ const { primitiveElement, currentElement } = usePrimitiveElement()
 onMounted(() => {
   menuContext.onIndicatorTrackChange(currentElement.value)
 })
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <template>

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuRoot.vue
@@ -1,10 +1,7 @@
 <script lang="ts">
-import {
-  type Ref,
-  computed,
-  ref,
-  toRefs,
-} from 'vue'
+import type { Ref } from 'vue'
+
+import type { PrimitiveProps } from '@/Primitive'
 import type { Direction, Orientation } from './utils'
 import { createContext, useCollection, useDirection, useId } from '@/shared'
 
@@ -53,10 +50,14 @@ export const [injectNavigationMenuContext, provideNavigationMenuContext]
 </script>
 
 <script setup lang="ts">
+import {
+  computed,
+  ref,
+  toRefs,
+} from 'vue'
 import { refAutoReset, useDebounceFn, useVModel } from '@vueuse/core'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuSub.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuSub.vue
@@ -1,23 +1,28 @@
-<script setup lang="ts">
-import { type Ref, ref } from 'vue'
-import { useVModel } from '@vueuse/core'
+<script lang="ts">
+import type { Ref } from 'vue'
 import type { Orientation } from './utils'
-import { injectNavigationMenuContext, provideNavigationMenuContext } from './NavigationMenuRoot.vue'
-import {
-  Primitive,
-  type PrimitiveProps,
-  usePrimitiveElement,
-} from '@/Primitive'
-import { useCollection } from '@/shared'
+import type { PrimitiveProps } from '@/Primitive'
+
+export type NavigationMenuSubEmits = {
+  'update:modelValue': [value: string]
+}
 
 export interface NavigationMenuSubProps extends PrimitiveProps {
   modelValue?: string
   defaultValue?: string
   orientation?: Orientation
 }
-export type NavigationMenuSubEmits = {
-  'update:modelValue': [value: string]
-}
+</script>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useVModel } from '@vueuse/core'
+import { injectNavigationMenuContext, provideNavigationMenuContext } from './NavigationMenuRoot.vue'
+import {
+  Primitive,
+  usePrimitiveElement,
+} from '@/Primitive'
+import { useCollection } from '@/shared'
 
 const props = withDefaults(defineProps<NavigationMenuSubProps>(), {
   orientation: 'horizontal',

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuTrigger.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuTrigger.vue
@@ -1,19 +1,27 @@
+<script lang="ts">
+import type { VNode } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface NavigationMenuTriggerProps extends PrimitiveProps {
+  disabled?: boolean
+}
+</script>
+
 <script setup lang="ts">
-import { type VNode, computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { refAutoReset, unrefElement } from '@vueuse/core'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
 import { injectNavigationMenuItemContext } from './NavigationMenuItem.vue'
 import { getOpenState, makeContentId, makeTriggerId } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { VisuallyHidden } from '@/VisuallyHidden'
 
-export interface NavigationMenuTriggerProps extends PrimitiveProps {
-  disabled?: boolean
-}
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<NavigationMenuTriggerProps>(), {
   as: 'button',
@@ -106,12 +114,6 @@ function handleVisuallyHiddenFocus(ev: FocusEvent) {
 
   if (wasTriggerFocused || !wasFocusFromContent)
     itemContext.onFocusProxyEnter(wasTriggerFocused ? 'start' : 'end')
-}
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 }
 </script>
 

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuViewport.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuViewport.vue
@@ -1,3 +1,15 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface NavigationMenuViewportProps extends PrimitiveProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with Vue animation libraries.
+   */
+  forceMount?: boolean
+}
+</script>
+
 <script setup lang="ts">
 import {
   computed,
@@ -10,18 +22,14 @@ import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
 import { getOpenState } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { Presence } from '@/Presence'
 
-export interface NavigationMenuViewportProps extends PrimitiveProps {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with Vue animation libraries.
-   */
-  forceMount?: boolean
-}
+defineOptions({
+  inheritAttrs: false,
+})
+
 defineProps<NavigationMenuViewportProps>()
 
 const { primitiveElement, currentElement } = usePrimitiveElement()
@@ -59,12 +67,6 @@ useResizeObserver(content, () => {
     }
   }
 })
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <template>

--- a/packages/radix-vue/src/Pagination/PaginationEllipsis.vue
+++ b/packages/radix-vue/src/Pagination/PaginationEllipsis.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface PaginationEllipsisProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 const props = defineProps<PaginationEllipsisProps>()
 </script>
 

--- a/packages/radix-vue/src/Pagination/PaginationFirst.vue
+++ b/packages/radix-vue/src/Pagination/PaginationFirst.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { injectPaginationRootContext } from './PaginationRoot.vue'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface PaginationFirstProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { injectPaginationRootContext } from './PaginationRoot.vue'
+
 const props = withDefaults(defineProps<PaginationFirstProps>(), { as: 'button' })
 
 const rootContext = injectPaginationRootContext()

--- a/packages/radix-vue/src/Pagination/PaginationLast.vue
+++ b/packages/radix-vue/src/Pagination/PaginationLast.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { injectPaginationRootContext } from './PaginationRoot.vue'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface PaginationLastProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { injectPaginationRootContext } from './PaginationRoot.vue'
+
 const props = withDefaults(defineProps<PaginationLastProps>(), { as: 'button' })
 
 const rootContext = injectPaginationRootContext()

--- a/packages/radix-vue/src/Pagination/PaginationList.vue
+++ b/packages/radix-vue/src/Pagination/PaginationList.vue
@@ -1,10 +1,15 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface PaginationListProps extends PrimitiveProps { }
+</script>
+
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { computed } from 'vue'
 import { injectPaginationRootContext } from './PaginationRoot.vue'
 import { getRange, transform } from './utils'
 
-export interface PaginationListProps extends PrimitiveProps { }
 const props = defineProps<PaginationListProps>()
 
 const rootContext = injectPaginationRootContext()

--- a/packages/radix-vue/src/Pagination/PaginationListItem.vue
+++ b/packages/radix-vue/src/Pagination/PaginationListItem.vue
@@ -1,11 +1,16 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { computed } from 'vue'
-import { injectPaginationRootContext } from './PaginationRoot.vue'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface PaginationListItemProps extends PrimitiveProps {
   value: number
 }
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { computed } from 'vue'
+import { injectPaginationRootContext } from './PaginationRoot.vue'
+
 const props = withDefaults(defineProps<PaginationListItemProps>(), { as: 'button' })
 
 const rootContext = injectPaginationRootContext()

--- a/packages/radix-vue/src/Pagination/PaginationNext.vue
+++ b/packages/radix-vue/src/Pagination/PaginationNext.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { injectPaginationRootContext } from './PaginationRoot.vue'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface PaginationNextProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { injectPaginationRootContext } from './PaginationRoot.vue'
+
 const props = withDefaults(defineProps<PaginationNextProps>(), { as: 'button' })
 
 const rootContext = injectPaginationRootContext()

--- a/packages/radix-vue/src/Pagination/PaginationPrev.vue
+++ b/packages/radix-vue/src/Pagination/PaginationPrev.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { injectPaginationRootContext } from './PaginationRoot.vue'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface PaginationPrevProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { injectPaginationRootContext } from './PaginationRoot.vue'
+
 const props = withDefaults(defineProps<PaginationPrevProps>(), { as: 'button' })
 
 const rootContext = injectPaginationRootContext()

--- a/packages/radix-vue/src/Pagination/PaginationRoot.vue
+++ b/packages/radix-vue/src/Pagination/PaginationRoot.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext } from '@/shared'
 
 type PaginationRootContext = {
@@ -9,16 +11,6 @@ type PaginationRootContext = {
   disabled: Ref<boolean>
   showEdges: Ref<boolean>
 }
-
-export const [injectPaginationRootContext, providePaginationRootContext]
-  = createContext<PaginationRootContext>('PaginationRoot')
-</script>
-
-<script setup lang="ts">
-import { Primitive } from '@/Primitive'
-import type { PrimitiveProps } from '@/Primitive'
-import { useVModel } from '@vueuse/core'
-import { type Ref, computed, toRefs } from 'vue'
 
 export interface PaginationRootProps extends PrimitiveProps {
   page?: number
@@ -33,6 +25,15 @@ export interface PaginationRootProps extends PrimitiveProps {
 export type PaginationRootEmits = {
   'update:page': [value: number]
 }
+
+export const [injectPaginationRootContext, providePaginationRootContext]
+  = createContext<PaginationRootContext>('PaginationRoot')
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { useVModel } from '@vueuse/core'
+import { computed, toRefs } from 'vue'
 
 const props = withDefaults(defineProps<PaginationRootProps>(), {
   as: 'nav',

--- a/packages/radix-vue/src/Popover/PopoverAnchor.vue
+++ b/packages/radix-vue/src/Popover/PopoverAnchor.vue
@@ -1,9 +1,14 @@
+<script lang="ts">
+import type { PopperAnchorProps } from '@/Popper'
+
+export interface PopoverAnchorProps extends PopperAnchorProps {}
+</script>
+
 <script setup lang="ts">
 import { onBeforeMount, onUnmounted } from 'vue'
 import { injectPopoverRootContext } from './PopoverRoot.vue'
-import { PopperAnchor, type PopperAnchorProps } from '@/Popper'
+import { PopperAnchor } from '@/Popper'
 
-export interface PopoverAnchorProps extends PopperAnchorProps {}
 const props = defineProps<PopoverAnchorProps>()
 
 const rootContext = injectPopoverRootContext()

--- a/packages/radix-vue/src/Popover/PopoverArrow.vue
+++ b/packages/radix-vue/src/Popover/PopoverArrow.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { PopperArrow, type PopperArrowProps } from '@/Popper'
+<script lang="ts">
+import type { PopperArrowProps } from '@/Popper'
 
 export interface PopoverArrowProps extends PopperArrowProps {}
+</script>
+
+<script setup lang="ts">
+import { PopperArrow } from '@/Popper'
+
 const props = defineProps<PopoverArrowProps>()
 </script>
 

--- a/packages/radix-vue/src/Popover/PopoverClose.vue
+++ b/packages/radix-vue/src/Popover/PopoverClose.vue
@@ -1,16 +1,20 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface PopoverCloseProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import {
   injectPopoverRootContext,
 } from './PopoverRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<PopoverCloseProps>(), {
   as: 'button',
 })
 
 const rootContext = injectPopoverRootContext()
-
-export interface PopoverCloseProps extends PrimitiveProps {}
 </script>
 
 <template>

--- a/packages/radix-vue/src/Popover/PopoverContent.vue
+++ b/packages/radix-vue/src/Popover/PopoverContent.vue
@@ -1,13 +1,10 @@
-<script setup lang="ts">
-import PopoverContentModal from './PopoverContentModal.vue'
-import PopoverContentNonModal from './PopoverContentNonModal.vue'
-import {
-  type PopoverContentImplEmits,
-  type PopoverContentImplProps,
+<script lang="ts">
+import type {
+  PopoverContentImplEmits,
+  PopoverContentImplProps,
 } from './PopoverContentImpl.vue'
-import { injectPopoverRootContext } from './PopoverRoot.vue'
-import { useForwardPropsEmits } from '@/shared'
-import { Presence } from '@/Presence'
+
+export type PopoverContentEmits = PopoverContentImplEmits
 
 export interface PopoverContentProps extends PopoverContentImplProps {
   /**
@@ -16,7 +13,14 @@ export interface PopoverContentProps extends PopoverContentImplProps {
    */
   forceMount?: boolean
 }
-export type PopoverContentEmits = PopoverContentImplEmits
+</script>
+
+<script setup lang="ts">
+import PopoverContentModal from './PopoverContentModal.vue'
+import PopoverContentNonModal from './PopoverContentNonModal.vue'
+import { injectPopoverRootContext } from './PopoverRoot.vue'
+import { useForwardPropsEmits } from '@/shared'
+import { Presence } from '@/Presence'
 
 const props = defineProps<PopoverContentProps>()
 const emits = defineEmits<PopoverContentEmits>()

--- a/packages/radix-vue/src/Popover/PopoverContentImpl.vue
+++ b/packages/radix-vue/src/Popover/PopoverContentImpl.vue
@@ -1,23 +1,10 @@
-<script setup lang="ts">
-import { injectPopoverRootContext } from './PopoverRoot.vue'
-import { PopperContent, type PopperContentProps } from '@/Popper'
-import {
-  DismissableLayer,
-  type DismissableLayerEmits,
-  type DismissableLayerProps,
+<script lang="ts">
+import type { PopperContentProps } from '@/Popper'
+import type {
+  DismissableLayerEmits,
+  DismissableLayerProps,
 } from '@/DismissableLayer'
-import { FocusScope, type FocusScopeProps } from '@/FocusScope'
-import { useFocusGuards, useForwardProps } from '@/shared'
-
-export interface PopoverContentImplProps
-  extends PopperContentProps,
-  DismissableLayerProps {
-  /**
-   * Whether focus should be trapped within the `MenuContent`
-   * (default: false)
-   */
-  trapFocus?: FocusScopeProps['trapped']
-}
+import type { FocusScopeProps } from '@/FocusScope'
 
 export type PopoverContentImplEmits = DismissableLayerEmits & {
   /**
@@ -31,6 +18,24 @@ export type PopoverContentImplEmits = DismissableLayerEmits & {
    */
   'closeAutoFocus': [event: Event]
 }
+
+export interface PopoverContentImplProps
+  extends PopperContentProps,
+  DismissableLayerProps {
+  /**
+   * Whether focus should be trapped within the `MenuContent`
+   * (default: false)
+   */
+  trapFocus?: FocusScopeProps['trapped']
+}
+</script>
+
+<script setup lang="ts">
+import { injectPopoverRootContext } from './PopoverRoot.vue'
+import { PopperContent } from '@/Popper'
+import { DismissableLayer } from '@/DismissableLayer'
+import { FocusScope } from '@/FocusScope'
+import { useFocusGuards, useForwardProps } from '@/shared'
 
 const props = defineProps<PopoverContentImplProps>()
 const emits = defineEmits<PopoverContentImplEmits>()

--- a/packages/radix-vue/src/Popover/PopoverPortal.vue
+++ b/packages/radix-vue/src/Popover/PopoverPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface PopoverPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<PopoverPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/Popover/PopoverTrigger.vue
+++ b/packages/radix-vue/src/Popover/PopoverTrigger.vue
@@ -1,14 +1,18 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface PopoverTriggerProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { injectPopoverRootContext } from './PopoverRoot.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { PopperAnchor } from '@/Popper'
 
-export interface PopoverTriggerProps extends PrimitiveProps {}
 const props = withDefaults(defineProps<PopoverTriggerProps>(), {
   as: 'button',
 })

--- a/packages/radix-vue/src/Popper/PopperAnchor.vue
+++ b/packages/radix-vue/src/Popper/PopperAnchor.vue
@@ -1,15 +1,19 @@
-<script setup lang="ts">
-import { watch } from 'vue'
-import { type Measurable, injectPopperRootContext } from './PopperRoot.vue'
-import {
-  Primitive,
-  type PrimitiveProps,
-  usePrimitiveElement,
-} from '@/Primitive'
+<script lang="ts">
+import type { Measurable } from './PopperRoot.vue'
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface PopperAnchorProps extends PrimitiveProps {
   element?: Measurable
 }
+</script>
+
+<script setup lang="ts">
+import { watch } from 'vue'
+import { injectPopperRootContext } from './PopperRoot.vue'
+import {
+  Primitive,
+  usePrimitiveElement,
+} from '@/Primitive'
 
 const props = defineProps<PopperAnchorProps>()
 

--- a/packages/radix-vue/src/Popper/PopperArrow.vue
+++ b/packages/radix-vue/src/Popper/PopperArrow.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Side } from './utils'
-import { type PrimitiveProps } from '@/Primitive'
+import type { PrimitiveProps } from '@/Primitive'
+import type { ArrowProps } from '@/shared/component/Arrow.vue'
 
 const OPPOSITE_SIDE: Record<Side, Side> = {
   top: 'bottom',
@@ -10,19 +11,16 @@ const OPPOSITE_SIDE: Record<Side, Side> = {
 }
 
 export interface PopperArrowProps extends ArrowProps, PrimitiveProps {}
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import {
-  injectPopperContentContext,
-} from './PopperContent.vue'
+import { injectPopperContentContext } from './PopperContent.vue'
 import Arrow from '@/shared/component/Arrow.vue'
-import { type ArrowProps } from '@/shared/component/Arrow.vue'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 withDefaults(
   defineProps<PopperArrowProps>(),

--- a/packages/radix-vue/src/Popper/PopperContent.vue
+++ b/packages/radix-vue/src/Popper/PopperContent.vue
@@ -1,6 +1,15 @@
 <script lang="ts">
 import type { ComponentPublicInstance, Ref } from 'vue'
+import type {
+  Middleware,
+  Placement,
+} from '@floating-ui/vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useForwardRef, useSize } from '@/shared'
+import type {
+  Align,
+  Side,
+} from './utils'
 
 export const PopperContentPropsDefaultValue = {
   side: 'bottom' as Side,
@@ -116,18 +125,12 @@ export interface PopperContentContext {
 
 export const [injectPopperContentContext, providePopperContentContext]
   = createContext<PopperContentContext>('PopperContent')
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
 import { computed, ref, watchEffect } from 'vue'
 import { computedEager } from '@vueuse/core'
 import {
-  type Middleware,
-  type Placement,
   autoUpdate,
   flip,
   arrow as floatingUIarrow,
@@ -140,17 +143,18 @@ import {
 } from '@floating-ui/vue'
 import { injectPopperRootContext } from './PopperRoot.vue'
 import {
-  type Align,
-  type Side,
   getSideAndAlignFromPlacement,
   isNotNull,
   transformOrigin,
 } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<PopperContentProps>(), {
   ...PopperContentPropsDefaultValue,

--- a/packages/radix-vue/src/Progress/ProgressIndicator.vue
+++ b/packages/radix-vue/src/Progress/ProgressIndicator.vue
@@ -1,10 +1,12 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface ProgressIndicatorProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
 import { injectProgressRootContext } from './ProgressRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 
 const props = defineProps<ProgressIndicatorProps>()
 

--- a/packages/radix-vue/src/Progress/ProgressRoot.vue
+++ b/packages/radix-vue/src/Progress/ProgressRoot.vue
@@ -1,15 +1,17 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext } from '@/shared'
+
+export type ProgressRootEmits = {
+  'update:modelValue': [value: string[] | undefined]
+  'update:max': [value: number]
+}
 
 export interface ProgressRootProps extends PrimitiveProps {
   modelValue?: number | null
   max?: number
   getValueLabel?: (value: number, max: number) => string
-}
-export type ProgressRootEmits = {
-  'update:modelValue': [value: string[] | undefined]
-  'update:max': [value: number]
 }
 
 const DEFAULT_MAX = 100
@@ -60,7 +62,7 @@ function validateMax(max: number): number {
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
 import { computed, nextTick, watch } from 'vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<ProgressRootProps>(), {
   max: DEFAULT_MAX,

--- a/packages/radix-vue/src/RadioGroup/Radio.vue
+++ b/packages/radix-vue/src/RadioGroup/Radio.vue
@@ -1,4 +1,10 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export type RadioEmits = {
+  'update:checked': [value: boolean]
+}
+
 export interface RadioProps extends PrimitiveProps {
   id?: string
   value?: string
@@ -7,20 +13,16 @@ export interface RadioProps extends PrimitiveProps {
   checked?: boolean
   name?: string
 }
-export type RadioEmits = {
-  'update:checked': [value: boolean]
-}
 </script>
 
 <script setup lang="ts">
 import { computed, toRefs } from 'vue'
+import { useVModel } from '@vueuse/core'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { useFormControl } from '@/shared'
-import { useVModel } from '@vueuse/core'
 
 const props = withDefaults(defineProps<RadioProps>(), {
   disabled: false,

--- a/packages/radix-vue/src/RadioGroup/RadioGroupIndicator.vue
+++ b/packages/radix-vue/src/RadioGroup/RadioGroupIndicator.vue
@@ -1,10 +1,12 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface RadioGroupIndicatorProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
 import { injectRadioGroupItemContext } from './RadioGroupItem.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 
 withDefaults(defineProps<RadioGroupIndicatorProps>(), {
   as: 'span',

--- a/packages/radix-vue/src/RadioGroup/RadioGroupItem.vue
+++ b/packages/radix-vue/src/RadioGroup/RadioGroupItem.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { ComputedRef } from 'vue'
+import type { RadioProps } from './Radio.vue'
 import { createContext } from '@/shared'
 
 export interface RadioGroupItemProps extends Omit<RadioProps, 'checked'> {}
@@ -10,25 +12,22 @@ interface RadioGroupItemContext {
 
 export const [injectRadioGroupItemContext, provideRadiogroupItemContext]
   = createContext<RadioGroupItemContext>('RadioGroupItem')
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
 import {
-  type ComputedRef,
   computed,
   ref,
 } from 'vue'
+import Radio from './Radio.vue'
 import { injectRadioGroupRootContext } from './RadioGroupRoot.vue'
-import {
-  usePrimitiveElement,
-} from '@/Primitive'
+import { usePrimitiveElement } from '@/Primitive'
 import { RovingFocusItem } from '@/RovingFocus'
-import Radio, { type RadioProps } from './Radio.vue'
 import { useEventListener } from '@vueuse/core'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<RadioGroupItemProps>(), {
   disabled: false,

--- a/packages/radix-vue/src/RadioGroup/RadioGroupRoot.vue
+++ b/packages/radix-vue/src/RadioGroup/RadioGroupRoot.vue
@@ -1,11 +1,7 @@
 <script lang="ts">
-import {
-  Primitive,
-  type PrimitiveProps,
-} from '@/Primitive'
-import type { DataOrientation, Direction } from '@/shared/types'
-import { useVModel } from '@vueuse/core'
 import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
+import type { DataOrientation, Direction } from '@/shared/types'
 import { createContext, useDirection } from '@/shared'
 
 export interface RadioGroupRootProps extends PrimitiveProps {
@@ -38,6 +34,8 @@ export const [injectRadioGroupRootContext, provideRadioGroupRootContext]
 
 <script setup lang="ts">
 import { toRefs } from 'vue'
+import { useVModel } from '@vueuse/core'
+import { Primitive } from '@/Primitive'
 import { RovingFocusGroup } from '@/RovingFocus'
 
 const props = withDefaults(defineProps<RadioGroupRootProps>(), {

--- a/packages/radix-vue/src/RovingFocus/RovingFocusGroup.vue
+++ b/packages/radix-vue/src/RovingFocus/RovingFocusGroup.vue
@@ -1,5 +1,11 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useCollection, useDirection } from '@/shared'
+import type {
+  Direction,
+  Orientation,
+} from './utils'
 
 export interface RovingFocusGroupProps extends PrimitiveProps {
   /**
@@ -41,20 +47,17 @@ export const [injectRovingFocusGroupContext, provideRovingFocusGroupContext]
 </script>
 
 <script setup lang="ts">
-import { type Ref, ref, toRefs } from 'vue'
+import { ref, toRefs } from 'vue'
 import { useVModel } from '@vueuse/core'
 import {
-  type Direction,
-  ENTRY_FOCUS,
-  EVENT_OPTIONS,
-  type Orientation,
-} from './utils'
-import { focusFirst } from './utils'
-import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
+import {
+  ENTRY_FOCUS,
+  EVENT_OPTIONS,
+  focusFirst,
+} from './utils'
 
 const props = withDefaults(defineProps<RovingFocusGroupProps>(), {
   loop: false,

--- a/packages/radix-vue/src/RovingFocus/RovingFocusItem.vue
+++ b/packages/radix-vue/src/RovingFocus/RovingFocusItem.vue
@@ -1,15 +1,19 @@
-<script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted } from 'vue'
-import { injectRovingFocusGroupContext } from './RovingFocusGroup.vue'
-import { focusFirst, getFocusIntent, wrapArray } from './utils'
-import { useCollection, useId } from '@/shared'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface RovingFocusItemProps extends PrimitiveProps {
   tabStopId?: string
   focusable?: boolean
   active?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted } from 'vue'
+import { injectRovingFocusGroupContext } from './RovingFocusGroup.vue'
+import { Primitive } from '@/Primitive'
+import { focusFirst, getFocusIntent, wrapArray } from './utils'
+import { useCollection, useId } from '@/shared'
 
 const props = withDefaults(defineProps<RovingFocusItemProps>(), {
   focusable: true,

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaCorner.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaCorner.vue
@@ -1,10 +1,14 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface ScrollAreaCornerProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import ScrollAreaCornerImpl from './ScrollAreaCornerImpl.vue'
-import { type PrimitiveProps } from '@/Primitive'
 
-export interface ScrollAreaCornerProps extends PrimitiveProps {}
 const props = defineProps<ScrollAreaCornerProps>()
 
 const rootContext = injectScrollAreaRootContext()

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaRoot.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaRoot.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { Direction, ScrollType } from './types'
 import { createContext, useDirection } from '@/shared'
 
@@ -38,7 +39,6 @@ export interface ScrollAreaRootProps extends PrimitiveProps {
 import { ref, toRefs } from 'vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbar.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbar.vue
@@ -1,11 +1,6 @@
 <script lang="ts">
-import {
-  type Ref,
-  computed,
-  onUnmounted,
-  toRefs,
-  watch,
-} from 'vue'
+import type { Ref } from 'vue'
+import type { AsTag, PrimitiveProps } from '@/Primitive'
 import { createContext } from '@/shared'
 
 export interface ScrollAreaScrollbarProps extends PrimitiveProps {
@@ -27,19 +22,24 @@ export interface ScrollAreaScollbarContext {
 
 export const [injectScrollAreaScrollbarContext, provideScrollAreaScrollbarContext]
   = createContext<ScrollAreaScollbarContext>('ScrollAreaScrollbar')
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
+import {
+  computed,
+  onUnmounted,
+  toRefs,
+  watch,
+} from 'vue'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import ScrollAreaScrollbarHover from './ScrollAreaScrollbarHover.vue'
 import ScrollAreaScrollbarScroll from './ScrollAreaScrollbarScroll.vue'
 import ScrollAreaScrollbarAuto from './ScrollAreaScrollbarAuto.vue'
 import ScrollAreaScrollbarVisible from './ScrollAreaScrollbarVisible.vue'
-import { type AsTag, type PrimitiveProps } from '@/Primitive'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<ScrollAreaScrollbarProps>(), {
   orientation: 'vertical',

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarAuto.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarAuto.vue
@@ -1,3 +1,9 @@
+<script lang="ts">
+export interface ScrollAreaScrollbarAutoProps {
+  forceMount?: boolean
+}
+</script>
+
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useDebounceFn, useResizeObserver } from '@vueuse/core'
@@ -7,9 +13,6 @@ import ScrollAreaScrollbarVisible from './ScrollAreaScrollbarVisible.vue'
 import { Presence } from '@/Presence'
 import { useForwardRef } from '@/shared'
 
-export interface ScrollAreaScrollbarAutoProps {
-  forceMount?: boolean
-}
 defineProps<ScrollAreaScrollbarAutoProps>()
 
 const rootContext = injectScrollAreaRootContext()

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarHover.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarHover.vue
@@ -1,11 +1,20 @@
+<script lang="ts">
+import type { ScrollAreaScrollbarAutoProps } from './ScrollAreaScrollbarAuto.vue'
+
+export interface ScrollAreaScrollbarHoverProps extends ScrollAreaScrollbarAutoProps {}
+</script>
+
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
-import ScrollAreaScrollbarAuto, { type ScrollAreaScrollbarAutoProps } from './ScrollAreaScrollbarAuto.vue'
+import ScrollAreaScrollbarAuto from './ScrollAreaScrollbarAuto.vue'
 import { Presence } from '@/Presence'
 import { useForwardRef } from '@/shared'
 
-export interface ScrollAreaScrollbarHoverProps extends ScrollAreaScrollbarAutoProps {}
+defineOptions({
+  inheritAttrs: false,
+})
+
 defineProps<ScrollAreaScrollbarHoverProps>()
 
 const rootContext = injectScrollAreaRootContext()
@@ -42,12 +51,6 @@ onUnmounted(() => {
     scrollArea.removeEventListener('pointerleave', handlePointerLeave)
   }
 })
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <template>

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarImpl.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarImpl.vue
@@ -1,5 +1,19 @@
+<script lang="ts">
+import type { ComponentPublicInstance } from 'vue'
+
+type ScrollbarAreaScrollbarImplEmits = {
+  'onDragScroll': [payload: { x: number; y: number }]
+  'onWheelScroll': [payload: { x: number; y: number }]
+  'onThumbPointerDown': [payload: { x: number; y: number }]
+}
+
+export interface ScrollAreaScrollbarImplProps {
+  isHorizontal: boolean
+}
+</script>
+
 <script setup lang="ts">
-import { type ComponentPublicInstance, onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import { injectScrollAreaScrollbarVisibleContext } from './ScrollAreaScrollbarVisible.vue'
@@ -9,18 +23,10 @@ import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { useForwardRef } from '@/shared'
 
 const props = defineProps<ScrollAreaScrollbarImplProps>()
-const emit = defineEmits<{
-  'onDragScroll': [payload: { x: number; y: number }]
-  'onWheelScroll': [payload: { x: number; y: number }]
-  'onThumbPointerDown': [payload: { x: number; y: number }]
-}>()
+const emit = defineEmits<ScrollbarAreaScrollbarImplEmits>()
 const rootContext = injectScrollAreaRootContext()
 const scrollbarVisibleContext = injectScrollAreaScrollbarVisibleContext()
 const scrollbarContext = injectScrollAreaScrollbarContext()
-
-export interface ScrollAreaScrollbarImplProps {
-  isHorizontal: boolean
-}
 
 const { primitiveElement, currentElement: scrollbar } = usePrimitiveElement()
 const forwardRef = useForwardRef()

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarScroll.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarScroll.vue
@@ -1,3 +1,9 @@
+<script lang="ts">
+export interface ScrollAreaScrollbarScrollProps {
+  forceMount?: boolean
+}
+</script>
+
 <script setup lang="ts">
 import { watchEffect } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
@@ -8,9 +14,6 @@ import ScrollAreaScrollbarVisible from './ScrollAreaScrollbarVisible.vue'
 import { Presence } from '@/Presence'
 import { useForwardRef } from '@/shared'
 
-export interface ScrollAreaScrollbarScrollProps {
-  forceMount?: boolean
-}
 defineProps<ScrollAreaScrollbarScrollProps>()
 
 const rootContext = injectScrollAreaRootContext()

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarVisible.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbarVisible.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
+import type { Ref } from 'vue'
 import { createContext, useForwardRef } from '@/shared'
+import type { Direction, Sizes } from './types'
 
 export interface ScrollAreaScrollbarVisibleContext {
   sizes: Ref<Sizes>
@@ -21,12 +23,7 @@ export const [injectScrollAreaScrollbarVisibleContext, provideScrollAreaScrollba
 </script>
 
 <script setup lang="ts">
-import {
-  type Ref,
-  computed,
-  ref,
-} from 'vue'
-import type { Direction, Sizes } from './types'
+import { computed, ref } from 'vue'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import { injectScrollAreaScrollbarContext } from './ScrollAreaScrollbar.vue'
 import ScrollAreaScrollbarX from './ScrollAreaScrollbarX.vue'

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaThumb.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaThumb.vue
@@ -1,16 +1,20 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface ScrollAreaThumbProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { computed, onUnmounted, ref } from 'vue'
 import { watchOnce } from '@vueuse/core'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
-} from '../Primitive'
+} from '@/Primitive'
 import { addUnlinkedScrollListener } from './utils'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import { injectScrollAreaScrollbarVisibleContext } from './ScrollAreaScrollbarVisible.vue'
 
-export interface ScrollAreaThumbProps extends PrimitiveProps {}
 const props = defineProps<ScrollAreaThumbProps>()
 
 const rootContext = injectScrollAreaRootContext()

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaViewport.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaViewport.vue
@@ -1,13 +1,21 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface ScrollAreaViewportProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 
-export interface ScrollAreaViewportProps extends PrimitiveProps {}
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = defineProps<ScrollAreaViewportProps>()
 
 const rootContext = injectScrollAreaRootContext()
@@ -21,12 +29,6 @@ onMounted(() => {
   rootContext.onViewportChange(viewportElement.value!)
   rootContext.onContentChange(contentElement.value!)
 })
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <template>

--- a/packages/radix-vue/src/Select/SelectArrow.vue
+++ b/packages/radix-vue/src/Select/SelectArrow.vue
@@ -1,13 +1,17 @@
+<script lang="ts">
+import type { PopperArrowProps } from '@/Popper'
+
+export interface SelectArrowProps extends PopperArrowProps {}
+</script>
+
 <script setup lang="ts">
 import { injectSelectRootContext } from './SelectRoot.vue'
 import { injectSelectContentContext } from './SelectContentImpl.vue'
-import { PopperArrow, type PopperArrowProps } from '@/Popper'
+import { PopperArrow } from '@/Popper'
 
 const props = defineProps<SelectArrowProps>()
 const rootContext = injectSelectRootContext()
 const contentContext = injectSelectContentContext()
-
-export interface SelectArrowProps extends PopperArrowProps {}
 </script>
 
 <template>

--- a/packages/radix-vue/src/Select/SelectContent.vue
+++ b/packages/radix-vue/src/Select/SelectContent.vue
@@ -1,19 +1,10 @@
 <script lang="ts">
-export default {
-  inheritAttrs: false,
-}
-</script>
-
-<script setup lang="ts">
-import { onMounted, ref } from 'vue'
-import SelectContentImpl, {
-  type SelectContentImplEmits,
-  type SelectContentImplProps,
+import type {
+  SelectContentImplEmits,
+  SelectContentImplProps,
 } from './SelectContentImpl.vue'
-import { injectSelectRootContext } from './SelectRoot.vue'
-import { Presence } from '@/Presence'
-import { useForwardPropsEmits } from '@/shared'
-import SelectProvider from './SelectProvider.vue'
+
+export type SelectContentEmits = SelectContentImplEmits
 
 export interface SelectContentProps extends SelectContentImplProps {
   /**
@@ -22,7 +13,19 @@ export interface SelectContentProps extends SelectContentImplProps {
    */
   forceMount?: boolean
 }
-export type SelectContentEmits = SelectContentImplEmits
+</script>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import SelectContentImpl from './SelectContentImpl.vue'
+import { injectSelectRootContext } from './SelectRoot.vue'
+import { Presence } from '@/Presence'
+import { useForwardPropsEmits } from '@/shared'
+import SelectProvider from './SelectProvider.vue'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<SelectContentProps>(), {
   align: 'start',

--- a/packages/radix-vue/src/Select/SelectContentImpl.vue
+++ b/packages/radix-vue/src/Select/SelectContentImpl.vue
@@ -1,4 +1,10 @@
 <script lang="ts">
+import type {
+  ComponentPublicInstance,
+  Ref,
+} from 'vue'
+import type { PopperContentProps } from '@/Popper'
+import type { PointerDownOutsideEvent } from '@/DismissableLayer'
 import {
   createContext,
   useBodyScrollLock,
@@ -37,13 +43,6 @@ export const SelectContentDefaultContextValue: SelectContentContext = {
   itemRefCallback: () => {},
 }
 
-export const [injectSelectContentContext, provideSelectContentContext]
-  = createContext<SelectContentContext>('SelectContent')
-
-export interface SelectContentImplProps extends PopperContentProps {
-  position?: 'item-aligned' | 'popper'
-}
-
 export type SelectContentImplEmits = {
   closeAutoFocus: [event: Event]
   /**
@@ -57,12 +56,17 @@ export type SelectContentImplEmits = {
    */
   pointerDownOutside: [event: PointerDownOutsideEvent]
 }
+
+export interface SelectContentImplProps extends PopperContentProps {
+  position?: 'item-aligned' | 'popper'
+}
+
+export const [injectSelectContentContext, provideSelectContentContext]
+  = createContext<SelectContentContext>('SelectContent')
 </script>
 
 <script setup lang="ts">
 import {
-  type ComponentPublicInstance,
-  type Ref,
   computed,
   ref,
   watch,
@@ -73,12 +77,8 @@ import { injectSelectRootContext } from './SelectRoot.vue'
 import SelectItemAlignedPosition from './SelectItemAlignedPosition.vue'
 import SelectPopperPosition from './SelectPopperPosition.vue'
 import { FocusScope } from '@/FocusScope'
-import {
-  DismissableLayer,
-  type PointerDownOutsideEvent,
-} from '@/DismissableLayer'
+import { DismissableLayer } from '@/DismissableLayer'
 import { focusFirst } from '@/Menu/utils'
-import type { PopperContentProps } from '@/Popper'
 
 const props = defineProps<SelectContentImplProps>()
 const emits = defineEmits<SelectContentImplEmits>()

--- a/packages/radix-vue/src/Select/SelectGroup.vue
+++ b/packages/radix-vue/src/Select/SelectGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useId } from '@/shared'
 
 export interface SelectGroupProps extends PrimitiveProps {}
@@ -12,7 +13,7 @@ export const [injectSelectGroupContext, provideSelectGroupContext]
 </script>
 
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 
 const props = defineProps<SelectGroupProps>()
 

--- a/packages/radix-vue/src/Select/SelectIcon.vue
+++ b/packages/radix-vue/src/Select/SelectIcon.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface SelectIconProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
 
 withDefaults(defineProps<SelectIconProps>(), {
   as: 'span',

--- a/packages/radix-vue/src/Select/SelectItem.vue
+++ b/packages/radix-vue/src/Select/SelectItem.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useId } from '@/shared'
 
 interface SelectItemContext {
@@ -21,7 +23,6 @@ export interface SelectItemProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import {
-  type Ref,
   computed,
   nextTick,
   onMounted,
@@ -33,7 +34,6 @@ import { SelectContentDefaultContextValue, injectSelectContentContext } from './
 import { SELECTION_KEYS } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 

--- a/packages/radix-vue/src/Select/SelectItemAlignedPosition.vue
+++ b/packages/radix-vue/src/Select/SelectItemAlignedPosition.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useCollection } from '@/shared'
 
 interface SelectItemAlignedPositionContext {
@@ -7,27 +9,26 @@ interface SelectItemAlignedPositionContext {
   onScrollButtonChange: (node: HTMLElement | undefined) => void
 }
 
+export interface SelectItemAlignedPositionProps extends PrimitiveProps {}
+
 export const [injectSelectItemAlignedPositionContext, provideSelectItemAlignedPositionContext]
   = createContext<SelectItemAlignedPositionContext>('SelectItemAlignedPosition')
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
-import { type Ref, nextTick, onMounted, ref } from 'vue'
+import { nextTick, onMounted, ref } from 'vue'
 import { clamp } from '@vueuse/shared'
 import { injectSelectRootContext } from './SelectRoot.vue'
 import { injectSelectContentContext } from './SelectContentImpl.vue'
 import { CONTENT_MARGIN } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 
-export interface SelectItemAlignedPositionProps extends PrimitiveProps {}
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = defineProps<SelectItemAlignedPositionProps>()
 const emits = defineEmits<{

--- a/packages/radix-vue/src/Select/SelectItemIndicator.vue
+++ b/packages/radix-vue/src/Select/SelectItemIndicator.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { injectSelectItemContext } from './SelectItem.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface SelectItemIndicatorProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { injectSelectItemContext } from './SelectItem.vue'
+import { Primitive } from '@/Primitive'
+
 const props = withDefaults(defineProps<SelectItemIndicatorProps>(), {
   as: 'span',
 })

--- a/packages/radix-vue/src/Select/SelectItemText.vue
+++ b/packages/radix-vue/src/Select/SelectItemText.vue
@@ -1,3 +1,9 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface SelectItemTextProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { computed, h, onBeforeUnmount, onMounted } from 'vue'
 import { injectSelectNativeOptionsContext, injectSelectRootContext } from './SelectRoot.vue'
@@ -5,11 +11,12 @@ import { SelectContentDefaultContextValue, injectSelectContentContext } from './
 import { injectSelectItemContext } from './SelectItem.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 
-export interface SelectItemTextProps extends PrimitiveProps {}
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<SelectItemTextProps>(), {
   as: 'span',
@@ -47,12 +54,6 @@ onMounted(() => {
 onBeforeUnmount(() => {
   nativeOptionContext.onNativeOptionRemove(nativeOption.value)
 })
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <template>

--- a/packages/radix-vue/src/Select/SelectLabel.vue
+++ b/packages/radix-vue/src/Select/SelectLabel.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface SelectLabelProps extends PrimitiveProps {
   for?: string
@@ -7,6 +7,7 @@ export interface SelectLabelProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
+import { Primitive } from '@/Primitive'
 import { injectSelectGroupContext } from './SelectGroup.vue'
 
 const props = withDefaults(defineProps<SelectLabelProps>(), {

--- a/packages/radix-vue/src/Select/SelectPopperPosition.vue
+++ b/packages/radix-vue/src/Select/SelectPopperPosition.vue
@@ -1,9 +1,13 @@
+<script lang="ts">
+import type { PopperContentProps } from '@/Popper'
+
+export interface SelectPopperPositionProps extends PopperContentProps {}
+</script>
+
 <script setup lang="ts">
 import { useForwardProps } from '..'
 import { CONTENT_MARGIN } from './utils'
-import { PopperContent, type PopperContentProps } from '@/Popper'
-
-export interface SelectPopperPositionProps extends PopperContentProps {}
+import { PopperContent } from '@/Popper'
 
 const props = withDefaults(defineProps<SelectPopperPositionProps>(), {
   align: 'start',

--- a/packages/radix-vue/src/Select/SelectPortal.vue
+++ b/packages/radix-vue/src/Select/SelectPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface SelectPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<SelectPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/Select/SelectRoot.vue
+++ b/packages/radix-vue/src/Select/SelectRoot.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { Ref, VNode } from 'vue'
 import type { DataOrientation, Direction } from '../shared/types'
-import BubbleSelect from './BubbleSelect.vue'
 import { createContext, useDirection, useFormControl, useId } from '@/shared'
 
 export interface SelectRootProps {
@@ -53,6 +52,7 @@ export const [injectSelectNativeOptionsContext, provideSelectNativeOptionsContex
 
 <script setup lang="ts">
 import { computed, ref, toRefs } from 'vue'
+import BubbleSelect from './BubbleSelect.vue'
 import { PopperRoot } from '@/Popper'
 import { useVModel } from '@vueuse/core'
 

--- a/packages/radix-vue/src/Select/SelectScrollDownButton.vue
+++ b/packages/radix-vue/src/Select/SelectScrollDownButton.vue
@@ -1,11 +1,16 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface SelectScrollDownButtonProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { ref, watch, watchEffect } from 'vue'
 import { SelectContentDefaultContextValue, injectSelectContentContext } from './SelectContentImpl.vue'
 import SelectScrollButtonImpl from './SelectScrollButtonImpl.vue'
-import { type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
+import { usePrimitiveElement } from '@/Primitive'
 import { injectSelectItemAlignedPositionContext } from './SelectItemAlignedPosition.vue'
 
-export interface SelectScrollDownButtonProps extends PrimitiveProps {}
 defineProps<SelectScrollDownButtonProps>()
 
 const contentContext = injectSelectContentContext(SelectContentDefaultContextValue)

--- a/packages/radix-vue/src/Select/SelectScrollUpButton.vue
+++ b/packages/radix-vue/src/Select/SelectScrollUpButton.vue
@@ -1,11 +1,16 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface SelectScrollUpButtonProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { ref, watch, watchEffect } from 'vue'
 import { SelectContentDefaultContextValue, injectSelectContentContext } from './SelectContentImpl.vue'
 import SelectScrollButtonImpl from './SelectScrollButtonImpl.vue'
-import { type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
+import { usePrimitiveElement } from '@/Primitive'
 import { injectSelectItemAlignedPositionContext } from './SelectItemAlignedPosition.vue'
 
-export interface SelectScrollUpButtonProps extends PrimitiveProps {}
 defineProps<SelectScrollUpButtonProps>()
 
 const contentContext = injectSelectContentContext(SelectContentDefaultContextValue)

--- a/packages/radix-vue/src/Select/SelectSeparator.vue
+++ b/packages/radix-vue/src/Select/SelectSeparator.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface SelectSeparatorProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 const props = defineProps<SelectSeparatorProps>()
 </script>
 

--- a/packages/radix-vue/src/Select/SelectTrigger.vue
+++ b/packages/radix-vue/src/Select/SelectTrigger.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface SelectTriggerProps extends PrimitiveProps {
   disabled?: boolean
 }
@@ -12,7 +14,6 @@ import {
 import { OPEN_KEYS, shouldShowPlaceholder } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { PopperAnchor } from '@/Popper'

--- a/packages/radix-vue/src/Select/SelectValue.vue
+++ b/packages/radix-vue/src/Select/SelectValue.vue
@@ -1,17 +1,20 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface SelectValueProps extends PrimitiveProps {
+  placeholder?: string
+}
+</script>
+
 <script setup lang="ts">
 import { onBeforeMount, onMounted, useSlots } from 'vue'
 import { shouldShowPlaceholder } from './utils'
 import { injectSelectRootContext } from './SelectRoot.vue'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { renderSlotFragments } from '@/shared'
-
-export interface SelectValueProps extends PrimitiveProps {
-  placeholder?: string
-}
 
 withDefaults(defineProps<SelectValueProps>(), {
   as: 'span',

--- a/packages/radix-vue/src/Select/SelectViewport.vue
+++ b/packages/radix-vue/src/Select/SelectViewport.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface SelectViewportProps extends PrimitiveProps {}
 </script>
 
@@ -8,7 +10,6 @@ import { SelectContentDefaultContextValue, injectSelectContentContext } from './
 import { CONTENT_MARGIN } from './utils'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { injectSelectItemAlignedPositionContext } from './SelectItemAlignedPosition.vue'

--- a/packages/radix-vue/src/Separator/Separator.vue
+++ b/packages/radix-vue/src/Separator/Separator.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
-import BaseSeparator, {
-  type BaseSeparatorProps,
-} from '@/shared/component/BaseSeparator.vue'
+import type { BaseSeparatorProps } from '@/shared/component/BaseSeparator.vue'
 
 export interface SeparatorProps extends BaseSeparatorProps {}
 </script>
 
 <script setup lang="ts">
+import BaseSeparator from '@/shared/component/BaseSeparator.vue'
+
 const props = withDefaults(defineProps<SeparatorProps>(), {
   orientation: 'horizontal',
 })

--- a/packages/radix-vue/src/Slider/SliderImpl.vue
+++ b/packages/radix-vue/src/Slider/SliderImpl.vue
@@ -1,7 +1,5 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { injectSliderRootContext } from './SliderRoot.vue'
-import { ARROW_KEYS, PAGE_KEYS } from './utils'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export type SliderImplEmits = {
   'slideStart': [event: PointerEvent]
@@ -13,6 +11,12 @@ export type SliderImplEmits = {
 }
 
 export interface SliderImplProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { injectSliderRootContext } from './SliderRoot.vue'
+import { ARROW_KEYS, PAGE_KEYS } from './utils'
 
 const props = withDefaults(defineProps<SliderImplProps>(), {
   as: 'span',

--- a/packages/radix-vue/src/Slider/SliderRange.vue
+++ b/packages/radix-vue/src/Slider/SliderRange.vue
@@ -1,10 +1,12 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface SliderRangeProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { injectSliderRootContext } from './SliderRoot.vue'
 import { convertValueToPercentage, injectSliderOrientationContext } from './utils'
 

--- a/packages/radix-vue/src/Slider/SliderRoot.vue
+++ b/packages/radix-vue/src/Slider/SliderRoot.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { DataOrientation, Direction } from '../shared/types'
 import { createContext, useCollection, useDirection, useFormControl } from '@/shared'
 
@@ -33,22 +35,19 @@ export interface SliderRootContext {
 
 export const [injectSliderRootContext, provideSliderRootContext]
   = createContext<SliderRootContext>('SliderRoot')
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
 import SliderHorizontal from './SliderHorizontal.vue'
 import SliderVertical from './SliderVertical.vue'
-import { type Ref, ref, toRefs } from 'vue'
-import {
-  type PrimitiveProps,
-  usePrimitiveElement,
-} from '@/Primitive'
+import { ref, toRefs } from 'vue'
+import { usePrimitiveElement } from '@/Primitive'
 import { useVModel } from '@vueuse/core'
 import { ARROW_KEYS, PAGE_KEYS, clamp, getClosestValueIndex, getDecimalCount, getNextSortedValues, hasMinStepsBetweenValues, roundValue } from './utils'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<SliderRootProps>(), {
   min: 0,

--- a/packages/radix-vue/src/Slider/SliderThumb.vue
+++ b/packages/radix-vue/src/Slider/SliderThumb.vue
@@ -1,10 +1,14 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface SliderThumbProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { useCollection } from '@/shared'
 import SliderThumbImpl from './SliderThumbImpl.vue'
-import { type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
+import { usePrimitiveElement } from '@/Primitive'
 import { computed } from 'vue'
-
-export interface SliderThumbProps extends PrimitiveProps {}
 
 const props = defineProps<SliderThumbProps>()
 const { injectCollection } = useCollection('sliderThumb')

--- a/packages/radix-vue/src/Slider/SliderThumbImpl.vue
+++ b/packages/radix-vue/src/Slider/SliderThumbImpl.vue
@@ -1,14 +1,22 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
-import { computed, onMounted, onUnmounted } from 'vue'
-import { injectSliderRootContext } from './SliderRoot.vue'
-import { convertValueToPercentage, getLabel, getThumbInBoundsOffset, injectSliderOrientationContext } from './utils'
-import { useSize } from '@/shared'
-import { useMounted } from '@vueuse/core'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface SliderThumbImplProps extends PrimitiveProps {
   index: number
 }
+</script>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue'
+import { useMounted } from '@vueuse/core'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
+import { injectSliderRootContext } from './SliderRoot.vue'
+import { convertValueToPercentage, getLabel, getThumbInBoundsOffset, injectSliderOrientationContext } from './utils'
+import { useSize } from '@/shared'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = defineProps<SliderThumbImplProps>()
 
@@ -38,12 +46,6 @@ onUnmounted(() => {
 defineExpose({
   $el: thumbElement,
 })
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <template>

--- a/packages/radix-vue/src/Slider/SliderTrack.vue
+++ b/packages/radix-vue/src/Slider/SliderTrack.vue
@@ -1,9 +1,11 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface SliderTrackProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { injectSliderRootContext } from './SliderRoot.vue'
 
 const props = withDefaults(defineProps<SliderTrackProps>(), { as: 'span' })

--- a/packages/radix-vue/src/Switch/SwitchRoot.vue
+++ b/packages/radix-vue/src/Switch/SwitchRoot.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useFormControl } from '@/shared'
 
 export interface SwitchRootProps extends PrimitiveProps {
@@ -29,7 +30,7 @@ export const [injectSwitchRootContext, provideSwitchRootContext]
 <script setup lang="ts">
 import { computed, toRefs } from 'vue'
 import { useVModel } from '@vueuse/core'
-import { Primitive, type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<SwitchRootProps>(), {
   as: 'button',

--- a/packages/radix-vue/src/Switch/SwitchThumb.vue
+++ b/packages/radix-vue/src/Switch/SwitchThumb.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface SwitchThumbProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import {
-  injectSwitchRootContext,
-} from './SwitchRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { injectSwitchRootContext } from './SwitchRoot.vue'
+import { Primitive } from '@/Primitive'
 
 withDefaults(defineProps<SwitchThumbProps>(), { as: 'span' })
 const rootContext = injectSwitchRootContext()

--- a/packages/radix-vue/src/Tabs/TabsContent.vue
+++ b/packages/radix-vue/src/Tabs/TabsContent.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface TabsContentProps extends PrimitiveProps {
   value: string
   /**
@@ -12,7 +14,7 @@ export interface TabsContentProps extends PrimitiveProps {
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { injectTabsRootContext } from './TabsRoot.vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { makeContentId, makeTriggerId } from './utils'
 import { Presence } from '@/Presence'
 

--- a/packages/radix-vue/src/Tabs/TabsList.vue
+++ b/packages/radix-vue/src/Tabs/TabsList.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface TabsListProps extends PrimitiveProps {
   loop?: boolean
 }
@@ -7,10 +9,7 @@ export interface TabsListProps extends PrimitiveProps {
 <script setup lang="ts">
 import { toRefs } from 'vue'
 import { injectTabsRootContext } from './TabsRoot.vue'
-import {
-  Primitive,
-  type PrimitiveProps,
-} from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { RovingFocusGroup } from '@/RovingFocus'
 
 const props = withDefaults(defineProps<TabsListProps>(), {

--- a/packages/radix-vue/src/Tabs/TabsRoot.vue
+++ b/packages/radix-vue/src/Tabs/TabsRoot.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { Ref } from 'vue'
-import { useVModel } from '@vueuse/core'
-import { toRefs } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { DataOrientation, Direction } from '../shared/types'
 import { createContext, useDirection, useId } from '@/shared'
 
@@ -13,13 +12,6 @@ export interface TabsRootContext {
   activationMode: 'automatic' | 'manual'
   baseId: string
 }
-
-export const [injectTabsRootContext, provideTabsRootContext]
-  = createContext<TabsRootContext>('TabsRoot')
-</script>
-
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
 
 export interface TabsRootProps extends PrimitiveProps {
   defaultValue?: string
@@ -43,6 +35,15 @@ export interface TabsRootProps extends PrimitiveProps {
 export type TabsRootEmits = {
   'update:modelValue': [payload: string]
 }
+
+export const [injectTabsRootContext, provideTabsRootContext]
+  = createContext<TabsRootContext>('TabsRoot')
+</script>
+
+<script setup lang="ts">
+import { toRefs } from 'vue'
+import { useVModel } from '@vueuse/core'
+import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<TabsRootProps>(), {
   orientation: 'horizontal',

--- a/packages/radix-vue/src/Tabs/TabsTrigger.vue
+++ b/packages/radix-vue/src/Tabs/TabsTrigger.vue
@@ -1,17 +1,18 @@
-<script setup lang="ts">
-import { computed } from 'vue'
-import { injectTabsRootContext } from './TabsRoot.vue'
-import {
-  Primitive,
-  type PrimitiveProps,
-} from '@/Primitive'
-import { RovingFocusItem } from '@/RovingFocus'
-import { makeContentId, makeTriggerId } from './utils'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface TabsTriggerProps extends PrimitiveProps {
   value: string
   disabled?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { injectTabsRootContext } from './TabsRoot.vue'
+import { Primitive } from '@/Primitive'
+import { RovingFocusItem } from '@/RovingFocus'
+import { makeContentId, makeTriggerId } from './utils'
 
 const props = withDefaults(defineProps<TabsTriggerProps>(), {
   disabled: false,

--- a/packages/radix-vue/src/Teleport/Teleport.vue
+++ b/packages/radix-vue/src/Teleport/Teleport.vue
@@ -1,11 +1,13 @@
-<script setup lang="ts">
-import { useMounted } from '@vueuse/core'
-
+<script lang="ts">
 export interface TeleportProps {
   to?: string | HTMLElement
   disabled?: boolean
   forceMount?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { useMounted } from '@vueuse/core'
 
 withDefaults(defineProps<TeleportProps>(), {
   to: 'body',

--- a/packages/radix-vue/src/Toast/ToastAction.vue
+++ b/packages/radix-vue/src/Toast/ToastAction.vue
@@ -1,6 +1,5 @@
-<script setup lang="ts">
-import ToastAnnounceExclude from './ToastAnnounceExclude.vue'
-import ToastClose, { type ToastCloseProps } from './ToastClose.vue'
+<script lang="ts">
+import type { ToastCloseProps } from './ToastClose.vue'
 
 export interface ToastActionProps extends ToastCloseProps {
   /**
@@ -11,6 +10,11 @@ export interface ToastActionProps extends ToastCloseProps {
    */
   altText: string
 }
+</script>
+
+<script setup lang="ts">
+import ToastAnnounceExclude from './ToastAnnounceExclude.vue'
+import ToastClose from './ToastClose.vue'
 
 const props = defineProps<ToastActionProps>()
 

--- a/packages/radix-vue/src/Toast/ToastAnnounceExclude.vue
+++ b/packages/radix-vue/src/Toast/ToastAnnounceExclude.vue
@@ -1,10 +1,14 @@
-<script setup lang="ts">
-import { Primitive } from '@/Primitive'
+<script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface ToastAnnounceExcludeProps extends PrimitiveProps {
   altText?: string
 }
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 defineProps<ToastAnnounceExcludeProps>()
 </script>
 

--- a/packages/radix-vue/src/Toast/ToastClose.vue
+++ b/packages/radix-vue/src/Toast/ToastClose.vue
@@ -1,10 +1,14 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface ToastCloseProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
-import type { PrimitiveProps } from '@/Primitive'
 import ToastAnnounceExclude from './ToastAnnounceExclude.vue'
 import { injectToastRootContext } from './ToastRootImpl.vue'
 
-export interface ToastCloseProps extends PrimitiveProps {}
 const props = withDefaults(defineProps<ToastCloseProps>(), {
   as: 'button',
 })

--- a/packages/radix-vue/src/Toast/ToastDescription.vue
+++ b/packages/radix-vue/src/Toast/ToastDescription.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ToastDescriptionProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 const props = defineProps<ToastDescriptionProps>()
 </script>
 

--- a/packages/radix-vue/src/Toast/ToastProvider.vue
+++ b/packages/radix-vue/src/Toast/ToastProvider.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { Ref } from 'vue'
 import type { SwipeDirection } from './utils'
 import { createContext } from '@/shared'
 
@@ -15,9 +16,6 @@ type ToastProviderContext = {
   isFocusedToastEscapeKeyDownRef: Ref<boolean>
   isClosePausedRef: Ref<boolean>
 }
-
-export const [injectToastProviderContext, provideToastProviderContext]
-  = createContext<ToastProviderContext>('ToastProvider')
 
 export interface ToastProviderProps {
   /**
@@ -42,10 +40,13 @@ export interface ToastProviderProps {
    */
   swipeThreshold?: number
 }
+
+export const [injectToastProviderContext, provideToastProviderContext]
+  = createContext<ToastProviderContext>('ToastProvider')
 </script>
 
 <script setup lang="ts">
-import { type Ref, ref, toRefs } from 'vue'
+import { ref, toRefs } from 'vue'
 
 const props = withDefaults(defineProps<ToastProviderProps>(), {
   label: 'Notification',

--- a/packages/radix-vue/src/Toast/ToastRoot.vue
+++ b/packages/radix-vue/src/Toast/ToastRoot.vue
@@ -1,16 +1,10 @@
-<script setup lang="ts">
-import { Presence } from '@/Presence'
-import ToastRootImpl, { type ToastRootImplEmits, type ToastRootImplProps } from './ToastRootImpl.vue'
-import { useVModel } from '@vueuse/core'
+<script lang="ts">
 import type { Ref } from 'vue'
+import type { ToastRootImplEmits, ToastRootImplProps } from './ToastRootImpl.vue'
 
-const props = withDefaults(defineProps<ToastRootProps>(), {
-  type: 'foreground',
-  open: undefined,
-  defaultOpen: true,
-  as: 'li',
-})
-const emits = defineEmits<ToastRootEmits>()
+export type ToastRootEmits = ToastRootImplEmits & {
+  'update:open': [value: boolean]
+}
 
 export interface ToastRootProps extends ToastRootImplProps {
   defaultOpen?: boolean
@@ -20,10 +14,20 @@ export interface ToastRootProps extends ToastRootImplProps {
    */
   forceMount?: boolean
 }
+</script>
 
-export type ToastRootEmits = ToastRootImplEmits & {
-  'update:open': [value: boolean]
-}
+<script setup lang="ts">
+import { useVModel } from '@vueuse/core'
+import { Presence } from '@/Presence'
+import ToastRootImpl from './ToastRootImpl.vue'
+
+const props = withDefaults(defineProps<ToastRootProps>(), {
+  type: 'foreground',
+  open: undefined,
+  defaultOpen: true,
+  as: 'li',
+})
+const emits = defineEmits<ToastRootEmits>()
 
 const open = useVModel(props, 'open', emits, {
   defaultValue: props.defaultOpen,

--- a/packages/radix-vue/src/Toast/ToastRootImpl.vue
+++ b/packages/radix-vue/src/Toast/ToastRootImpl.vue
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { ComponentPublicInstance } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
+import type { SwipeEvent } from './utils'
 import { createContext, useForwardRef } from '@/shared'
 
 export type ToastRootImplEmits = {
@@ -27,12 +30,10 @@ export const [injectToastRootContext, provideToastRootContext]
 </script>
 
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps, usePrimitiveElement } from '@/Primitive'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { computed, onMounted, onUnmounted, ref, watchEffect } from 'vue'
-import type { ComponentPublicInstance } from 'vue'
 import { injectToastProviderContext } from './ToastProvider.vue'
-import { getAnnounceTextContent, handleAndDispatchCustomEvent, isDeltaInDirection } from './utils'
-import { type SwipeEvent, TOAST_SWIPE_CANCEL, TOAST_SWIPE_END, TOAST_SWIPE_MOVE, TOAST_SWIPE_START, VIEWPORT_PAUSE, VIEWPORT_RESUME } from './utils'
+import { TOAST_SWIPE_CANCEL, TOAST_SWIPE_END, TOAST_SWIPE_MOVE, TOAST_SWIPE_START, VIEWPORT_PAUSE, VIEWPORT_RESUME, getAnnounceTextContent, handleAndDispatchCustomEvent, isDeltaInDirection } from './utils'
 import ToastAnnounce from './ToastAnnounce.vue'
 import { onKeyStroke } from '@vueuse/core'
 

--- a/packages/radix-vue/src/Toast/ToastRootImpl.vue
+++ b/packages/radix-vue/src/Toast/ToastRootImpl.vue
@@ -1,12 +1,29 @@
 <script lang="ts">
 import { createContext, useForwardRef } from '@/shared'
 
+export type ToastRootImplEmits = {
+  'close': []
+  'escapeKeyDown': [event: KeyboardEvent]
+  'pause': []
+  'resume': []
+  'swipeStart': [event: SwipeEvent]
+  'swipeMove': [event: SwipeEvent]
+  'swipeCancel': [event: SwipeEvent]
+  'swipeEnd': [event: SwipeEvent]
+}
+
+export interface ToastRootImplProps extends PrimitiveProps {
+  type?: 'foreground' | 'background'
+  open?: boolean
+  /**
+   * Time in milliseconds that toast should remain visible for. Overrides value
+   * given to `ToastProvider`.
+   */
+  duration?: number
+}
+
 export const [injectToastRootContext, provideToastRootContext]
   = createContext<{ onClose(): void }>('ToastRoot')
-
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <script setup lang="ts">
@@ -19,26 +36,9 @@ import { type SwipeEvent, TOAST_SWIPE_CANCEL, TOAST_SWIPE_END, TOAST_SWIPE_MOVE,
 import ToastAnnounce from './ToastAnnounce.vue'
 import { onKeyStroke } from '@vueuse/core'
 
-export interface ToastRootImplProps extends PrimitiveProps {
-  type?: 'foreground' | 'background'
-  open?: boolean
-  /**
-   * Time in milliseconds that toast should remain visible for. Overrides value
-   * given to `ToastProvider`.
-   */
-  duration?: number
-}
-
-export type ToastRootImplEmits = {
-  'close': []
-  'escapeKeyDown': [event: KeyboardEvent]
-  'pause': []
-  'resume': []
-  'swipeStart': [event: SwipeEvent]
-  'swipeMove': [event: SwipeEvent]
-  'swipeCancel': [event: SwipeEvent]
-  'swipeEnd': [event: SwipeEvent]
-}
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<ToastRootImplProps>(), {
   open: false,

--- a/packages/radix-vue/src/Toast/ToastTitle.vue
+++ b/packages/radix-vue/src/Toast/ToastTitle.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ToastTitleProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+
 const props = defineProps<ToastTitleProps>()
 </script>
 

--- a/packages/radix-vue/src/Toast/ToastViewport.vue
+++ b/packages/radix-vue/src/Toast/ToastViewport.vue
@@ -1,14 +1,6 @@
-<script setup lang="ts">
-import { Primitive, usePrimitiveElement } from '@/Primitive'
+<script lang="ts">
+import type { ComponentPublicInstance } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
-import { type ComponentPublicInstance, computed, onMounted, ref, toRefs, watchEffect } from 'vue'
-import { injectToastProviderContext } from './ToastProvider.vue'
-import { onKeyStroke, unrefElement } from '@vueuse/core'
-import FocusProxy from './FocusProxy.vue'
-import { focusFirst, getTabbableCandidates } from '@/FocusScope/utils'
-import { useCollection } from '@/shared'
-import { VIEWPORT_DEFAULT_HOTKEY, VIEWPORT_PAUSE, VIEWPORT_RESUME } from './utils'
-import { DismissableLayerBranch } from '@/DismissableLayer'
 
 export interface ToastViewportProps extends PrimitiveProps {
   /**
@@ -23,6 +15,22 @@ export interface ToastViewportProps extends PrimitiveProps {
    */
   label?: string
 }
+</script>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, toRefs, watchEffect } from 'vue'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
+import { injectToastProviderContext } from './ToastProvider.vue'
+import { onKeyStroke, unrefElement } from '@vueuse/core'
+import FocusProxy from './FocusProxy.vue'
+import { focusFirst, getTabbableCandidates } from '@/FocusScope/utils'
+import { useCollection } from '@/shared'
+import { VIEWPORT_DEFAULT_HOTKEY, VIEWPORT_PAUSE, VIEWPORT_RESUME } from './utils'
+import { DismissableLayerBranch } from '@/DismissableLayer'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<ToastViewportProps>(), {
   hotkey: () => VIEWPORT_DEFAULT_HOTKEY,
@@ -145,12 +153,6 @@ function getSortedTabbableCandidates({ tabbingDirection }: { tabbingDirection: '
   return (
     tabbingDirection === 'forwards' ? tabbableCandidates.reverse() : tabbableCandidates
   ).flat()
-}
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 }
 </script>
 

--- a/packages/radix-vue/src/Toggle/ToggleRoot.vue
+++ b/packages/radix-vue/src/Toggle/ToggleRoot.vue
@@ -1,5 +1,11 @@
 <script lang="ts">
-import { computed } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
+
+export type ToggleEmits = {
+  'update:pressed': [value: boolean]
+}
+
+export type DataState = 'on' | 'off'
 
 export interface ToggleProps extends PrimitiveProps {
   /**
@@ -16,16 +22,12 @@ export interface ToggleProps extends PrimitiveProps {
    */
   disabled?: boolean
 }
-export type ToggleEmits = {
-  'update:pressed': [value: boolean]
-}
-
-export type DataState = 'on' | 'off'
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useVModel } from '@vueuse/core'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<ToggleProps>(), {
   pressed: undefined,

--- a/packages/radix-vue/src/ToggleGroup/ToggleGroupItem.vue
+++ b/packages/radix-vue/src/ToggleGroup/ToggleGroupItem.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { ToggleProps } from '@/Toggle'
+
 export interface ToggleGroupItemProps extends ToggleProps {
   /**
    * A string value for the toggle group item. All items within a toggle group should use a unique value.
@@ -10,7 +12,7 @@ export interface ToggleGroupItemProps extends ToggleProps {
 <script setup lang="ts">
 import { computed } from 'vue'
 import { injectToggleGroupRootContext } from './ToggleGroupRoot.vue'
-import { Toggle, type ToggleProps } from '@/Toggle'
+import { Toggle } from '@/Toggle'
 import { RovingFocusItem } from '@/RovingFocus'
 import { Primitive } from '@/Primitive'
 

--- a/packages/radix-vue/src/ToggleGroup/ToggleGroupRoot.vue
+++ b/packages/radix-vue/src/ToggleGroup/ToggleGroupRoot.vue
@@ -1,8 +1,7 @@
 <script lang="ts">
 import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { DataOrientation, Direction } from '../shared/types'
-import { useSingleOrMultipleValue } from '@/shared/useSingleOrMultipleValue'
-import { RovingFocusGroup } from '@/RovingFocus'
 import { createContext, useDirection } from '@/shared'
 
 type TypeEnum = 'single' | 'multiple'
@@ -38,7 +37,9 @@ export const [injectToggleGroupRootContext, provideToggleGroupRootContext]
 
 <script setup lang="ts">
 import { toRefs } from 'vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
+import { useSingleOrMultipleValue } from '@/shared/useSingleOrMultipleValue'
+import { RovingFocusGroup } from '@/RovingFocus'
 
 const props = withDefaults(defineProps<ToggleGroupRootProps>(), {
   type: 'single',

--- a/packages/radix-vue/src/Toolbar/ToolbarButton.vue
+++ b/packages/radix-vue/src/Toolbar/ToolbarButton.vue
@@ -1,10 +1,15 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { RovingFocusItem } from '@/RovingFocus'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ToolbarButtonProps extends PrimitiveProps {
   disabled?: boolean
 }
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { RovingFocusItem } from '@/RovingFocus'
+
 const props = withDefaults(defineProps<ToolbarButtonProps>(), { as: 'button' })
 </script>
 

--- a/packages/radix-vue/src/Toolbar/ToolbarLink.vue
+++ b/packages/radix-vue/src/Toolbar/ToolbarLink.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
-import { RovingFocusItem } from '@/RovingFocus'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface ToolbarLinkProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
+import { RovingFocusItem } from '@/RovingFocus'
+
 const props = withDefaults(defineProps<ToolbarLinkProps>(), { as: 'a' })
 </script>
 

--- a/packages/radix-vue/src/Toolbar/ToolbarRoot.vue
+++ b/packages/radix-vue/src/Toolbar/ToolbarRoot.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { DataOrientation, Direction } from '@/shared/types'
 import { createContext, useDirection } from '@/shared'
 
@@ -20,7 +21,7 @@ export const [injectToolbarRootContext, provideToolbarRootContext]
 
 <script setup lang="ts">
 import { toRefs } from 'vue'
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { RovingFocusGroup } from '@/RovingFocus'
 
 const props = withDefaults(defineProps<ToolbarRootProps>(), {

--- a/packages/radix-vue/src/Toolbar/ToolbarSeparator.vue
+++ b/packages/radix-vue/src/Toolbar/ToolbarSeparator.vue
@@ -1,9 +1,13 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface ToolbarSeparatorProps extends PrimitiveProps {}
+</script>
+
 <script setup lang="ts">
 import BaseSeparator from '../shared/component/BaseSeparator.vue'
 import { injectToolbarRootContext } from './ToolbarRoot.vue'
-import { type PrimitiveProps } from '@/Primitive'
 
-export interface ToolbarSeparatorProps extends PrimitiveProps {}
 const props = defineProps<ToolbarSeparatorProps>()
 
 const rootContext = injectToolbarRootContext()

--- a/packages/radix-vue/src/Toolbar/ToolbarToggleGroup.vue
+++ b/packages/radix-vue/src/Toolbar/ToolbarToggleGroup.vue
@@ -1,20 +1,23 @@
+<script lang="ts">
+import type {
+  ToggleGroupRootEmits,
+  ToggleGroupRootProps,
+} from '@/ToggleGroup'
+
+export type ToolbarToggleGroupEmits = ToggleGroupRootEmits
+
+export interface ToolbarToggleGroupProps extends ToggleGroupRootProps {}
+</script>
+
 <script setup lang="ts">
 import { injectToolbarRootContext } from './ToolbarRoot.vue'
-import {
-  ToggleGroupRoot,
-  type ToggleGroupRootEmits,
-  type ToggleGroupRootProps,
-} from '@/ToggleGroup'
+import { ToggleGroupRoot } from '@/ToggleGroup'
 import { useEmitAsProps } from '@/shared'
 
 const props = defineProps<ToolbarToggleGroupProps>()
-
 const emits = defineEmits<ToolbarToggleGroupEmits>()
 
 const rootContext = injectToolbarRootContext()
-
-export interface ToolbarToggleGroupProps extends ToggleGroupRootProps {}
-export type ToolbarToggleGroupEmits = ToggleGroupRootEmits
 
 const emitsAsProps = useEmitAsProps(emits)
 </script>

--- a/packages/radix-vue/src/Toolbar/ToolbarToggleItem.vue
+++ b/packages/radix-vue/src/Toolbar/ToolbarToggleItem.vue
@@ -1,8 +1,13 @@
-<script setup lang="ts">
-import ToolbarButton from './ToolbarButton.vue'
-import { ToggleGroupItem, type ToggleGroupItemProps } from '@/ToggleGroup'
+<script lang="ts">
+import type { ToggleGroupItemProps } from '@/ToggleGroup'
 
 export interface ToolbarToggleItemProps extends ToggleGroupItemProps {}
+</script>
+
+<script setup lang="ts">
+import ToolbarButton from './ToolbarButton.vue'
+import { ToggleGroupItem } from '@/ToggleGroup'
+
 const props = defineProps<ToolbarToggleItemProps>()
 </script>
 

--- a/packages/radix-vue/src/Tooltip/TooltipArrow.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipArrow.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface TooltipArrowProps extends PrimitiveProps {
   /**
    * The width of the arrow in pixels.
@@ -18,7 +20,6 @@ export interface TooltipArrowProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import { PopperArrow } from '@/Popper'
-import type { PrimitiveProps } from '@/Primitive'
 
 const props = withDefaults(defineProps<TooltipArrowProps>(), {
   width: 10,

--- a/packages/radix-vue/src/Tooltip/TooltipContent.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipContent.vue
@@ -1,11 +1,16 @@
+<script lang="ts">
+import type { TooltipContentImplEmits, TooltipContentImplProps } from './TooltipContentImpl.vue'
+
+export type TooltipContentEmits = TooltipContentImplEmits
+
+export interface TooltipContentProps extends TooltipContentImplProps {}
+</script>
+
 <script setup lang="ts">
-import TooltipContentImpl, { type TooltipContentImplEmits, type TooltipContentImplProps } from './TooltipContentImpl.vue'
+import TooltipContentImpl from './TooltipContentImpl.vue'
 import TooltipContentHoverable from './TooltipContentHoverable.vue'
 import { injectTooltipRootContext } from './TooltipRoot.vue'
 import { useForwardPropsEmits } from '@/shared'
-
-export interface TooltipContentProps extends TooltipContentImplProps {}
-export type TooltipContentEmits = TooltipContentImplEmits
 
 const props = withDefaults(defineProps<TooltipContentProps>(), {
   side: 'top',

--- a/packages/radix-vue/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipContentImpl.vue
@@ -1,7 +1,12 @@
 <script lang="ts">
-import { useEventListener } from '@vueuse/core'
+import type { VNode } from 'vue'
+import type { PrimitiveProps } from '@/Primitive'
 import type { PopperContentProps } from '@/Popper'
-import { TOOLTIP_OPEN } from './utils'
+
+export type TooltipContentImplEmits = {
+  'escapeKeyDown': [event: KeyboardEvent]
+  'pointerDownOutside': [event: Event]
+}
 
 export interface TooltipContentImplProps
   extends PrimitiveProps,
@@ -28,18 +33,14 @@ export interface TooltipContentImplProps
    */
   ariaLabel?: string
 }
-
-export type TooltipContentImplEmits = {
-  'escapeKeyDown': [event: KeyboardEvent]
-  'pointerDownOutside': [event: Event]
-}
 </script>
 
 <script setup lang="ts">
+import { computed, onMounted, ref, useSlots } from 'vue'
+import { useEventListener } from '@vueuse/core'
+import { TOOLTIP_OPEN } from './utils'
 import { PopperContent } from '@/Popper'
-import { type PrimitiveProps } from '@/Primitive'
 import { VisuallyHidden } from '@/VisuallyHidden'
-import { type VNode, computed, onMounted, ref, useSlots } from 'vue'
 import { injectTooltipRootContext } from './TooltipRoot.vue'
 import { DismissableLayer } from '@/DismissableLayer'
 

--- a/packages/radix-vue/src/Tooltip/TooltipPortal.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipPortal.vue
@@ -1,7 +1,12 @@
-<script setup lang="ts">
-import { TeleportPrimitive, type TeleportProps } from '@/Teleport'
+<script lang="ts">
+import type { TeleportProps } from '@/Teleport'
 
 export interface TooltipPortalProps extends TeleportProps {}
+</script>
+
+<script setup lang="ts">
+import { TeleportPrimitive } from '@/Teleport'
+
 const props = defineProps<TooltipPortalProps>()
 </script>
 

--- a/packages/radix-vue/src/Tooltip/TooltipProvider.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipProvider.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { Ref } from 'vue'
 import { createContext } from '@/shared'
 
 interface TooltipProviderContext {
@@ -41,7 +42,7 @@ export interface TooltipProviderProps {
 
 <script setup lang="ts">
 import { useTimeoutFn } from '@vueuse/shared'
-import { type Ref, ref, toRefs } from 'vue'
+import { ref, toRefs } from 'vue'
 
 const props = withDefaults(defineProps<TooltipProviderProps>(), {
   delayDuration: 700,

--- a/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
+++ b/packages/radix-vue/src/Tooltip/TooltipTrigger.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export type TooltipTriggerDataState =
   | 'closed'
   | 'delayed-open'
@@ -13,7 +15,6 @@ import { injectTooltipRootContext } from './TooltipRoot.vue'
 import { PopperAnchor } from '@/Popper'
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 import { injectTooltipProviderContext } from './TooltipProvider.vue'

--- a/packages/radix-vue/src/VisuallyHidden/VisuallyHidden.vue
+++ b/packages/radix-vue/src/VisuallyHidden/VisuallyHidden.vue
@@ -1,7 +1,11 @@
-<script setup lang="ts">
-import { Primitive, type PrimitiveProps } from '@/Primitive'
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface VisuallyHiddenProps extends PrimitiveProps {}
+</script>
+
+<script setup lang="ts">
+import { Primitive } from '@/Primitive'
 
 withDefaults(defineProps<VisuallyHiddenProps>(), { as: 'span' })
 </script>

--- a/packages/radix-vue/src/shared/component/Arrow.vue
+++ b/packages/radix-vue/src/shared/component/Arrow.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
 export interface ArrowProps extends PrimitiveProps {
   /**
    * The width of the arrow in pixels.
@@ -18,7 +20,6 @@ export interface ArrowProps extends PrimitiveProps {
 <script setup lang="ts">
 import {
   Primitive,
-  type PrimitiveProps,
   usePrimitiveElement,
 } from '@/Primitive'
 

--- a/packages/radix-vue/src/shared/component/BaseSeparator.vue
+++ b/packages/radix-vue/src/shared/component/BaseSeparator.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
-import { computed } from 'vue'
 import type { DataOrientation } from '../types'
-import { type PrimitiveProps } from '@/Primitive'
+import type { PrimitiveProps } from '@/Primitive'
 
 export interface BaseSeparatorProps extends PrimitiveProps {
   /**
@@ -17,6 +16,7 @@ export interface BaseSeparatorProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<BaseSeparatorProps>(), {


### PR DESCRIPTION
~~Best Practices~~ Happy Practices for `Component Orders`
Best Practices don't really exist 😅 

```ts
<script lang="ts">
// types and interface

// context
</script>

<script setup lang="ts">
// imports

// defineOptions
// defineProps
// defineEmits

// setup
// computed
// watch

// lifecycles
// methods/functions

// defineExpose
</script>
```