### PR TITLE
fix: remove coords check in `usePointerDownOutside`

### DIFF
--- a/docs/content/components/dialog.md
+++ b/docs/content/components/dialog.md
@@ -242,6 +242,20 @@ import './styles.css'
 }
 ```
 
+However, there's a caveat to this approach, where user might click on the scrollbar and close the dialog unintentionally. There's no universal solution that would fix this issue for now, however you can add the following snippet to `DialogContent` to prevent closing of modal when clicking on scrollbar.
+
+```vue
+<DialogContent
+  @pointer-down-outside="(event) => {
+    const originalEvent = event.detail.originalEvent;
+    const target = originalEvent.target as HTMLElement;
+    if (originalEvent.offsetX > target.clientWidth || originalEvent.offsetY > target.clientHeight) {
+      event.preventDefault();
+    }
+  }"
+>
+```
+
 ### Custom portal container
 
 Customise the element that your dialog portals into.

--- a/packages/radix-vue/src/DismissableLayer/utils.ts
+++ b/packages/radix-vue/src/DismissableLayer/utils.ts
@@ -62,9 +62,6 @@ export function usePointerDownOutside(
         return
       }
 
-      if (event.clientX > target.clientWidth || event.clientY > target.clientHeight)
-        return
-
       if (event.target && !isPointerInsideDOMTree.value) {
         const eventDetail = { originalEvent: event }
 


### PR DESCRIPTION
It seems that my last change in #695 did not fix the problem completely. After upgrading to the latest version, one of my Select components now works, but the other does not. And some of the dropdowns are not working as expected.

```ts
if (event.clientX > target.clientWidth || event.clientY > target.clientHeight)
	return
```

As I undrestand it, we need those lines for this particular example of dialog: https://www.shadcn-vue.com/docs/components/dialog.html#scroll-overlay. To handle the case when we click on the scrollbar and the dialog closes. This is valid issue, but I think this is the wrong way to fix it. We dont need to modify the composable, because it will affect all other components and break a lot of things. We can modify the `@pointer-down-outside` handler just for this case with scroll overlay. 

Here is how we can fix it for shadcn-vue: 
https://github.com/radix-vue/shadcn-vue/blob/dev/apps/www/src/lib/registry/default/ui/dialog/DialogScrollContent.vue
```vue
<template>
  <DialogPortal>
    <DialogOverlay
      class="fixed inset-0 z-50 grid place-items-center overflow-y-auto bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
    >
      <DialogContent
        :class="
          cn(
            'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg md:w-full',
            props.class,
          )
        "
        v-bind="forwarded"
        @pointer-down-outside="(event) => {
          const originalEvent = event.detail.originalEvent;
          const target = originalEvent.target as HTMLElement;
          if (originalEvent.offsetX > target.clientWidth || originalEvent.offsetY > target.clientHeight) {
            event.preventDefault();
          }
        }"
      >
        <slot />

        <DialogClose
          class="absolute top-3 right-3 p-0.5 transition-colors rounded-md hover:bg-secondary"
        >
          <X class="w-4 h-4" />
          <span class="sr-only">Close</span>
        </DialogClose>
      </DialogContent>
    </DialogOverlay>
  </DialogPortal>
</template>
```