### PR TITLE
fix(Combobox): update `AcceptableValue` inside `Combobox.vue`

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -5,7 +5,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import { createContext, useDirection, useFormControl, useForwardExpose, useId } from '@/shared'
 import { createCollection } from '@/Collection'
 
-export type AcceptableValue = string | number | boolean | object
+export type AcceptableValue = string | number | boolean | Record<string, any>
 type ArrayOrWrapped<T> = T extends any[] ? T : Array<T>
 
 type ComboboxRootContext<T> = {


### PR DESCRIPTION
Please first read this issue: https://github.com/radix-vue/shadcn-vue/issues/327

So I delved deeper inside `radix-vue` codebase and searched that `type AcceptableValue = string | number | boolean | object`

But `object` type inside TS is more that just object we think about:

```typescript
let obj: object;
obj = {}; // Allowed
obj = []; // Allowed
obj = () => {}; // Allowed
obj = 42; // Not allowed, because 42 is a primitive type
```

type `Object` don't feet too I think:

```typescript
let obj: Object;
obj = {}; // Allowed
obj = []; // Allowed
obj = new Object(); // Allowed
obj = () => {}; // Not allowed, because () => {} is not an instance of Object
```

So I think that the best `object` for this values will be `PlainObject`:

```typescript
type PlainObject = Record<string, any>;
```

So, this PR change `object` to `Record<string, any>`

If you think about other edge cases, I'm open to chat and discussion 🙂 