### PR TITLE
fix(date): shared calendar year jump on createDecade

### DIFF
--- a/packages/radix-vue/src/shared/date/calendar.ts
+++ b/packages/radix-vue/src/shared/date/calendar.ts
@@ -129,7 +129,7 @@ export function endOfDecade(dateObj: DateValue) {
 export function createDecade(props: SetDecadeProps): DateValue[] {
   const { dateObj, startIndex, endIndex, minValue, maxValue } = props
 
-  const decadeArray = Array.from({ length: Math.abs((startIndex ?? 0) - endIndex) }, (_, i) => i < Math.abs(startIndex ?? 0) ? dateObj.subtract({ years: i }).set({ day: 1, month: 1 }) : dateObj.add({ years: i }).set({ day: 1, month: 1 })).toSorted((a, b) => a.year - b.year)
+  const decadeArray = Array.from({ length: Math.abs(startIndex ?? 0) + endIndex }, (_, i) => i <= Math.abs((startIndex ?? 0)) ? dateObj.subtract({ years: i }).set({ day: 1, month: 1 }) : dateObj.add({ years: i - endIndex }).set({ day: 1, month: 1 })).toSorted((a, b) => a.year - b.year)
 
   return decadeArray.filter((year) => {
     if (minValue && isBefore(year, minValue))


### PR DESCRIPTION
Hello,

This PR fixes an issue outlined by @sadeghbarati in which the `createDecade` doesn't output the correct year progression, but it just jumps from the current year to 10 years in the future.

Screenshot of the issue on `CalendarPopover.story.vue`:
![Screenshot 2024-04-01 at 14 17 52](https://github.com/radix-vue/radix-vue/assets/17836403/ef89e6cd-b8c9-494e-9a2b-51be2c33f834)
