### PR TITLE
fix(Combobox): Allow array type for `modelValue` and `defaultValue`

### DIFF
--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -23,7 +23,7 @@
   {
     'name': 'defaultValue',
     'description': '<p>The value of the combobox when initially rendered. Use when you do not need to control the state of the Combobox</p>\n',
-    'type': 'AcceptableValue',
+    'type': 'AcceptableValue | AcceptableValue[]',
     'required': false
   },
   {
@@ -53,7 +53,7 @@
   {
     'name': 'modelValue',
     'description': '<p>The controlled value of the Combobox. Can be binded-with with <code>v-model</code>.</p>\n',
-    'type': 'AcceptableValue',
+    'type': 'AcceptableValue | AcceptableValue[]',
     'required': false
   },
   {
@@ -109,6 +109,6 @@
   {
     'name': 'modelValue',
     'description': 'Current active value',
-    'type': 'string | number | false | true | object'
+    'type': 'AcceptableValue | AcceptableValue[]'
   }
 ]" />

--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -47,7 +47,7 @@
   {
     'name': 'filterFunction',
     'description': '<p>The custom filter function for filtering <code>ComboboxItem</code>.</p>\n',
-    'type': '((val: string[] | number[] | false[] | true[] | object[], term: string) => string[] | number[] | false[] | true[] | object[])',
+    'type': '((val: string[] | number[] | false[] | true[] | Record<string, any>[], term: string) => string[] | number[] | false[] | true[] | Record<string, any>[])',
     'required': false
   },
   {

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -44,9 +44,9 @@ export type ComboboxRootEmits<T = AcceptableValue> = {
 
 export interface ComboboxRootProps<T = AcceptableValue> extends PrimitiveProps {
   /** The controlled value of the Combobox. Can be binded-with with `v-model`. */
-  modelValue?: T
+  modelValue?: T | Array<T>
   /** The value of the combobox when initially rendered. Use when you do not need to control the state of the Combobox */
-  defaultValue?: T
+  defaultValue?: T | Array<T>
   /** The controlled open state of the Combobox. Can be binded-with with `v-model:open`. */
   open?: boolean
   /** The open state of the combobox when it is initially rendered. <br> Use when you do not need to control its open state. */

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -104,7 +104,7 @@ const modelValue = useVModel(props, 'modelValue', emit, {
   defaultValue: props.defaultValue ?? multiple.value ? [] : undefined,
   passive: (props.modelValue === undefined) as false,
   deep: true,
-}) as Ref<T>
+}) as Ref<T | T[]>
 
 const open = useVModel(props, 'open', emit, {
   defaultValue: props.defaultOpen,
@@ -166,7 +166,7 @@ const filteredOptions = computed(() => {
 })
 
 function resetSearchTerm() {
-  if (!multiple.value && modelValue.value) {
+  if (!multiple.value && modelValue.value && !Array.isArray(modelValue.value)) {
     if (props.displayValue)
       searchTerm.value = props.displayValue(modelValue.value)
     else if (typeof modelValue.value !== 'object')


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #698 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a simple PR that improves the type of `ComboboxRootProps`. Since the `ComboboxRoot` component allows `multiple` to select more than one value, the `modelValue` and `defaultValue` can also be an array.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.