### PR TITLE
feat: add direction support for Calendar/Date Field/Date Picker 

### DIFF
--- a/docs/content/meta/CalendarRoot.md
+++ b/docs/content/meta/CalendarRoot.md
@@ -33,6 +33,12 @@
     'required': false
   },
   {
+    'name': 'dir',
+    'description': '<p>The reading direction of the calendar when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'type': '\'ltr\' | \'rtl\'',
+    'required': false
+  },
+  {
     'name': 'disabled',
     'description': '<p>Whether or not the calendar is disabled</p>\n',
     'type': 'boolean',

--- a/docs/content/meta/DateFieldRoot.md
+++ b/docs/content/meta/DateFieldRoot.md
@@ -27,6 +27,12 @@
     'required': false
   },
   {
+    'name': 'dir',
+    'description': '<p>The reading direction of the date field when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'type': '\'ltr\' | \'rtl\'',
+    'required': false
+  },
+  {
     'name': 'disabled',
     'description': '<p>Whether or not the date field is disabled</p>\n',
     'type': 'boolean',

--- a/docs/content/meta/DatePickerRoot.md
+++ b/docs/content/meta/DatePickerRoot.md
@@ -34,6 +34,12 @@
     'required': false
   },
   {
+    'name': 'dir',
+    'description': '<p>The reading direction of the date field when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'type': '\'ltr\' | \'rtl\'',
+    'required': false
+  },
+  {
     'name': 'disabled',
     'description': '<p>Whether or not the date field is disabled</p>\n',
     'type': 'boolean',

--- a/docs/content/meta/DateRangeFieldRoot.md
+++ b/docs/content/meta/DateRangeFieldRoot.md
@@ -27,6 +27,12 @@
     'required': false
   },
   {
+    'name': 'dir',
+    'description': '<p>The reading direction of the date field when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'type': '\'ltr\' | \'rtl\'',
+    'required': false
+  },
+  {
     'name': 'disabled',
     'description': '<p>Whether or not the date field is disabled</p>\n',
     'type': 'boolean',

--- a/docs/content/meta/DateRangePickerRoot.md
+++ b/docs/content/meta/DateRangePickerRoot.md
@@ -34,6 +34,12 @@
     'required': false
   },
   {
+    'name': 'dir',
+    'description': '<p>The reading direction of the date field when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'type': '\'ltr\' | \'rtl\'',
+    'required': false
+  },
+  {
     'name': 'disabled',
     'description': '<p>Whether or not the date field is disabled</p>\n',
     'type': 'boolean',

--- a/docs/content/meta/RangeCalendarRoot.md
+++ b/docs/content/meta/RangeCalendarRoot.md
@@ -33,6 +33,12 @@
     'required': false
   },
   {
+    'name': 'dir',
+    'description': '<p>The reading direction of the calendar when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'type': '\'ltr\' | \'rtl\'',
+    'required': false
+  },
+  {
     'name': 'disabled',
     'description': '<p>Whether or not the calendar is disabled</p>\n',
     'type': 'boolean',

--- a/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
@@ -93,12 +93,13 @@ function handleArrowKey(e: KeyboardEvent) {
   const index = allCollectionItems.indexOf(currentElement.value)
   let newIndex = index
   const indexIncrementation = 7
+  const sign = rootContext.dir.value === 'rtl' ? -1 : 1
   switch (e.code) {
     case kbd.ARROW_RIGHT:
-      newIndex++
+      newIndex += sign
       break
     case kbd.ARROW_LEFT:
-      newIndex--
+      newIndex -= sign
       break
     case kbd.ARROW_UP:
       newIndex -= indexIncrementation

--- a/packages/radix-vue/src/Calendar/CalendarRoot.vue
+++ b/packages/radix-vue/src/Calendar/CalendarRoot.vue
@@ -3,11 +3,12 @@ import { type DateValue, isEqualDay, isSameDay } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
-import { type Formatter, createContext } from '@/shared'
+import { type Formatter, createContext, useDirection } from '@/shared'
 
 import { useCalendar, useCalendarState } from './useCalendar'
 import { createDecade, createYear, getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
 import type { Grid, Matcher, WeekDayFormat } from '@/shared/date'
+import type { Direction } from '@/shared/types'
 
 type CalendarRootContext = {
   locale: Ref<string>
@@ -38,6 +39,7 @@ type CalendarRootContext = {
   isNextButtonDisabled: Ref<boolean>
   isPrevButtonDisabled: Ref<boolean>
   formatter: Formatter
+  dir: Ref<Direction>
 }
 
 interface BaseCalendarRootProps extends PrimitiveProps {
@@ -77,6 +79,8 @@ interface BaseCalendarRootProps extends PrimitiveProps {
   isDateDisabled?: Matcher
   /** A function that returns whether or not a date is unavailable */
   isDateUnavailable?: Matcher
+  /** The reading direction of the calendar when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
+  dir?: Direction
 }
 
 interface MultipleCalendarRootProps extends BaseCalendarRootProps {
@@ -164,10 +168,12 @@ const {
   isDateDisabled: propsIsDateDisabled,
   isDateUnavailable: propsIsDateUnavailable,
   calendarLabel,
+  dir: propDir,
 } = toRefs(props)
 
 const { primitiveElement, currentElement: parentElement }
   = usePrimitiveElement()
+const dir = useDirection(propDir)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? undefined,
@@ -302,6 +308,7 @@ onMounted(() => {
 
 provideCalendarRootContext({
   isDateUnavailable,
+  dir,
   isDateDisabled,
   locale,
   formatter,
@@ -342,6 +349,7 @@ provideCalendarRootContext({
     :data-readonly="readonly ? '' : undefined"
     :data-disabled="disabled ? '' : undefined"
     :data-invalid="isInvalid ? '' : undefined"
+    :dir="dir"
   >
     <slot
       :date="placeholder"

--- a/packages/radix-vue/src/Calendar/story/CalendarDir.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarDir.story.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot } from '../'
+import { ConfigProvider } from '@/ConfigProvider'
+</script>
+
+<template>
+  <Story title="Calendar/Direction" :layout="{ type: 'single' }">
+    <Variant title="default">
+      <ConfigProvider dir="rtl">
+        <CalendarRoot
+          v-slot="{ weekDays, grid }"
+
+          class="mt-6 rounded-xl border border-black bg-white p-4 shadow-md"
+        >
+          <CalendarHeader class="flex items-center justify-between">
+            <CalendarPrev
+              class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+            >
+              <Icon icon="radix-icons:chevron-left" class="w-6 h-6" />
+            </CalendarPrev>
+
+            <CalendarHeading class="text-[15px] text-black font-medium" />
+
+            <CalendarNext
+              class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+            >
+              <Icon icon="radix-icons:chevron-right" class="w-6 h-6" />
+            </CalendarNext>
+          </CalendarHeader>
+
+          <div
+            class="flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0"
+          >
+            <CalendarGrid v-for="month in grid" :key="month.value.toString()" class="w-full border-collapse select-none space-y-1">
+              <CalendarGridHead>
+                <CalendarGridRow class="mb-1 grid w-full grid-cols-7">
+                  <CalendarHeadCell
+                    v-for="day in weekDays" :key="day"
+                    class="rounded-md text-xs !font-normal text-black"
+                  >
+                    {{ day }}
+                  </CalendarHeadCell>
+                </CalendarGridRow>
+              </CalendarGridHead>
+              <CalendarGridBody class="grid">
+                <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="grid grid-cols-7">
+                  <CalendarCell
+                    v-for="weekDate in weekDates"
+                    :key="weekDate.toString()"
+                    :date="weekDate"
+                    class="relative text-center text-sm"
+                  >
+                    <CalendarCellTrigger
+                      :day="weekDate"
+                      :month="month.value"
+                      class="relative flex items-center justify-center whitespace-nowrap rounded-lg border border-transparent bg-transparent text-sm font-normal text-black w-8 h-8 outline-none focus:shadow-[0_0_0_2px] focus:shadow-black hover:border-black data-[selected]:bg-black data-[selected]:font-medium data-[disabled]:text-black/30 data-[selected]:text-white data-[unavailable]:text-black/30 data-[unavailable]:line-through before:absolute before:top-[5px] before:hidden before:rounded-full before:w-1 before:h-1 before:bg-white data-[today]:before:block data-[today]:before:bg-grass9 data-[selected]:before:bg-white"
+                    />
+                  </CalendarCell>
+                </CalendarGridRow>
+              </CalendarGridBody>
+            </CalendarGrid>
+          </div>
+        </CalendarRoot>
+      </ConfigProvider>
+    </Variant>
+  </Story>
+</template>

--- a/packages/radix-vue/src/DateField/DateFieldRoot.vue
+++ b/packages/radix-vue/src/DateField/DateFieldRoot.vue
@@ -3,7 +3,7 @@ import { type DateValue, isEqualDay } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
-import { type Formatter, createContext, useDateFormatter, useKbd } from '@/shared'
+import { type Formatter, createContext, useDateFormatter, useDirection, useKbd } from '@/shared'
 import {
   type Granularity,
   type HourCycle,
@@ -15,6 +15,7 @@ import {
   isBefore,
 } from '@/shared/date'
 import { createContent, initializeSegmentValues, isSegmentNavigationKey, syncSegmentValues } from './utils'
+import type { Direction } from '@/shared/types'
 
 type DateFieldRootContext = {
   locale: Ref<string>
@@ -66,6 +67,8 @@ export interface DateFieldRootProps extends PrimitiveProps {
   required?: boolean
   /** Id of the element */
   id?: string
+  /** The reading direction of the date field when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
+  dir?: Direction
 }
 
 export type DateFieldRootEmits = {
@@ -108,9 +111,10 @@ defineSlots<{
   }): any
 }>()
 
-const { locale, disabled, readonly, isDateUnavailable: propsIsDateUnavailable, granularity } = toRefs(props)
+const { locale, disabled, readonly, isDateUnavailable: propsIsDateUnavailable, granularity, dir: propDir } = toRefs(props)
 
 const formatter = useDateFormatter(props.locale)
+const dir = useDirection(propDir)
 const { primitiveElement, currentElement: parentElement }
   = usePrimitiveElement()
 const segmentElements = ref<Set<HTMLElement>>(new Set())
@@ -201,16 +205,21 @@ const currentSegmentIndex = computed(() =>
     === currentFocusedElement.value?.getAttribute('data-radix-vue-date-field-segment')))
 
 const nextFocusableSegment = computed(() => {
-  if (currentSegmentIndex.value > segmentElements.value.size - 1)
+  const sign = dir.value === 'rtl' ? -1 : 1
+  const nextCondition = sign < 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
+  if (nextCondition)
     return null
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value + 1]
+  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value + sign]
   return segmentToFocus
 })
+
 const prevFocusableSegment = computed(() => {
-  if (currentSegmentIndex.value < 0)
+  const sign = dir.value === 'rtl' ? -1 : 1
+  const prevCondition = sign > 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
+  if (prevCondition)
     return null
 
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value - 1]
+  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value - sign]
   return segmentToFocus
 })
 
@@ -256,9 +265,15 @@ defineExpose({
 
 <template>
   <Primitive
-    v-bind="$attrs" ref="primitiveElement" role="group" :aria-disabled="disabled ? true : undefined"
-    :data-disabled="disabled ? '' : undefined" :data-readonly="readonly ? '' : undefined"
-    :data-invalid="isInvalid ? '' : undefined" @keydown.left.right="handleKeydown"
+    v-bind="$attrs"
+    ref="primitiveElement"
+    role="group"
+    :aria-disabled="disabled ? true : undefined"
+    :data-disabled="disabled ? '' : undefined"
+    :data-readonly="readonly ? '' : undefined"
+    :data-invalid="isInvalid ? '' : undefined"
+    :dir="dir"
+    @keydown.left.right="handleKeydown"
   >
     <slot :model-value="modelValue" :segments="segmentContents" :is-invalid="isInvalid" />
   </Primitive>

--- a/packages/radix-vue/src/DatePicker/DatePickerCalendar.vue
+++ b/packages/radix-vue/src/DatePicker/DatePickerCalendar.vue
@@ -25,6 +25,7 @@ const rootContext = injectDatePickerRootContext()
       numberOfMonths: rootContext.numberOfMonths.value,
       readonly: rootContext.readonly.value,
       preventDeselect: rootContext.preventDeselect.value,
+      dir: rootContext.dir.value,
     }"
     :model-value="rootContext.modelValue.value"
     :placeholder="rootContext.placeholder.value"

--- a/packages/radix-vue/src/DatePicker/DatePickerField.vue
+++ b/packages/radix-vue/src/DatePicker/DatePickerField.vue
@@ -27,6 +27,7 @@ const rootContext = injectDatePickerRootContext()
       locale: rootContext.locale.value,
       isDateUnavailable: rootContext.isDateUnavailable,
       required: rootContext.required.value,
+      dir: rootContext.dir.value,
     }"
     @update:model-value="(date: DateValue | undefined) => {
       if (date && rootContext.modelValue.value && isEqualDay(rootContext.modelValue.value, date) && date.compare(rootContext.modelValue.value) === 0) return

--- a/packages/radix-vue/src/DatePicker/DatePickerRoot.vue
+++ b/packages/radix-vue/src/DatePicker/DatePickerRoot.vue
@@ -2,10 +2,11 @@
 import { type DateValue, isEqualDay, isSameDay } from '@internationalized/date'
 
 import type { Ref } from 'vue'
-import { createContext } from '@/shared'
+import { createContext, useDirection } from '@/shared'
 import { type Granularity, type HourCycle, type Matcher, type WeekDayFormat, getDefaultDate } from '@/shared/date'
 
 import { type CalendarRootProps, type DateFieldRoot, type DateFieldRootProps, PopoverRoot, type PopoverRootEmits, type PopoverRootProps } from '..'
+import type { Direction } from '@/shared/types'
 
 type DatePickerRootContext = {
   id: Ref<string | undefined>
@@ -35,6 +36,7 @@ type DatePickerRootContext = {
   modal: Ref<boolean>
   onDateChange: (date: DateValue | undefined) => void
   onPlaceholderChange: (date: DateValue) => void
+  dir: Ref<Direction>
 }
 
 export type DatePickerRootProps = DateFieldRootProps & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect'>
@@ -99,7 +101,10 @@ const {
   granularity,
   hideTimeZone,
   hourCycle,
+  dir: propDir,
 } = toRefs(props)
+
+const dir = useDirection(propDir)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? undefined,
@@ -150,6 +155,7 @@ provideDatePickerRootContext({
   hideTimeZone,
   hourCycle,
   dateFieldRef,
+  dir,
   onDateChange(date: DateValue | undefined) {
     if (!date || !modelValue.value)
       modelValue.value = date

--- a/packages/radix-vue/src/DateRangePicker/DateRangePickerCalendar.vue
+++ b/packages/radix-vue/src/DateRangePicker/DateRangePickerCalendar.vue
@@ -25,6 +25,7 @@ const rootContext = injectDateRangePickerRootContext()
       preventDeselect: rootContext.preventDeselect.value,
       minValue: rootContext.minValue.value,
       maxValue: rootContext.maxValue.value,
+      dir: rootContext.dir.value,
     }"
     initial-focus
     :model-value="rootContext.modelValue.value"

--- a/packages/radix-vue/src/DateRangePicker/DateRangePickerField.vue
+++ b/packages/radix-vue/src/DateRangePicker/DateRangePickerField.vue
@@ -27,6 +27,7 @@ const rootContext = injectDateRangePickerRootContext()
       locale: rootContext.locale.value,
       isDateUnavailable: rootContext.isDateUnavailable,
       required: rootContext.required.value,
+      dir: rootContext.dir.value,
     }"
     @update:model-value="(date) => {
       if (date.start && rootContext.modelValue.value.start && date.end && rootContext.modelValue.value.end && date.start.compare(rootContext.modelValue.value.start) === 0 && date.end.compare(rootContext.modelValue.value.end) === 0) return

--- a/packages/radix-vue/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/radix-vue/src/DateRangePicker/DateRangePickerRoot.vue
@@ -2,7 +2,7 @@
 import { type DateValue } from '@internationalized/date'
 
 import type { Ref } from 'vue'
-import { createContext } from '@/shared'
+import { createContext, useDirection } from '@/shared'
 import { type DateRange, type Granularity, type HourCycle, type Matcher, type WeekDayFormat, getDefaultDate } from '@/shared/date'
 
 import { type CalendarRootProps, type DateRangeFieldRoot, type DateRangeFieldRootProps, PopoverRoot, type PopoverRootEmits, type PopoverRootProps } from '..'

--- a/packages/radix-vue/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/radix-vue/src/DateRangePicker/DateRangePickerRoot.vue
@@ -6,6 +6,7 @@ import { createContext } from '@/shared'
 import { type DateRange, type Granularity, type HourCycle, type Matcher, type WeekDayFormat, getDefaultDate } from '@/shared/date'
 
 import { type CalendarRootProps, type DateRangeFieldRoot, type DateRangeFieldRootProps, PopoverRoot, type PopoverRootEmits, type PopoverRootProps } from '..'
+import type { Direction } from '@/shared/types'
 
 type DateRangePickerRootContext = {
   id: Ref<string | undefined>
@@ -35,6 +36,7 @@ type DateRangePickerRootContext = {
   modal: Ref<boolean>
   onDateChange: (date: DateRange) => void
   onPlaceholderChange: (date: DateValue) => void
+  dir: Ref<Direction>
 }
 
 export type DateRangePickerRootProps = DateRangeFieldRootProps & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect'>
@@ -98,7 +100,10 @@ const {
   granularity,
   hideTimeZone,
   hourCycle,
+  dir: propsDir,
 } = toRefs(props)
+
+const dir = useDirection(propsDir)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? { start: undefined, end: undefined },
@@ -149,7 +154,7 @@ provideDateRangePickerRootContext({
   hideTimeZone,
   hourCycle,
   dateFieldRef,
-
+  dir,
   onDateChange(date: DateRange) {
     modelValue.value = { start: date.start?.copy(), end: date.end?.copy() }
   },

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -125,16 +125,17 @@ function handleArrowKey(e: KeyboardEvent) {
   const allCollectionItems: HTMLElement[] = parentElement
     ? Array.from(parentElement.querySelectorAll(SELECTOR))
     : []
+
   const index = allCollectionItems.indexOf(currentElement.value)
   let newIndex = index
   const indexIncrementation = 7
-
+  const sign = rootContext.dir.value === 'rtl' ? -1 : 1
   switch (e.code) {
     case kbd.ARROW_RIGHT:
-      newIndex++
+      newIndex += sign
       break
     case kbd.ARROW_LEFT:
-      newIndex--
+      newIndex -= sign
       break
     case kbd.ARROW_UP:
       newIndex -= indexIncrementation

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
@@ -3,11 +3,12 @@ import { type DateValue, isEqualDay, isSameDay } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
-import { type Formatter, createContext } from '@/shared'
+import { type Formatter, createContext, useDirection } from '@/shared'
 import { createDecade, createYear, getDefaultDate, handleCalendarInitialFocus, isBefore } from '@/shared/date'
 import type { DateRange, Grid, Matcher, WeekDayFormat } from '@/shared/date'
 import { useRangeCalendarState } from './useRangeCalendar'
 import { useCalendar } from '@/Calendar/useCalendar'
+import type { Direction } from '@/shared/types'
 
 type RangeCalendarRootContext = {
   modelValue: Ref<DateRange>
@@ -43,6 +44,7 @@ type RangeCalendarRootContext = {
   isNextButtonDisabled: Ref<boolean>
   isPrevButtonDisabled: Ref<boolean>
   formatter: Formatter
+  dir: Ref<Direction>
 }
 
 export interface RangeCalendarRootProps extends PrimitiveProps {
@@ -84,6 +86,8 @@ export interface RangeCalendarRootProps extends PrimitiveProps {
   isDateDisabled?: Matcher
   /** A function that returns whether or not a date is unavailable */
   isDateUnavailable?: Matcher
+  /** The reading direction of the calendar when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
+  dir?: Direction
 }
 
 export type RangeCalendarRootEmits = {
@@ -155,10 +159,12 @@ const {
   maxValue,
   minValue,
   locale,
+  dir: propsDir,
 } = toRefs(props)
 
 const { primitiveElement, currentElement: parentElement }
   = usePrimitiveElement()
+const dir = useDirection(propsDir)
 
 const lastPressedDateValue = ref() as Ref<DateValue | undefined>
 const focusedValue = ref() as Ref<DateValue | undefined>
@@ -320,7 +326,7 @@ provideRangeCalendarRootContext({
   parentElement,
   onPlaceholderChange,
   locale,
-
+  dir,
 })
 
 onMounted(() => {
@@ -339,6 +345,7 @@ onMounted(() => {
     :data-readonly="readonly ? '' : undefined"
     :data-disabled="disabled ? '' : undefined"
     :data-invalid="isInvalid ? '' : undefined"
+    :dir="dir"
   >
     <div style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;">
       <div role="heading" aria-level="2">


### PR DESCRIPTION
This feature adds support for the `dir` property for all date-related components from `ConfigProvider` or from the HTML tags.

Also added a story in `Calendar` for showcase.

cc @sadeghbarati for the PR and for suggesting the feature