### PR TITLE
docs: fix demo Avatar styles

### DIFF
--- a/docs/components/demo/Avatar/css/index.vue
+++ b/docs/components/demo/Avatar/css/index.vue
@@ -4,7 +4,7 @@ import './styles.css'
 </script>
 
 <template>
-  <div :style="{ display: 'flex', gap: 20 }">
+  <div :style="{ display: 'flex', gap: '20px' }">
     <AvatarRoot class="AvatarRoot">
       <AvatarImage
         class="AvatarImage"


### PR DESCRIPTION
In  the docs https://www.radix-vue.com/components/avatar.html

style should be `:style="{ display: 'flex', gap: '20px' }`
not `:style="{ display: 'flex', gap: 20}`