### PR TITLE
fix(PinInput): modelValue elements mutated directly

### DIFF
--- a/packages/radix-vue/src/PinInput/PinInputInput.vue
+++ b/packages/radix-vue/src/PinInput/PinInputInput.vue
@@ -33,7 +33,7 @@ function handleInput(event: Event) {
   }
 
   target.value = target.value.slice(-1)
-  context.modelValue.value[props.index] = target.value
+  updateModelValueAt(props.index, target.value)
 
   const nextEl = inputElements.value[props.index + 1]
   if (nextEl)
@@ -56,20 +56,20 @@ function handleBackspace(event: KeyboardEvent) {
   const value = target.value
 
   if (value) {
-    context.modelValue.value[props.index] = ''
+    updateModelValueAt(props.index, '')
   }
   else {
     const prevEl = inputElements.value[props.index - 1]
     if (prevEl) {
       prevEl.focus()
-      context.modelValue.value[props.index - 1] = ''
+      updateModelValueAt(props.index - 1, '')
     }
   }
 }
 
 function handleDelete(event: KeyboardEvent) {
   event.preventDefault()
-  context.modelValue.value[props.index] = ''
+  updateModelValueAt(props.index, '')
 }
 
 function handleFocus(event: FocusEvent) {
@@ -104,10 +104,16 @@ function handlePaste(event: ClipboardEvent) {
       continue
 
     input.value = value
-    context.modelValue.value[i] = value
+    updateModelValueAt(i, value)
     input.focus()
   }
   inputElements.value[lastIndex]?.focus()
+}
+
+function updateModelValueAt(index: number, value: string) {
+  const tempModelValue = context.modelValue.value
+  tempModelValue[index] = value
+  context.modelValue.value = tempModelValue
 }
 
 onMounted(() => {

--- a/packages/radix-vue/src/PinInput/PinInputInput.vue
+++ b/packages/radix-vue/src/PinInput/PinInputInput.vue
@@ -111,7 +111,7 @@ function handlePaste(event: ClipboardEvent) {
 }
 
 function updateModelValueAt(index: number, value: string) {
-  const tempModelValue = context.modelValue.value
+  const tempModelValue = [...context.modelValue.value]
   tempModelValue[index] = value
   context.modelValue.value = tempModelValue
 }


### PR DESCRIPTION
Resolves #549.

Addresses the direct mutation of `modelValue` elements in `PinInputInput`s by using a temporary copy.

This workaround seems a little clunky, but currently, I couldn't think of a better solution. Feedback is appreciated!