### PR TITLE
fix: `SelectTrigger` is not disabled when passing disabled prop to `SelectRoot`

### DIFF
--- a/packages/radix-vue/src/Select/SelectTrigger.vue
+++ b/packages/radix-vue/src/Select/SelectTrigger.vue
@@ -53,7 +53,7 @@ function handleOpen() {
       :aria-expanded="rootContext.open.value || false"
       :aria-required="rootContext.required?.value"
       aria-autocomplete="none"
-      :disabled="disabled"
+      :disabled="isDisabled"
       :dir="rootContext?.dir.value"
       :data-state="rootContext?.open.value ? 'open' : 'closed'"
       :data-disabled="isDisabled ? '' : undefined"


### PR DESCRIPTION
Related issue https://github.com/radix-vue/shadcn-vue/issues/354

https://stackblitz.com/edit/xyl3we?file=src%2FApp.vue

I think we need to `check/cleanup` all components from up to bottom from radix-ui