### PR TITLE
fix(Combobox): Computed warning when opening items

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -72,7 +72,7 @@ export interface ComboboxRootProps<T = AcceptableValue> extends PrimitiveProps {
 import { computed, nextTick, ref, toRefs, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
 import { Primitive } from '@/Primitive'
-import { computedWithControl, useVModel } from '@vueuse/core'
+import { useVModel } from '@vueuse/core'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
 import isEqual from 'fast-deep-equal'
 
@@ -150,9 +150,11 @@ const contentElement = ref<HTMLElement>()
 const { forwardRef, currentElement: parentElement } = useForwardExpose()
 const { getItems, reactiveItems, itemMapSize } = createCollection<{ value: T }>('data-radix-vue-combobox-item')
 
-const options = computedWithControl(() => itemMapSize.value, () => {
-  return getItems().map(i => i.value)
-})
+const options = ref<T[]>([]) as Ref<T[]>
+
+watch(() => itemMapSize.value, () => {
+  options.value = getItems().map(i => i.value)
+}, { immediate: true })
 
 const filteredOptions = computed(() => {
   if (isUserInputted.value) {

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -161,8 +161,8 @@ const filteredOptions = computed(() => {
     if (props.filterFunction)
       return props.filterFunction(options.value as ArrayOrWrapped<T>, searchTerm.value) as T[]
 
-    else if (typeof options.value[0] === 'string')
-      return options.value.filter(i => (i as string).toLowerCase().includes(searchTerm.value?.toLowerCase()))
+    // The default filter only compares strings
+    return options.value.filter(i => typeof i === 'string' && i.toLowerCase().includes(searchTerm.value?.toLowerCase()))
   }
   return options.value
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #708 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This PR aims to remove the warning caused when opening the `ComboboxContent`, which says the following:

```
[Vue warn] Computed is still dirty after getter evaluation, likely because a computed is mutating its own dependency in its getter. State mutations in computed getters should be avoided.
```

This warning seems to occur at the `ComboboxRoot` component when reading the value of the `options` property inside of a regular `computed`. The `options` property uses the VueUse utility `computedWithControl` to only change the value when `itemMapSize` changes. 

However, as mentioned in the following issue from VueUse (https://github.com/vueuse/vueuse/issues/3794#issuecomment-1951369704) it is recommended to instead use a `watch` to perform the side effects, instead of `computedWithControl`.

This PR replaces `computedWithControl` with a simple `watch` and `ref` implementation to achieve the same goal. I compared the behavior of both implementations and they where practically identical, but now the warning is gone.

I will leave the PR open in case you have a better suggestion!

### 📝 Checklist

- [x] I have linked an issue or discussion.