### PR TITLE
fix(RangeCalendar): data-selection-start not being applied on first select

### DIFF
--- a/packages/radix-vue/src/RangeCalendar/RangeCalendar.test.ts
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendar.test.ts
@@ -106,7 +106,7 @@ describe('RangeCalendar', () => {
     startValue = calendar.querySelector('[data-selection-start]')
     endValue = calendar.querySelector('[data-selection-end]')
 
-    expect(startValue).not.toBeInTheDocument()
+    expect(startValue).toBeInTheDocument()
     expect(endValue).not.toBeInTheDocument()
 
     const seventhDayInMonth = getByTestId('date-1-7')

--- a/packages/radix-vue/src/RangeCalendar/useRangeCalendar.ts
+++ b/packages/radix-vue/src/RangeCalendar/useRangeCalendar.ts
@@ -43,13 +43,13 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
   )
 
   const isSelectionStart = (date: DateValue) => {
-    if (!props.start.value || !props.end.value)
+    if (!props.start.value)
       return false
     return isSameDay(props.start.value, date)
   }
 
   const isSelectionEnd = (date: DateValue) => {
-    if (!props.end.value || !props.start.value)
+    if (!props.end.value)
       return false
     return isSameDay(props.end.value, date)
   }


### PR DESCRIPTION
Bug and image provided by @sadeghbarati 

`data-selection-start=true` wasn't being applied when you were first selecting a value in the range, it was being applied only when you selected both dates of the range.

![image](https://github.com/radix-vue/radix-vue/assets/17836403/da9b22a8-0a25-45c8-8e6d-bb9c35b5867e)
