### PR TITLE
fix: remove duplicate keydown enter

### DIFF
--- a/packages/radix-vue/src/Toggle/ToggleRoot.vue
+++ b/packages/radix-vue/src/Toggle/ToggleRoot.vue
@@ -61,7 +61,6 @@ const dataState = computed<DataState>(() => {
     :data-disabled="disabled ? '' : undefined"
     :disabled="disabled"
     @click="togglePressed"
-    @keydown.enter="togglePressed"
   >
     <slot />
   </Primitive>


### PR DESCRIPTION
# Overview

This PR is related to #638.

I saw `ToggleRoot` emitted an event twice, `@click` and `@keydown.enter`. This made `pressed` was mutated twice too.
Then, I removed `@keydown.enter`, an event was still emitted after pressing `Enter` but only once from `@click`.
`@click` works with pressing `Space` too.

# Scope of work

I have removed `@keydown.enter` from `ToggleRoot`.

-------

If you have any feedback or suggestion, please let me know.