### PR TITLE
fix: make hover card tappable

### DIFF
--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -27,7 +27,8 @@ rootContext.triggerElement = currentElement
       :as-child="asChild"
       :as="as"
       :data-state="rootContext.open.value ? 'open' : 'closed'"
-      @pointerenter="excludeTouch(rootContext.onOpen)($event)"
+      @pointerenter="excludeTouch($event, rootContext.onOpen)"
+      @pointerleave="excludeTouch($event, rootContext.onClose)"
       @focus="rootContext.onOpen()"
       @blur="rootContext.onClose()"
     >

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -27,8 +27,8 @@ rootContext.triggerElement = currentElement
       :as-child="asChild"
       :as="as"
       :data-state="rootContext.open.value ? 'open' : 'closed'"
-      @pointerenter="excludeTouch($event, rootContext.onOpen)"
-      @pointerleave="excludeTouch($event, rootContext.onClose)"
+      @pointerenter="excludeTouch(rootContext.onOpen)($event)"
+      @pointerleave="excludeTouch(rootContext.onClose)($event)"
       @focus="rootContext.onOpen()"
       @blur="rootContext.onClose()"
     >

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -28,7 +28,6 @@ rootContext.triggerElement = currentElement
       :as="as"
       :data-state="rootContext.open.value ? 'open' : 'closed'"
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
-      @pointerleave="excludeTouch(rootContext.onClose)($event)"
       @focus="rootContext.onOpen()"
       @blur="rootContext.onClose()"
     >

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -29,10 +29,7 @@ rootContext.triggerElement = currentElement
       :data-state="rootContext.open.value ? 'open' : 'closed'"
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
       @focus="rootContext.onOpen()"
-      @blur="rootContext.onClose"
-      @touchstart.prevent="() => {
-        // prevent focus event on touch devices
-      }"
+      @blur="rootContext.onClose()"
     >
       <slot />
     </Primitive>

--- a/packages/radix-vue/src/HoverCard/utils.ts
+++ b/packages/radix-vue/src/HoverCard/utils.ts
@@ -1,6 +1,6 @@
-export function excludeTouch(eventHandler: () => void) {
-  return (event: PointerEvent) =>
-    event.pointerType === 'touch' ? undefined : eventHandler()
+export function excludeTouch(event: PointerEvent, eventHandler: () => void) {
+  if (event.pointerType !== 'touch')
+    eventHandler()
 }
 
 /**

--- a/packages/radix-vue/src/HoverCard/utils.ts
+++ b/packages/radix-vue/src/HoverCard/utils.ts
@@ -1,6 +1,5 @@
-export function excludeTouch(event: PointerEvent, eventHandler: () => void) {
-  if (event.pointerType !== 'touch')
-    eventHandler()
+export function excludeTouch(eventHandler: () => void) {
+  return (event: PointerEvent) => event.pointerType === 'touch' ? undefined : eventHandler()
 }
 
 /**


### PR DESCRIPTION
Let's just remove this.

In Radix Primitives for React this doesn't even do anything as the `event` there is some weird React abstraction.