### PR TITLE
fix: prevent override default boolean prop value with useForwardProps

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxContentImpl.vue
@@ -3,6 +3,7 @@ import type { Ref } from 'vue'
 import {
   createContext,
   useBodyScrollLock,
+  useForwardProps,
   useHideOthers,
 } from '@/shared'
 
@@ -56,6 +57,8 @@ const pickedProps = computed(() => {
   else return {}
 })
 
+const forwardedProps = useForwardProps(pickedProps.value)
+
 function handleLeave(ev: PointerEvent) {
   rootContext.onSelectedValueChange('')
 }
@@ -102,7 +105,7 @@ provideComboboxContentContext({ position })
     >
       <component
         :is="position === 'popper' ? PopperContent : Primitive "
-        v-bind="{ ...$attrs, ...pickedProps }"
+        v-bind="{ ...$attrs, ...forwardedProps }"
         :id="rootContext.contentId"
         ref="primitiveElement"
         role="listbox"

--- a/packages/radix-vue/src/Select/SelectContent.vue
+++ b/packages/radix-vue/src/Select/SelectContent.vue
@@ -27,10 +27,8 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(defineProps<SelectContentProps>(), {
-  align: 'start',
-  position: 'item-aligned',
-})
+const props = defineProps<SelectContentProps>()
+
 const emits = defineEmits<SelectContentEmits>()
 const forwarded = useForwardPropsEmits(props, emits)
 

--- a/packages/radix-vue/src/Select/SelectContentImpl.vue
+++ b/packages/radix-vue/src/Select/SelectContentImpl.vue
@@ -188,11 +188,13 @@ function handleKeyDown(event: KeyboardEvent) {
   }
 }
 
