### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Radix is an unstyled, customisable UI Library with built in accessibility for bu
 ## Installation
 
 ```bash
-pnpm add radix-vue
+npx nuxi@latest module add radix-vue
 ```
 ```bash
-npm install radix-vue
+npx nuxi@latest module add radix-vue
 ```
 ```bash
-yarn add radix-vue
+npx nuxi@latest module add radix-vue
 ```
 
 ## Documentation

--- a/packages/radix-vue/README.md
+++ b/packages/radix-vue/README.md
@@ -36,13 +36,13 @@ Radix is an unstyled, customisable UI Library with built in accessibility for bu
 ## Installation
 
 ```bash
-pnpm add radix-vue
+npx nuxi@latest module add radix-vue
 ```
 ```bash
-npm install radix-vue
+npx nuxi@latest module add radix-vue
 ```
 ```bash
-yarn add radix-vue
+npx nuxi@latest module add radix-vue
 ```
 
 ## Documentation


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
