### PR TITLE
[PopperArrow] `width` and `height` aren't passed to `Arrow`

### DIFF
--- a/packages/radix-vue/src/Popper/PopperArrow.vue
+++ b/packages/radix-vue/src/Popper/PopperArrow.vue
@@ -65,6 +65,8 @@ const baseSide = computed(() => OPPOSITE_SIDE[contentContext.placedSide.value])
       }"
       :as="as"
       :as-child="asChild"
+      :width="width"
+      :height="height"
     />
   </span>
 </template>


### PR DESCRIPTION
In the `PopperArrow` component, the `width` and `height` properties aren't being passed to the `Arrow` component. Despite providing values for `width` and `height`, they always default to `width="10"` and `height="5"`.

ref. Docs for `PopoverArrow` https://www.radix-vue.com/components/popover.html#arrow

![CleanShot 2023-11-08 at 22 02 13](https://github.com/radix-vue/radix-vue/assets/15260226/813ed0ed-6c39-4946-8796-f245f48bae66)
