### PR TITLE
docs: update toast.md

### DIFF
--- a/docs/content/components/toast.md
+++ b/docs/content/components/toast.md
@@ -659,7 +659,6 @@ Create your own imperative API to allow [toast duplication](/components/toast#du
 ```vue
 <script setup lang="ts">
 import Toast from './your-toast.vue'
-import type { InstanceType } from 'vue'
 
 const savedRef = ref<InstanceType<typeof Toast>>()
 </script>


### PR DESCRIPTION
- Module '"vue"' has no exported member 'InstanceType'.
- `InstanceType` is in `typescript`

```ts
/**
 * Obtain the return type of a constructor function type
 */
type InstanceType<T extends abstract new (...args: any) => any> = T extends abstract new (...args: any) => infer R ? R : any;
```