-const popperContentProps = computed(() => {
+const pickedProps = computed(() => {
   if (props.position === 'popper')
-    return useForwardProps(props)
+    return props
   else return {}
 })
+
+const forwardedProps = useForwardProps(pickedProps.value)
 
 provideSelectContentContext({
   content,
@@ -258,7 +260,7 @@ provideSelectContentContext({
             ? SelectPopperPosition
             : SelectItemAlignedPosition
         "
-        v-bind="{ ...$attrs, ...popperContentProps }"
+        v-bind="{ ...$attrs, ...forwardedProps }"
         :id="rootContext.contentId"
         :ref="
           (vnode: ComponentPublicInstance) => {

--- a/packages/radix-vue/src/Select/SelectContentImpl.vue
+++ b/packages/radix-vue/src/Select/SelectContentImpl.vue
@@ -10,6 +10,7 @@ import {
   useBodyScrollLock,
   useCollection,
   useFocusGuards,
+  useForwardProps,
   useHideOthers,
   useTypeahead,
 } from '@/shared'
@@ -80,7 +81,10 @@ import { FocusScope } from '@/FocusScope'
 import { DismissableLayer } from '@/DismissableLayer'
 import { focusFirst } from '@/Menu/utils'
 
-const props = defineProps<SelectContentImplProps>()
+const props = withDefaults(defineProps<SelectContentImplProps>(), {
+  align: 'start',
+  position: 'item-aligned',
+})
 const emits = defineEmits<SelectContentImplEmits>()
 
 const rootContext = injectSelectRootContext()
@@ -184,9 +188,9 @@ function handleKeyDown(event: KeyboardEvent) {
   }
 }
 
-const pickedProps = computed(() => {
+const popperContentProps = computed(() => {
   if (props.position === 'popper')
-    return props
+    return useForwardProps(props)
   else return {}
 })
 
@@ -254,7 +258,7 @@ provideSelectContentContext({
             ? SelectPopperPosition
             : SelectItemAlignedPosition
         "
-        v-bind="{ ...$attrs, ...pickedProps }"
+        v-bind="{ ...$attrs, ...popperContentProps }"
         :id="rootContext.contentId"
         :ref="
           (vnode: ComponentPublicInstance) => {


### PR DESCRIPTION
Related PR in `shadcn-vue`

https://github.com/radix-vue/shadcn-vue/pull/272

![image](https://github.com/radix-vue/shadcn-vue/assets/17480987/f52d2851-02ba-4e67-b4e4-cdbe34985024)

---


`PopperContent.vue` already has [`avoidCollisions: true` prop by default](https://github.com/radix-vue/radix-vue/blob/main/packages/radix-vue/src/Popper/PopperContent.vue#L20), in other **Primitive Wrappers** (SelectContentImpl.vue) 
We pass down the same `PopperContent` types props but Vue will cast boolean props as false which will override the **Main Primitive** (PopperContent.vue) prop value

Now I fully understand why you create `useForwardProps`

- [React Playground](https://stackblitz.com/edit/vitejs-vite-fzy92e?file=src%2FApp.tsx,src%2Fmain.tsx,src%2Fcomponents%2FAnotherPrimitive.tsx,src%2Fcomponents%2FPrimitives.tsx&terminal=dev)
- [Vue SFC Playground](https://play.vuejs.org/#eNqVVl1P2zAU/StWHgZINIHB9tAVBtuYBNIAjWl7yYub3LSGxLZspxRV/e+7tts0Tdq0qC+17/E9537ZmQXXUoaTEoJ+MNCJYtIQDaaUJKd8dBEHRsfBZcxZIYUy5JoLMwb1qFjBDJsAyZQoyEEYNQ3W5cGXmA8i7xRd4MJAIXNqAFeEDFrOItwfRDVQcIz8ieAZG4XPWnAUObNH4yARhWQ5qAdpmOCosU+cxdponovXO7dnVAnHy/1kDMnLhv1nPbV7cfCoQIOaQBxUNkPVCIw33zzdwxT/V8ZCpGWO6A7jb9AiL61GD/tW8hRl13BO7a1LL+OjP/pmaoDrZVBWqEXOHT4OMK3fO0JfyT0Lz9y5mM8xi1WOdaPW61WGqasy4wZURhMgq3OPSkjtiV4A5K+3H5DRMjd/aV7C1z4ZCpEDxSIj43rRO7oKS6sNkc71BXllZrzwqg9TyBgHxzpoqLg8PDrepmSZsflRd++lbOK2bdpuMd1pK9aldTa7e3q4D7VRWB6WvR06uWGb+miOofszg7GyvYx/Ik/U7OpN47K1KovZM28SyKxVknk1g+tFPthQztbEYcsCT/XmOtMlWkifogr1T1EpQa3KjpP+nrovIpqRUsNPoV6pSteDUTRl056PYgFeSdwWMIrYs6GaeVh11M6Y6w1mf54x80FAiqyNmHy/7NWOtnVwoXNh3F3o14v2bGqu4MMKaReqdnLzgLynockHPtQSE/suh7ZTRebLsG1QtineWYAVtMW782wnc1soYZrgfe0aJyXD0s+gttsJ1Qb3qF5OAHkds2SMLZfnJBljtwNBLQQPW3crlol33LxyqmpGq3LiLVITWLsFyaQ3ZDzFeXIpjoNdsKo9a9BtV5Mft15BZePJ9Yb196aaU/+6jY2Ruh9FI4pnZREyEXFZ9CvU1Wl4Fp4isTYRKoMpwmpPISJ6KRSs09kSdHUSnp6Hn6OcDRe+ijVnV1kuqH1SeyWLEqG6JbbQKPVTeOal1myhtXUxpaLYnwjBjue8zYOmLhr8pMhdKfYjcnDM2Mdl9utUzriT7H2R7UG4I8JdTdUEYyJPNhUMTZ6m+hya/wf2gcfP) --- [Vue SFC Playground Two](https://play.vuejs.org/#eNp9VMFymzAQ/RUNFyczrjnk5hJ3mk4OzcHJ1J1eSg+AFwdXSBpJuM5Q/r0ryTKiEG7afU/vPVZrt9FnIVanBqJ1lKhCVkITBboRm5RVteBSk5ZIKElHSslrskDq4gp94bW49FexKYzS4mPKkthpoQoWGmpBMw1YEZLYSzGekzgAomWkVcFZWR1WR8UZ5mkNPY0K5FcU5LPQFWcqjdbEIgbLKOV/nmxPywaWvl+8QvF7on9UZ9NLoxcJCuQJ0uiK6UweQDv4cbeFM56vYM33DUX2DPgNFKeNyehoDw3bY+yAZ9N+taOr2OG7ejxrYMp/lAlqmJ3lpxGO0ozqvU/v496t7uy9lHU4Rf8M/z8ooRk73OM9lLHPgsNWmgjJhSL3ZA9lxeDFVIn1yDmnkLEfGW3g09qXBlFaYnwPuMr0WVPnIH3fVaaP5hR8++dFaHm5uLwQfxlmw/Azh8Lkr7fGU6/J8yMU2lPdUDQo/eC4w8AW2Vm5QWDb31rNa2DiR7m5ubXLO7PJ++pkD8NhYZz2afe8XTmjqny7CeHbriMfSJJv2la/CeDl4HLXJXFuvYxs8irtL8VVwdwnPAJ0bBGAcw7BC044BOjYIQDnHPpdmDDowbF+j83J9ws0Id+DY/kem5MPtm5CP0DHBgH4vkMSu5Ua/jN2/wA22PHX)
- [Svelte Playground](https://svelte.dev/repl/29916055f42449028b197a7ab7ff3f96?version=3.47.0)

---

I also have to check this PR too 

https://github.com/radix-vue/shadcn-vue/pull/241

Which I mostly pass down `props` instead of `forwarded` props