### PR TITLE
fix(Checkbox): check indeterminate state in click event handler

### DIFF
--- a/packages/radix-vue/src/Checkbox/Checkbox.test.ts
+++ b/packages/radix-vue/src/Checkbox/Checkbox.test.ts
@@ -90,7 +90,7 @@ describe('given checked value as "indeterminate"', async () => {
 
   it('should still be clickable', async () => {
     await wrapper.find('button').trigger('click')
-    expect(wrapper.find('button').attributes('data-state')).toBe('unchecked')
+    expect(wrapper.find('button').attributes('data-state')).toBe('checked')
   })
 })
 

--- a/packages/radix-vue/src/Checkbox/CheckboxRoot.vue
+++ b/packages/radix-vue/src/Checkbox/CheckboxRoot.vue
@@ -90,7 +90,7 @@ provideCheckboxRootContext({
     @keydown.enter.prevent="() => {
       // According to WAI ARIA, Checkboxes don't activate on enter keypress
     }"
-    @click="checked = !checked"
+    @click="checked = isIndeterminate(checked) ? true : !checked"
   >
     <slot />
   </Primitive>


### PR DESCRIPTION
When checkbox is in indeterminate state, we should account for it in the click handler and set the state to `true`.

Reference:
https://github.com/radix-ui/primitives/blob/c31c97274ff357aea99afe6c01c1c8c58b6356e0/packages/react/checkbox/src/Checkbox.tsx#L93C42-L93C57