### PR TITLE
fix(Dialog): remove `aria-label="Close"` from DialogClose

### DIFF
--- a/docs/content/components/dialog.md
+++ b/docs/content/components/dialog.md
@@ -468,6 +468,26 @@ const container = ref(null)
 
 Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
 
+### Close icon button
+
+When providing an icon (or font icon), remember to label it correctly for screen reader users.
+
+```html line=8-9
+<DialogRoot>
+  <DialogTrigger />
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogContent>
+      <DialogTitle />
+      <DialogDescription />
+      <DialogClose aria-label="Close">
+        <span aria-hidden>×</span>
+      </DialogClose>
+    </DialogContent>
+  </DialogPortal>
+</DialogRoot>
+```
+
 ### Keyboard Interactions
 
 <KeyboardTable

--- a/packages/radix-vue/src/Dialog/DialogClose.vue
+++ b/packages/radix-vue/src/Dialog/DialogClose.vue
@@ -19,7 +19,6 @@ const rootContext = injectDialogRootContext()
   <Primitive
     v-bind="props"
     :type="as === 'button' ? 'button' : undefined"
-    aria-label="Close"
     @click="rootContext.onOpenChange(false)"
   >
     <slot />


### PR DESCRIPTION
To be in line with Radix UI. Authors can still set `aria-label="Close"` themselves, or use another method to provide an accessible name.

Resolves #541