### PR TITLE
fix(select): fix select content animation

### DIFF
--- a/packages/radix-vue/src/Select/SelectContent.vue
+++ b/packages/radix-vue/src/Select/SelectContent.vue
@@ -16,7 +16,7 @@ export interface SelectContentProps extends SelectContentImplProps {
 </script>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import SelectContentImpl from './SelectContentImpl.vue'
 import { injectSelectRootContext } from './SelectRoot.vue'
 import { Presence } from '@/Presence'
@@ -40,20 +40,21 @@ onMounted(() => {
 })
 
 const presenceRef = ref<InstanceType<typeof Presence>>()
+
+const renderPresence = computed(() => props.forceMount || rootContext.open.value)
 </script>
 
 <template>
-  <Presence ref="presenceRef" :present="forceMount || rootContext.open.value">
+  <Presence v-if="renderPresence" ref="presenceRef" :present="true">
     <SelectContentImpl v-bind="{ ...forwarded, ...$attrs }">
       <slot />
     </SelectContentImpl>
   </Presence>
-
-  <Teleport v-if="!presenceRef?.present && fragment" :to="fragment">
-    <SelectProvider :context="rootContext">
-      <div>
+  <div v-else-if="!presenceRef?.present && fragment">
+    <Teleport :to="fragment">
+      <SelectProvider :context="rootContext">
         <slot />
-      </div>
-    </SelectProvider>
-  </Teleport>
+      </SelectProvider>
+    </Teleport>
+  </div>
 </template>

--- a/packages/radix-vue/src/Select/story/SelectDemo.story.vue
+++ b/packages/radix-vue/src/Select/story/SelectDemo.story.vue
@@ -45,61 +45,75 @@ const POSITION = ['item-aligned', 'popper'] as const
           </SelectTrigger>
 
           <SelectPortal>
-            <SelectContent
-              class="min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade"
-              :side-offset="5"
-              :position="position"
-            >
-              <SelectScrollUpButton
-                class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+            <Transition>
+              <SelectContent
+                class="min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade"
+                :side-offset="5"
+                :position="position"
               >
-                <Icon icon="radix-icons:chevron-up" />
-              </SelectScrollUpButton>
+                <SelectScrollUpButton
+                  class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+                >
+                  <Icon icon="radix-icons:chevron-up" />
+                </SelectScrollUpButton>
 
-              <SelectViewport class="p-[5px]">
-                <SelectLabel
-                  class="px-[25px] text-xs leading-[25px] text-mauve11"
-                >
-                  Fruits
-                </SelectLabel>
-                <SelectGroup>
-                  <SelectItemWrapper :options="options" />
-                </SelectGroup>
-                <SelectSeparator class="h-[1px] bg-violet6 m-[5px]" />
-                <SelectLabel
-                  class="px-[25px] text-xs leading-[25px] text-mauve11"
-                >
-                  Vegetables
-                </SelectLabel>
-                <SelectGroup>
-                  <SelectItem
-                    v-for="(option, index) in vegetables"
-                    :key="index"
-                    class="text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
-                    :value="option"
-                    :disabled="option === 'Courgette'"
+                <SelectViewport class="p-[5px]">
+                  <SelectLabel
+                    class="px-[25px] text-xs leading-[25px] text-mauve11"
                   >
-                    <SelectItemIndicator
-                      class="absolute left-0 w-[25px] inline-flex items-center justify-center"
+                    Fruits
+                  </SelectLabel>
+                  <SelectGroup>
+                    <SelectItemWrapper :options="options" />
+                  </SelectGroup>
+                  <SelectSeparator class="h-[1px] bg-violet6 m-[5px]" />
+                  <SelectLabel
+                    class="px-[25px] text-xs leading-[25px] text-mauve11"
+                  >
+                    Vegetables
+                  </SelectLabel>
+                  <SelectGroup>
+                    <SelectItem
+                      v-for="(option, index) in vegetables"
+                      :key="index"
+                      class="text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
+                      :value="option"
+                      :disabled="option === 'Courgette'"
                     >
-                      <Icon icon="radix-icons:check" />
-                    </SelectItemIndicator>
-                    <SelectItemText>
-                      {{ option }}
-                    </SelectItemText>
-                  </SelectItem>
-                </SelectGroup>
-              </SelectViewport>
+                      <SelectItemIndicator
+                        class="absolute left-0 w-[25px] inline-flex items-center justify-center"
+                      >
+                        <Icon icon="radix-icons:check" />
+                      </SelectItemIndicator>
+                      <SelectItemText>
+                        {{ option }}
+                      </SelectItemText>
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectViewport>
 
-              <SelectScrollDownButton
-                class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
-              >
-                <Icon icon="radix-icons:chevron-down" />
-              </SelectScrollDownButton>
-            </SelectContent>
+                <SelectScrollDownButton
+                  class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+                >
+                  <Icon icon="radix-icons:chevron-down" />
+                </SelectScrollDownButton>
+              </SelectContent>
+            </Transition>
           </SelectPortal>
         </SelectRoot>
       </div>
     </Variant>
   </Story>
 </template>
+
+<style scoped>
+.v-enter-active,
+.v-leave-active {
+  transition: opacity .3s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+</style>

--- a/packages/radix-vue/src/Select/story/SelectDemo.story.vue
+++ b/packages/radix-vue/src/Select/story/SelectDemo.story.vue
@@ -47,7 +47,7 @@ const POSITION = ['item-aligned', 'popper'] as const
           <SelectPortal>
             <Transition>
               <SelectContent
-                class="min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade"
+                class="min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]"
                 :side-offset="5"
                 :position="position"
               >


### PR DESCRIPTION
Hi 👋🏻 Closes #787 

# Changed
## SelectContent.vue

- rewrite template for using v-if/ v-else
- wrap select provider in `div`

It's bug because `<Transiton />` can't be applied on fragment or multi root components. I tried some hacks and debug, and come up with this solution:
- set prop `present` in `Presence` component to `true`. And move old prop value to `v-if`
- wrap `Teleport` with `div` and `v-else-if` condition.

And it works. Maybe I'm missing something, but it works  😅


# Artifact

https://github.com/radix-vue/radix-vue/assets/20302368/fb77015e-9cca-446a-9409-34ffdd5b3403
