### PR TITLE
chore(Checkbox): export `CheckboxCheckedState` type

### DIFF
--- a/packages/radix-vue/src/Checkbox/index.ts
+++ b/packages/radix-vue/src/Checkbox/index.ts
@@ -7,3 +7,6 @@ export {
   default as CheckboxIndicator,
   type CheckboxIndicatorProps,
 } from './CheckboxIndicator.vue'
+export type {
+  CheckedState as CheckboxCheckedState,
+} from './utils'


### PR DESCRIPTION
Makes it more convenient to provide type information for e.g. `ref` or `computed`:

```
import type { CheckboxCheckedState } from 'radix-vue'

const isChecked = ref<CheckboxCheckedState>(false)
```