### PR TITLE
fix(hovercard): Tap not opening trigger link

### DIFF
--- a/docs/content/components/hover-card.md
+++ b/docs/content/components/hover-card.md
@@ -22,7 +22,6 @@ For sighted users to preview content available behind a link.
     'Customize side, alignment, offsets, collision handling.',
     'Optionally render a pointing arrow.',
     'Supports custom open and close delays.',
-    'Opens on hover only.',
     'Ignored by screen readers.',
   ]"
 />
@@ -292,6 +291,16 @@ import { HoverCardArrow, HoverCardContent, HoverCardPortal, HoverCardRoot, Hover
 
 ## Accessibility
 
+The hover card is intended for sighted users only, the content will be inaccessible to keyboard users.
+
 ### Keyboard Interactions
 
-The hover card is intended for mouse users only so will not respond to keyboard navigation.
+<KeyboardTable :data="[
+    {
+      keys: ['Tab'],
+      description: 'Opens/closes the hover card.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Opens the hover card link',
+    }]" />

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -30,9 +30,6 @@ rootContext.triggerElement = currentElement
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
       @focus="rootContext.onOpen()"
       @blur="rootContext.onClose"
-      @touchstart.prevent="() => {
-        // prevent focus event on touch devices
-      }"
     >
       <slot />
     </Primitive>


### PR DESCRIPTION
This PR intends to fix #802

### The Problem

The current implementation of the `HoverCard` tries to prevent any touch events from triggering the `focus()` event, so that the `HoverCardContent` only shows when an actual mouse hovers the `HoverCardTrigger`.

However, Vue makes the `@touchstart` event non-passive, so calling `@touchstart.prevent` completely removes the events from the trigger, which causes that tapping on the link doesn't do anything at all, not even open the `href` from the link of the `HoverCardTrigger`.

### The Solution

Remove the `@touchstart.prevent` event entirely. This will allow a long press on mobile to open the content, but it should not be a problem. Even Radix UI has the same behavior, but with them preventing the event is not a problem because React makes the `onTouchStart` event passive by default, so it just throws an error.

Credits to @remonke for pointing out that Vue makes `@touchstart` non-passive.

This PR also adds the missing Keyboard Interactions to the docs for the `HoverCard`. It currently says that there are none, but in reality when you `Tab` or focus the `HoverCardTrigger` it opens/closes the content; also when pressing `Enter` it opens the link from the `HoverCardTrigger`.