### PR TITLE
chore: change docs theme-color 

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   title: radixVueName,
   description: radixVueDescription,
   head: [
-    ['meta', { name: 'theme-color', content: '#729b1a' }],
+    ['meta', { name: 'theme-color', content: '#00C38A' }],
     ['link', { rel: 'icon', href: '/logo.png' }],
     ['link', { rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
     [


### PR DESCRIPTION
The current `theme-color` simply doesn't match the logo and og:image color scheme.

![image](https://github.com/radix-vue/radix-vue/assets/51422045/1380838d-615f-408a-877c-a58b7c1568da)
