### PR TITLE
chore: make vue peer dependency

### DIFF
--- a/packages/radix-vue/package.json
+++ b/packages/radix-vue/package.json
@@ -78,7 +78,6 @@
   },
   "devDependencies": {
     "@iconify/vue": "^4.1.1",
-    "@internationalized/date": "^3.5.2",
     "@testing-library/dom": "^9.3.3",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/user-event": "^14.5.1",

--- a/packages/radix-vue/package.json
+++ b/packages/radix-vue/package.json
@@ -56,15 +56,32 @@
     "test": "vitest",
     "pub:release": "pnpm publish --access public"
   },
+  "peerDependencies": {
+    "@internationalized/date": "^3.5.2",
+    "vue": "^3.2.0"
+  },
+  "peerDependenciesMeta": {
+    "vue": {
+      "optional": false
+    },
+    "@internationalized/date": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@floating-ui/dom": "^1.5.4",
     "@floating-ui/vue": "^1.0.4",
-    "@internationalized/date": "^3.5.2",
+    "@vueuse/components": "^10.5.0",
+    "@vueuse/core": "^10.5.0",
+    "@vueuse/shared": "^10.5.0",
+    "aria-hidden": "^1.2.3",
+    "defu": "^6.1.4",
     "fast-deep-equal": "^3.1.3",
     "nanoid": "^5.0.6"
   },
   "devDependencies": {
     "@iconify/vue": "^4.1.1",
+    "@internationalized/date": "^3.5.2",
     "@testing-library/dom": "^9.3.3",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/user-event": "^14.5.1",
@@ -77,11 +94,6 @@
     "@vue/shared": "^3.4.6",
     "@vue/test-utils": "^2.4.1",
     "@vue/tsconfig": "^0.4.0",
-    "@vueuse/components": "^10.5.0",
-    "@vueuse/core": "^10.5.0",
-    "@vueuse/shared": "^10.5.0",
-    "aria-hidden": "^1.2.3",
-    "defu": "^6.1.4",
     "dts-bundle": "^0.7.3",
     "jsdom": "^23.2.0",
     "typescript": "^5.3.3",

--- a/packages/radix-vue/package.json
+++ b/packages/radix-vue/package.json
@@ -57,20 +57,17 @@
     "pub:release": "pnpm publish --access public"
   },
   "peerDependencies": {
-    "@internationalized/date": "^3.5.2",
     "vue": "^3.2.0"
   },
   "peerDependenciesMeta": {
     "vue": {
       "optional": false
-    },
-    "@internationalized/date": {
-      "optional": true
     }
   },
   "dependencies": {
     "@floating-ui/dom": "^1.5.4",
     "@floating-ui/vue": "^1.0.4",
+    "@internationalized/date": "^3.5.2",
     "@vueuse/components": "^10.5.0",
     "@vueuse/core": "^10.5.0",
     "@vueuse/shared": "^10.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,21 @@ importers:
       '@floating-ui/vue':
         specifier: ^1.0.4
         version: 1.0.6(vue@3.4.21)
-      '@internationalized/date':
-        specifier: ^3.5.2
-        version: 3.5.2
+      '@vueuse/components':
+        specifier: ^10.5.0
+        version: 10.9.0(vue@3.4.21)
+      '@vueuse/core':
+        specifier: ^10.5.0
+        version: 10.9.0(vue@3.4.21)
+      '@vueuse/shared':
+        specifier: ^10.5.0
+        version: 10.9.0(vue@3.4.21)
+      aria-hidden:
+        specifier: ^1.2.3
+        version: 1.2.3
+      defu:
+        specifier: ^6.1.4
+        version: 6.1.4
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -214,6 +226,9 @@ importers:
       '@iconify/vue':
         specifier: ^4.1.1
         version: 4.1.1(vue@3.4.21)
+      '@internationalized/date':
+        specifier: ^3.5.2
+        version: 3.5.2
       '@testing-library/dom':
         specifier: ^9.3.3
         version: 9.3.4
@@ -250,21 +265,6 @@ importers:
       '@vue/tsconfig':
         specifier: ^0.4.0
         version: 0.4.0
-      '@vueuse/components':
-        specifier: ^10.5.0
-        version: 10.9.0(vue@3.4.21)
-      '@vueuse/core':
-        specifier: ^10.5.0
-        version: 10.9.0(vue@3.4.21)
-      '@vueuse/shared':
-        specifier: ^10.5.0
-        version: 10.9.0(vue@3.4.21)
-      aria-hidden:
-        specifier: ^1.2.3
-        version: 1.2.3
-      defu:
-        specifier: ^6.1.4
-        version: 6.1.4
       dts-bundle:
         specifier: ^0.7.3
         version: 0.7.3
@@ -1650,7 +1650,6 @@ packages:
     resolution: {integrity: sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==}
     dependencies:
       '@swc/helpers': 0.5.6
-    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2121,7 +2120,6 @@ packages:
     resolution: {integrity: sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==}
     dependencies:
       tslib: 2.6.2
-    dev: false
 
   /@testing-library/dom@9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -2815,6 +2813,7 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+    dev: false
 
   /@vueuse/core@10.9.0(vue@3.4.21):
     resolution: {integrity: sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==}
@@ -3099,7 +3098,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -10448,13 +10447,24 @@ packages:
     resolution: {directory: packages/radix-vue, type: directory}
     id: file:packages/radix-vue
     name: radix-vue
+    peerDependencies:
+      '@internationalized/date': ^3.5.2
+      vue: ^3.2.0
+    peerDependenciesMeta:
+      '@internationalized/date':
+        optional: true
     dependencies:
       '@floating-ui/dom': 1.6.3
       '@floating-ui/vue': 1.0.6(vue@3.4.21)
       '@internationalized/date': 3.5.2
+      '@vueuse/components': 10.9.0(vue@3.4.21)
+      '@vueuse/core': 10.9.0(vue@3.4.21)
+      '@vueuse/shared': 10.9.0(vue@3.4.21)
+      aria-hidden: 1.2.3
+      defu: 6.1.4
       fast-deep-equal: 3.1.3
       nanoid: 5.0.6
+      vue: 3.4.21(typescript@5.3.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
-      - vue
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@floating-ui/vue':
         specifier: ^1.0.4
         version: 1.0.6(vue@3.4.21)
+      '@internationalized/date':
+        specifier: ^3.5.2
+        version: 3.5.2
       '@vueuse/components':
         specifier: ^10.5.0
         version: 10.9.0(vue@3.4.21)
@@ -226,9 +229,6 @@ importers:
       '@iconify/vue':
         specifier: ^4.1.1
         version: 4.1.1(vue@3.4.21)
-      '@internationalized/date':
-        specifier: ^3.5.2
-        version: 3.5.2
       '@testing-library/dom':
         specifier: ^9.3.3
         version: 9.3.4
@@ -1650,6 +1650,7 @@ packages:
     resolution: {integrity: sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==}
     dependencies:
       '@swc/helpers': 0.5.6
+    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2120,6 +2121,7 @@ packages:
     resolution: {integrity: sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==}
     dependencies:
       tslib: 2.6.2
+    dev: false
 
   /@testing-library/dom@9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -10448,11 +10450,7 @@ packages:
     id: file:packages/radix-vue
     name: radix-vue
     peerDependencies:
-      '@internationalized/date': ^3.5.2
       vue: ^3.2.0
-    peerDependenciesMeta:
-      '@internationalized/date':
-        optional: true
     dependencies:
       '@floating-ui/dom': 1.6.3
       '@floating-ui/vue': 1.0.6(vue@3.4.21)


### PR DESCRIPTION
Idk why we haven't done this before, but I think we need to make vue a peer dependency. You basically can't use radix-vue without vue. It's a general thing among outher libraries, for example [headless-ui](https://github.com/tailwindlabs/headlessui/blob/000e0c01927f38a70f2197df6ee9a388f7a72d99/packages/%40headlessui-vue/package.json#L44-L51) or [ark-ui](https://github.com/chakra-ui/ark/blob/4aad0c95cf7e3fdecc85ec083e16fd586cf7c3ee/packages/frameworks/vue/package.json#L98-L102)

I also moved this part of the dependencies from "devDependencies" to just "dependencies" because they are actually used at runtime.

```
"@vueuse/components": "^10.5.0",
"@vueuse/core": "^10.5.0",
"@vueuse/shared": "^10.5.0",
"aria-hidden": "^1.2.3",
"defu": "^6.1.4",
```




