### PR TITLE
feat(Pagination): expose page count on PaginationRoot

### DIFF
--- a/packages/radix-vue/src/Pagination/PaginationRoot.vue
+++ b/packages/radix-vue/src/Pagination/PaginationRoot.vue
@@ -78,6 +78,6 @@ providePaginationRootContext({
 
 <template>
   <Primitive :as="as" :as-child="asChild">
-    <slot :page="page" />
+    <slot :page="page" :page-count="pageCount" />
   </Primitive>
 </template>


### PR DESCRIPTION
I had to style the pagination items based on, among other things, total number of pages, and found out that it's not exposed by radix-vue. While it's not a big deal and can be computed easily regardless, I figured it would be a nice little addition to expose an already computed value on `PaginationRoot` component.

I also noticed that there's no component or any convention on how document scoped slots props in the docs (probably due to the fact the slots are rarely used in this library). I improvised a little bit and decided to use `PropsTable` to describe scoped slots props for `PaginationRoot` as well as `PaginationList`.

Furthermore, I'm also not sure whether I should write test(s) for this (and what such tests should look like). I was looking in `@vue/test-utils` docs to find a way to simply check what data scoped slots are exposing, but couldn't find it - it seems like you actually need to provide respective slots and use the data in the slot template.