### PR TITLE
docs: add notes about scoped styles

### DIFF
--- a/docs/content/guides/styling.md
+++ b/docs/content/guides/styling.md
@@ -22,6 +22,10 @@ You are in control of all aspects of styling, including functional styles. For e
 
 All components accept `class` attributes, just like normal component. This class will be passed through to the DOM element. You can use it in CSS as expected.
 
+#### Teleported elements
+
+Some elements, such as modals or popovers, are teleported to the `body`. When using scoped style to apply CSS, you will need to use [deep selectors](https://vuejs.org/api/sfc-css-features.html#deep-selectors) to target them.
+
 ### Data attributes
 
 When components are stateful, their state will be exposed in a `data-state` attribute. For example, when an [Accordion Item](../components/accordion) is opened, it includes a `data-state="open"` attribute.
@@ -63,6 +67,37 @@ You can style a component state by targeting its `data-state` attribute.
 .AccordionItem[data-state="open"] {
   border-bottom-width: 2px;
 }
+```
+
+### Scoped style
+
+You can style a component using scoped style. Be wary of teleported elements, as they require the use of [deep selectors](https://vuejs.org/api/sfc-css-features.html#deep-selectors) to be targeted.
+
+```vue{7}
+<script setup lang="ts">
+import { DropdownMenuRoot, DropdownMenuItem, ... } from "radix-vue";
+</script>
+
+<template>
+  <DropdownMenuRoot>
+    <!-- ... -->
+    <DropdownMenuPortal>
+      <DropdownMenuContent class="DropdownMenuContent">
+        <DropdownMenuItem class="DropdownMenuItem">An item</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenuPortal>
+  </DropdownMenuRoot>
+</template>
+
+<style scoped>
+:deep(.DropdownMenuContent) {
+  /* ... */
+}
+
+.DropdownMenuItem {
+  /* ... */
+}
+</style>
 ```
 
 ## Styling with Tailwind CSS


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#651

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a note about scoped styles, and the need to use deep selectors when styling teleported elements.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.