### PR TITLE
docs: update extending example

### DIFF
--- a/docs/content/guides/styling.md
+++ b/docs/content/guides/styling.md
@@ -121,11 +121,11 @@ interface Props extends AccordionItemProps {
   foo: string;
 }
 
-defineProps<AccordionItemProps>();
+defineProps<Props>();
 </script>
 
 <template>
-  <AccordionItem v-bind="props" />
+  <AccordionItem v-bind="$props"><slot /></AccordionItem>
 </template>
 ```
 


### PR DESCRIPTION
Just stumbled on this small syntax error.
I also noticed, that you currently cannot get typed emits when you extend a component.

When you add them like this
```html
<template>
  <AccordionItem v-bind="$props"><slot /></AccordionItem>
</template>

<script lang="ts" setup>
  import { AccordionItem, type AccordionItemProps, type AccordionItemEmits } from "radix-vue";
  
  defineProps<AccordionItemProps>()
  defineEmits<AccordionItemEmits>()
</script>
```
then the typescript works, but they are never getting emitted/called. I also tried to add them like `<AccordionItem v-bind="{  ...$props, ...$attrs }"><slot /></AccordionItem>`, same story.