### PR TITLE
Handle possible null element in useFocusOutside focus callback

### DIFF
--- a/packages/radix-vue/src/DismissableLayer/utils.ts
+++ b/packages/radix-vue/src/DismissableLayer/utils.ts
@@ -152,7 +152,7 @@ export function useFocusOutside(
         return
 
       await nextTick()
-      if (isLayerExist(element.value, event.target as HTMLElement))
+      if (!element.value || isLayerExist(element.value, event.target as HTMLElement))
         return
 
       if (event.target && !isFocusInsideDOMTree.value) {


### PR DESCRIPTION
I'm working on another reactivity refactor [here](https://github.com/vuejs/core/tree/reactivity-refactor) and noticed uncaught errors in radix-vue tests (despite all the tests passing): https://github.com/vuejs/ecosystem-ci/actions/runs/8029583738/job/21936045284

The root cause here is that the refactor gives computed a more correct behavior in that it will always give the latest value, even if its owner component has unmounted.

Previously, computed's effect is stopped after the owner component is unmounted, causing it to become stale and always return the last value before unmount. The refactor removed the need to "stop" a computed, and ensures that it never gets stale even when it has no subscriber.

The line in question here happens to rely on this behavior: although it checked for `element.value` at the top, after `await nextTick()` the element computed value actually becomes `null` because the owner component unsets the dependency template ref when it unmounts.