### PR TITLE
fix: don't set disabled attribute to `MenuItem` component

### DIFF
--- a/packages/radix-vue/src/Menu/MenuItemImpl.vue
+++ b/packages/radix-vue/src/Menu/MenuItemImpl.vue
@@ -66,8 +66,8 @@ defineExpose({
     data-radix-vue-collection-item
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled ? '' : undefined"
+    :disabled="disabled && as === 'button' ? true : undefined"
     :data-highlighted="isFocused ? '' : undefined"
-    :disabled="as === 'button' && disabled ? true : undefined"
     @pointermove="handlePointerMove"
     @pointerleave="handlePointerLeave"
     @focus="

--- a/packages/radix-vue/src/Menu/MenuItemImpl.vue
+++ b/packages/radix-vue/src/Menu/MenuItemImpl.vue
@@ -66,8 +66,8 @@ defineExpose({
     data-radix-vue-collection-item
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled ? '' : undefined"
-    :disabled="disabled"
     :data-highlighted="isFocused ? '' : undefined"
+    :disabled="as === 'button' && disabled ? true : undefined"
     @pointermove="handlePointerMove"
     @pointerleave="handlePointerLeave"
     @focus="

--- a/packages/radix-vue/src/Menu/MenuItemImpl.vue
+++ b/packages/radix-vue/src/Menu/MenuItemImpl.vue
@@ -66,7 +66,6 @@ defineExpose({
     data-radix-vue-collection-item
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled ? '' : undefined"
-    :disabled="disabled && as === 'button' ? true : undefined"
     :data-highlighted="isFocused ? '' : undefined"
     @pointermove="handlePointerMove"
     @pointerleave="handlePointerLeave"


### PR DESCRIPTION
resolves: #600

Original radix-ui doesn't set disabled attribute to MenuItem component. Only `aria-disabled` and `data-disabled` https://github.com/radix-ui/primitives/blob/c31c97274ff357aea99afe6c01c1c8c58b6356e0/packages/react/menu/src/Menu.tsx#L708-L709

If you want to use MenuItem as button - use `asChild` props 

```vue
<MenuItem as-child disabled>
	<button disabled>
		Hello world
	</button>
</MenuItem>
```