### PR TITLE
fix(Select): Touch scroll triggers the select content

### DIFF
--- a/packages/radix-vue/src/Select/Select.test.ts
+++ b/packages/radix-vue/src/Select/Select.test.ts
@@ -4,6 +4,7 @@ import Select from './story/_SelectTest.vue'
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { fireEvent } from '@testing-library/vue'
 import { handleSubmit } from '@/test'
 
 describe('given default Select', () => {
@@ -33,7 +34,7 @@ describe('given default Select', () => {
 
   describe('opening the modal', () => {
     beforeEach(async () => {
-      await wrapper.find('button').trigger('pointerup', {
+      await wrapper.find('button').trigger('pointerdown', {
         button: 0,
         ctrlKey: false,
       })
@@ -58,6 +59,8 @@ describe('given default Select', () => {
         const selection = wrapper.findAll('[role=option]')[1];
         (selection.element as HTMLElement).focus()
         await selection.trigger('pointerup')
+        // Needs 2 pointerup because SelectContentImpl prevents accidental pointerup's
+        await fireEvent.pointerUp(selection.element)
       })
 
       it('should show value correctly', () => {
@@ -71,7 +74,7 @@ describe('given default Select', () => {
 
       describe('after opening the modal again', () => {
         beforeEach(async () => {
-          await wrapper.find('button').trigger('pointerup', {
+          await wrapper.find('button').trigger('pointerdown', {
             button: 0,
             ctrlKey: false,
           })
@@ -108,7 +111,7 @@ describe('given select in a form', async () => {
 
   describe('after selecting option and clicking submit button', () => {
     beforeEach(async () => {
-      await wrapper.find('button').trigger('pointerup', {
+      await wrapper.find('button').trigger('pointerdown', {
         button: 0,
         ctrlKey: false,
       })
@@ -116,6 +119,8 @@ describe('given select in a form', async () => {
       const selection = wrapper.findAll('[role=option]')[1];
       (selection.element as HTMLElement).focus()
       await selection.trigger('pointerup')
+      // Needs 2 pointerup because SelectContentImpl prevents accidental pointerup's
+      await fireEvent.pointerUp(selection.element)
       await wrapper.find('form').trigger('submit')
     })
 
@@ -127,7 +132,7 @@ describe('given select in a form', async () => {
 
   describe('after selecting other option and click submit button again', () => {
     beforeEach(async () => {
-      await wrapper.find('button').trigger('pointerup', {
+      await wrapper.find('button').trigger('pointerdown', {
         button: 0,
         ctrlKey: false,
       })
@@ -135,6 +140,8 @@ describe('given select in a form', async () => {
       const selection = wrapper.findAll('[role=option]')[4];
       (selection.element as HTMLElement).focus()
       await selection.trigger('pointerup')
+      // Needs 2 pointerup because SelectContentImpl prevents accidental pointerup's
+      await fireEvent.pointerUp(selection.element)
       await wrapper.find('form').trigger('submit')
     })
 

--- a/packages/radix-vue/src/Select/Select.test.ts
+++ b/packages/radix-vue/src/Select/Select.test.ts
@@ -58,8 +58,6 @@ describe('given default Select', () => {
         const selection = wrapper.findAll('[role=option]')[1];
         (selection.element as HTMLElement).focus()
         await selection.trigger('pointerup')
-        // not sure why need 2 pointUp to trigger the selection correctly
-        // await fireEvent.pointerUp(selection.element)
       })
 
       it('should show value correctly', () => {
@@ -118,8 +116,6 @@ describe('given select in a form', async () => {
       const selection = wrapper.findAll('[role=option]')[1];
       (selection.element as HTMLElement).focus()
       await selection.trigger('pointerup')
-      // not sure why need 2 pointUp to trigger the selection correctly
-      // await fireEvent.pointerUp(selection.element)
       await wrapper.find('form').trigger('submit')
     })
 
@@ -139,8 +135,6 @@ describe('given select in a form', async () => {
       const selection = wrapper.findAll('[role=option]')[4];
       (selection.element as HTMLElement).focus()
       await selection.trigger('pointerup')
-      // not sure why need 2 pointUp to trigger the selection correctly
-      // await fireEvent.pointerUp(selection.element)
       await wrapper.find('form').trigger('submit')
     })
 

--- a/packages/radix-vue/src/Select/Select.test.ts
+++ b/packages/radix-vue/src/Select/Select.test.ts
@@ -4,7 +4,6 @@ import Select from './story/_SelectTest.vue'
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
-import { fireEvent } from '@testing-library/vue'
 import { handleSubmit } from '@/test'
 
 describe('given default Select', () => {
@@ -34,7 +33,7 @@ describe('given default Select', () => {
 
   describe('opening the modal', () => {
     beforeEach(async () => {
-      await wrapper.find('button').trigger('pointerdown', {
+      await wrapper.find('button').trigger('pointerup', {
         button: 0,
         ctrlKey: false,
       })
@@ -60,7 +59,7 @@ describe('given default Select', () => {
         (selection.element as HTMLElement).focus()
         await selection.trigger('pointerup')
         // not sure why need 2 pointUp to trigger the selection correctly
-        await fireEvent.pointerUp(selection.element)
+        // await fireEvent.pointerUp(selection.element)
       })
 
       it('should show value correctly', () => {
@@ -74,7 +73,7 @@ describe('given default Select', () => {
 
       describe('after opening the modal again', () => {
         beforeEach(async () => {
-          await wrapper.find('button').trigger('pointerdown', {
+          await wrapper.find('button').trigger('pointerup', {
             button: 0,
             ctrlKey: false,
           })
@@ -111,7 +110,7 @@ describe('given select in a form', async () => {
 
   describe('after selecting option and clicking submit button', () => {
     beforeEach(async () => {
-      await wrapper.find('button').trigger('pointerdown', {
+      await wrapper.find('button').trigger('pointerup', {
         button: 0,
         ctrlKey: false,
       })
@@ -120,7 +119,7 @@ describe('given select in a form', async () => {
       (selection.element as HTMLElement).focus()
       await selection.trigger('pointerup')
       // not sure why need 2 pointUp to trigger the selection correctly
-      await fireEvent.pointerUp(selection.element)
+      // await fireEvent.pointerUp(selection.element)
       await wrapper.find('form').trigger('submit')
     })
 
@@ -132,7 +131,7 @@ describe('given select in a form', async () => {
 
   describe('after selecting other option and click submit button again', () => {
     beforeEach(async () => {
-      await wrapper.find('button').trigger('pointerdown', {
+      await wrapper.find('button').trigger('pointerup', {
         button: 0,
         ctrlKey: false,
       })
@@ -141,7 +140,7 @@ describe('given select in a form', async () => {
       (selection.element as HTMLElement).focus()
       await selection.trigger('pointerup')
       // not sure why need 2 pointUp to trigger the selection correctly
-      await fireEvent.pointerUp(selection.element)
+      // await fireEvent.pointerUp(selection.element)
       await wrapper.find('form').trigger('submit')
     })
 

--- a/packages/radix-vue/src/Select/SelectContentImpl.vue
+++ b/packages/radix-vue/src/Select/SelectContentImpl.vue
@@ -77,7 +77,6 @@ import {
   computed,
   ref,
   watch,
-  watchEffect,
 } from 'vue'
 import { unrefElement } from '@vueuse/core'
 import { injectSelectRootContext } from './SelectRoot.vue'
@@ -118,54 +117,6 @@ function focusSelectedItem() {
 
 watch(isPositioned, () => {
   focusSelectedItem()
-})
-
-// prevent selecting items on `pointerup` in some cases after opening from `pointerdown`
-// and close on `pointerup` outside.
-const { onOpenChange, triggerPointerDownPosRef } = rootContext
-watchEffect((cleanupFn) => {
-  if (!content.value)
-    return
-  let pointerMoveDelta = { x: 0, y: 0 }
-
-  const handlePointerMove = (event: PointerEvent) => {
-    pointerMoveDelta = {
-      x: Math.abs(
-        Math.round(event.pageX) - (triggerPointerDownPosRef.value?.x ?? 0),
-      ),
-      y: Math.abs(
-        Math.round(event.pageY) - (triggerPointerDownPosRef.value?.y ?? 0),
-      ),
-    }
-  }
-  const handlePointerUp = (event: PointerEvent) => {
-    // If the pointer hasn't moved by a certain threshold then we prevent selecting item on `pointerup`.
-    if (pointerMoveDelta.x <= 10 && pointerMoveDelta.y <= 10) {
-      event.preventDefault()
-    }
-    else {
-      // otherwise, if the event was outside the content, close.
-      if (!content.value?.contains(event.target as HTMLElement))
-        onOpenChange(false)
-    }
-    document.removeEventListener('pointermove', handlePointerMove)
-    triggerPointerDownPosRef.value = null
-  }
-
-  if (triggerPointerDownPosRef.value !== null) {
-    document.addEventListener('pointermove', handlePointerMove)
-    document.addEventListener('pointerup', handlePointerUp, {
-      capture: true,
-      once: true,
-    })
-  }
-
-  cleanupFn(() => {
-    document.removeEventListener('pointermove', handlePointerMove)
-    document.removeEventListener('pointerup', handlePointerUp, {
-      capture: true,
-    })
-  })
 })
 
 function handleKeyDown(event: KeyboardEvent) {

--- a/packages/radix-vue/src/Select/SelectItem.vue
+++ b/packages/radix-vue/src/Select/SelectItem.vue
@@ -144,6 +144,9 @@ provideSelectItemContext({
     @focus="isFocused = true"
     @blur="isFocused = false"
     @pointerup="handleSelect"
+    @pointerdown="(event) => {
+      (event.currentTarget as HTMLElement).focus({ preventScroll: true })
+    }"
     @touchend.prevent.stop
     @pointermove="handlePointerMove"
     @pointerleave="handlePointerLeave"

--- a/packages/radix-vue/src/Select/SelectTrigger.vue
+++ b/packages/radix-vue/src/Select/SelectTrigger.vue
@@ -7,7 +7,7 @@ export interface SelectTriggerProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, nextTick, onMounted } from 'vue'
 import {
   injectSelectRootContext,
 } from './SelectRoot.vue'
@@ -63,39 +63,24 @@ function handleOpen() {
       "
       :as-child="asChild"
       :as="as"
-      @click="
-        (event: MouseEvent) => {
-          // Whilst browsers generally have no issue focusing the trigger when clicking
-          // on a label, Safari seems to struggle with the fact that there's no `onClick`.
-          // We force `focus` in this case. Note: this doesn't create any other side-effect
-          // because we are preventing default in `onPointerDown` so effectively
-          // this only runs for a label 'click'
-          (event?.currentTarget as HTMLElement)?.focus();
-        }
-      "
-      @pointerdown="
-        (event: PointerEvent) => {
-          // prevent implicit pointer capture
-          // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
-          const target = event.target as HTMLElement;
-          if (target.hasPointerCapture(event.pointerId)) {
-            target.releasePointerCapture(event.pointerId);
-          }
-
+      @pointerup="
+        async (event: MouseEvent) => {
           // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
           // but not when the control key is pressed (avoiding MacOS right click)
-          if (event.button === 0 && event.ctrlKey === false) {
+          if (!isDisabled && event.button === 0 && event.ctrlKey === false) {
             handleOpen();
             rootContext.triggerPointerDownPosRef.value = {
               x: Math.round(event.pageX),
               y: Math.round(event.pageY),
             };
-            // prevent trigger from stealing focus from the active item after opening.
-            event.preventDefault();
+
+            // prevent trigger focusing when opening
+            // this allows the content to be given focus without competition
+            await nextTick();
+            if (rootContext.open.value) event.preventDefault();
           }
         }
       "
-      @pointerup.prevent
       @keydown="
         (event) => {
           const isTypingAhead = search !== '';

--- a/packages/radix-vue/src/Select/SelectTrigger.vue
+++ b/packages/radix-vue/src/Select/SelectTrigger.vue
@@ -7,7 +7,7 @@ export interface SelectTriggerProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 import {
   injectSelectRootContext,
 } from './SelectRoot.vue'
@@ -63,22 +63,49 @@ function handleOpen() {
       "
       :as-child="asChild"
       :as="as"
-      @pointerup="
-        async (event: MouseEvent) => {
+      @click="
+        (event: MouseEvent) => {
+          // Whilst browsers generally have no issue focusing the trigger when clicking
+          // on a label, Safari seems to struggle with the fact that there's no `onClick`.
+          // We force `focus` in this case. Note: this doesn't create any other side-effect
+          // because we are preventing default in `onPointerDown` so effectively
+          // this only runs for a label 'click'
+          (event?.currentTarget as HTMLElement)?.focus();
+        }
+      "
+      @pointerdown="
+        (event: PointerEvent) => {
+          // Prevent opening on touch down.
+          // https://github.com/radix-vue/radix-vue/issues/804
+          if (event.pointerType === 'touch')
+            return;
+
+          // prevent implicit pointer capture
+          // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
+          const target = event.target as HTMLElement;
+          if (target.hasPointerCapture(event.pointerId)) {
+            target.releasePointerCapture(event.pointerId);
+          }
+
           // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
           // but not when the control key is pressed (avoiding MacOS right click)
-          if (!isDisabled && event.button === 0 && event.ctrlKey === false) {
+          if (event.button === 0 && event.ctrlKey === false) {
             handleOpen();
             rootContext.triggerPointerDownPosRef.value = {
               x: Math.round(event.pageX),
               y: Math.round(event.pageY),
             };
-
-            // prevent trigger focusing when opening
-            // this allows the content to be given focus without competition
-            await nextTick();
-            if (rootContext.open.value) event.preventDefault();
+            // prevent trigger from stealing focus from the active item after opening.
+            event.preventDefault();
           }
+        }
+      "
+      @pointerup.prevent="
+        (event: PointerEvent) => {
+          // Only open on pointer up when using touch devices
+          // https://github.com/radix-vue/radix-vue/issues/804
+          if (event.pointerType === 'touch')
+            handleOpen();
         }
       "
       @keydown="

--- a/packages/radix-vue/src/Select/SelectTrigger.vue
+++ b/packages/radix-vue/src/Select/SelectTrigger.vue
@@ -42,6 +42,14 @@ function handleOpen() {
     resetTypeahead()
   }
 }
+
+function handlePointerOpen(event: PointerEvent) {
+  handleOpen()
+  rootContext.triggerPointerDownPosRef.value = {
+    x: Math.round(event.pageX),
+    y: Math.round(event.pageY),
+  }
+}
 </script>
 
 <template>
@@ -78,7 +86,7 @@ function handleOpen() {
           // Prevent opening on touch down.
           // https://github.com/radix-vue/radix-vue/issues/804
           if (event.pointerType === 'touch')
-            return;
+            return event.preventDefault();
 
           // prevent implicit pointer capture
           // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
@@ -90,11 +98,7 @@ function handleOpen() {
           // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
           // but not when the control key is pressed (avoiding MacOS right click)
           if (event.button === 0 && event.ctrlKey === false) {
-            handleOpen();
-            rootContext.triggerPointerDownPosRef.value = {
-              x: Math.round(event.pageX),
-              y: Math.round(event.pageY),
-            };
+            handlePointerOpen(event)
             // prevent trigger from stealing focus from the active item after opening.
             event.preventDefault();
           }
@@ -105,7 +109,7 @@ function handleOpen() {
           // Only open on pointer up when using touch devices
           // https://github.com/radix-vue/radix-vue/issues/804
           if (event.pointerType === 'touch')
-            handleOpen();
+            handlePointerOpen(event)
         }
       "
       @keydown="


### PR DESCRIPTION
This PR aims to improve the behavior of the `Select` component on touch devices.

Fixes: #804 

### The Problem

On the latest version of Radix UI (v1.6.1) if you try to scroll on a touch screen device and the initial tap to begin the scroll gesture fell on the `SelectTrigger`, it prevents scrolling and immediately opens the `SelectContent`.

This behavior feels wrong to the end user because they expect to be able to scroll by tapping anywhere on the screen. But if they tap on any `SelectTrigger`, not only does it lock scrolling, it also opens the `SelectContent` and feels like a bug.

See #804 for more details.

### The Cause

The issue was caused by the `SelectTrigger` opening the `SelectContent` via the `@pointerdown` event, which feels normal with a mouse, but on touch devices it gets triggered immediately after touching the screen, even if it's for a gesture.

This was done because if we triggered the open event on `@click`, restoring the focus on the `SelectTrigger` after the content closes caused it to get triggered again, so the `SelectContent` did not get closed on `Enter`.

### The Solution

This proposal replaces the `@pointerdown` with `@pointerup` and follows the same behavior as the `DropdownMenuTrigger` to prevent focus competition.

It also removes the `watchEffect` from `SelectContentImpl.vue` that prevented the `@pointerdown` event from selecting an option accidentally. Since we now use `@pointerup`, the pointer is no longer interacting and cannot trigger an item. (This was also the behavior that prevented an option from being selected until a second `pointerup` event was triggered)

I updated the tests to use `@pointerup` as well. I also tested on Safari, Chrome and Firefox on both iOS, MacOS, Windows and Android and the behavior seems to work as expected.