### PR TITLE
fix(useCalendar): grid update condition in watcher

### DIFF
--- a/packages/radix-vue/src/Calendar/CalendarRoot.vue
+++ b/packages/radix-vue/src/Calendar/CalendarRoot.vue
@@ -204,17 +204,17 @@ const {
 } = useCalendar({
   locale,
   placeholder,
-  weekStartsOn: props.weekStartsOn,
-  fixedWeeks: props.fixedWeeks,
-  numberOfMonths: props.numberOfMonths,
+  weekStartsOn,
+  fixedWeeks,
+  numberOfMonths,
   minValue,
   maxValue,
   disabled,
-  weekdayFormat: props.weekdayFormat,
-  pagedNavigation: props.pagedNavigation,
+  weekdayFormat,
+  pagedNavigation,
   isDateDisabled: propsIsDateDisabled.value,
   isDateUnavailable: propsIsDateUnavailable.value,
-  calendarLabel: calendarLabel.value,
+  calendarLabel,
 })
 
 const {

--- a/packages/radix-vue/src/Calendar/story/CalendarDefault.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarDefault.story.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot } from '../'
+import { useMediaQuery } from '@vueuse/core'
+
+const isLargeScreen = useMediaQuery('(min-width: 768px)')
 </script>
 
 <template>
   <Story title="Calendar/Default" :layout="{ type: 'single' }">
     <Variant title="default">
+      {{ isLargeScreen.toString() }}
       <CalendarRoot
         v-slot="{ weekDays, grid }"
-
+        :number-of-months="isLargeScreen ? 2 : 1"
         class="mt-6 rounded-xl border border-black bg-white p-4 shadow-md"
       >
         <CalendarHeader class="flex items-center justify-between">

--- a/packages/radix-vue/src/Calendar/story/CalendarDefault.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarDefault.story.vue
@@ -1,18 +1,13 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot } from '../'
-import { useMediaQuery } from '@vueuse/core'
-
-const isLargeScreen = useMediaQuery('(min-width: 768px)')
 </script>
 
 <template>
   <Story title="Calendar/Default" :layout="{ type: 'single' }">
     <Variant title="default">
-      {{ isLargeScreen.toString() }}
       <CalendarRoot
         v-slot="{ weekDays, grid }"
-        :number-of-months="isLargeScreen ? 2 : 1"
         class="mt-6 rounded-xl border border-black bg-white p-4 shadow-md"
       >
         <CalendarHeader class="flex items-center justify-between">

--- a/packages/radix-vue/src/Calendar/useCalendar.ts
+++ b/packages/radix-vue/src/Calendar/useCalendar.ts
@@ -2,7 +2,7 @@
   * Adapted from https://github.com/melt-ui/melt-ui/blob/develop/src/lib/builders/calendar/create.ts
 */
 
-import { type DateValue, isEqualDay, isSameDay, isSameMonth } from '@internationalized/date'
+import { type DateValue, isSameDay, isSameMonth } from '@internationalized/date'
 import { type Ref, computed, ref, watch } from 'vue'
 import { type Grid, type Matcher, type WeekDayFormat, createMonths, isAfter, isBefore, toDate } from '@/shared/date'
 import { useDateFormatter } from '@/shared'
@@ -165,16 +165,16 @@ export function useCalendar(props: UseCalendarProps) {
     props.placeholder.value = newGrid[0].value.set({ day: 1 })
   }
 
-  watch(props.placeholder, (value, oldValue) => {
-    if (!isEqualDay(value, oldValue)) {
-      grid.value = createMonths({
-        dateObj: value,
-        weekStartsOn: props.weekStartsOn,
-        locale: props.locale.value,
-        fixedWeeks: props.fixedWeeks,
-        numberOfMonths: props.numberOfMonths,
-      })
-    }
+  watch(props.placeholder, (value) => {
+    if (visibleView.value.some(month => isSameMonth(month, value)))
+      return
+    grid.value = createMonths({
+      dateObj: value,
+      weekStartsOn: props.weekStartsOn,
+      locale: props.locale.value,
+      fixedWeeks: props.fixedWeeks,
+      numberOfMonths: props.numberOfMonths,
+    })
   })
 
   const headingValue = computed(() => {

--- a/packages/radix-vue/src/Calendar/useCalendar.ts
+++ b/packages/radix-vue/src/Calendar/useCalendar.ts
@@ -10,17 +10,17 @@ import { useDateFormatter } from '@/shared'
 export type UseCalendarProps = {
   locale: Ref<string>
   placeholder: Ref<DateValue>
-  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
-  fixedWeeks: boolean
-  numberOfMonths: number
+  weekStartsOn: Ref<0 | 1 | 2 | 3 | 4 | 5 | 6>
+  fixedWeeks: Ref<boolean>
+  numberOfMonths: Ref<number>
   minValue: Ref<DateValue | undefined>
   maxValue: Ref<DateValue | undefined>
   disabled: Ref<boolean>
-  weekdayFormat: WeekDayFormat
-  pagedNavigation: boolean
+  weekdayFormat: Ref<WeekDayFormat>
+  pagedNavigation: Ref<boolean>
   isDateDisabled?: Matcher
   isDateUnavailable?: Matcher
-  calendarLabel?: string
+  calendarLabel: Ref<string | undefined>
 }
 
 export type UseCalendarStateProps = {
@@ -76,10 +76,10 @@ export function useCalendar(props: UseCalendarProps) {
 
   const grid = ref<Grid<DateValue>[]>(createMonths({
     dateObj: props.placeholder.value,
-    weekStartsOn: props.weekStartsOn,
+    weekStartsOn: props.weekStartsOn.value,
     locale: props.locale.value,
-    fixedWeeks: props.fixedWeeks,
-    numberOfMonths: props.numberOfMonths,
+    fixedWeeks: props.fixedWeeks.value,
+    numberOfMonths: props.numberOfMonths.value,
   })) as Ref<Grid<DateValue>[]>
 
   const visibleView = computed(() => {
@@ -131,7 +131,7 @@ export function useCalendar(props: UseCalendarProps) {
     if (!grid.value.length)
       return []
     return grid.value[0].rows[0].map((date) => {
-      return formatter.dayOfWeek(toDate(date), props.weekdayFormat)
+      return formatter.dayOfWeek(toDate(date), props.weekdayFormat.value)
     })
   })
 
@@ -139,11 +139,11 @@ export function useCalendar(props: UseCalendarProps) {
     const firstDate = grid.value[0].value
 
     const newGrid = createMonths({
-      dateObj: firstDate.add({ months: props.pagedNavigation ? props.numberOfMonths : 1 }),
-      weekStartsOn: props.weekStartsOn,
+      dateObj: firstDate.add({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }),
+      weekStartsOn: props.weekStartsOn.value,
       locale: props.locale.value,
-      fixedWeeks: props.fixedWeeks,
-      numberOfMonths: props.numberOfMonths,
+      fixedWeeks: props.fixedWeeks.value,
+      numberOfMonths: props.numberOfMonths.value,
     })
 
     grid.value = newGrid
@@ -155,11 +155,11 @@ export function useCalendar(props: UseCalendarProps) {
     const firstDate = grid.value[0].value
 
     const newGrid = createMonths({
-      dateObj: firstDate.subtract({ months: props.pagedNavigation ? props.numberOfMonths : 1 }),
-      weekStartsOn: props.weekStartsOn,
+      dateObj: firstDate.subtract({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }),
+      weekStartsOn: props.weekStartsOn.value,
       locale: props.locale.value,
-      fixedWeeks: props.fixedWeeks,
-      numberOfMonths: props.numberOfMonths,
+      fixedWeeks: props.fixedWeeks.value,
+      numberOfMonths: props.numberOfMonths.value,
     })
 
     props.placeholder.value = newGrid[0].value.set({ day: 1 })
@@ -170,10 +170,20 @@ export function useCalendar(props: UseCalendarProps) {
       return
     grid.value = createMonths({
       dateObj: value,
-      weekStartsOn: props.weekStartsOn,
+      weekStartsOn: props.weekStartsOn.value,
       locale: props.locale.value,
-      fixedWeeks: props.fixedWeeks,
-      numberOfMonths: props.numberOfMonths,
+      fixedWeeks: props.fixedWeeks.value,
+      numberOfMonths: props.numberOfMonths.value,
+    })
+  })
+
+  watch([props.locale, props.weekStartsOn, props.fixedWeeks, props.numberOfMonths], () => {
+    grid.value = createMonths({
+      dateObj: props.placeholder.value,
+      weekStartsOn: props.weekStartsOn.value,
+      locale: props.locale.value,
+      fixedWeeks: props.fixedWeeks.value,
+      numberOfMonths: props.numberOfMonths.value,
     })
   })
 
@@ -205,7 +215,7 @@ export function useCalendar(props: UseCalendarProps) {
     return content
   })
 
-  const fullCalendarLabel = computed(() => `${props.calendarLabel ?? 'Event Date'}, ${headingValue.value}`)
+  const fullCalendarLabel = computed(() => `${props.calendarLabel.value ?? 'Event Date'}, ${headingValue.value}`)
 
   return {
     isDateDisabled,

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
@@ -201,17 +201,17 @@ const {
 } = useCalendar({
   locale,
   placeholder,
-  weekStartsOn: props.weekStartsOn,
-  fixedWeeks: props.fixedWeeks,
-  numberOfMonths: props.numberOfMonths,
+  weekStartsOn,
+  fixedWeeks,
+  numberOfMonths,
   minValue,
   maxValue,
   disabled,
-  weekdayFormat: props.weekdayFormat,
-  pagedNavigation: props.pagedNavigation,
+  weekdayFormat,
+  pagedNavigation,
   isDateDisabled: propsIsDateDisabled.value,
   isDateUnavailable: propsIsDateUnavailable.value,
-  calendarLabel: calendarLabel.value,
+  calendarLabel,
 })
 
 const {


### PR DESCRIPTION
Hello,

This PR fixes an issue with the `Calendar/RangeCalendar` always updating the grid view (with the `numberOfMonths` prop set to a number greater than 1) when selecting a date on a month other than the first in the grid view, even if the date is part of the `visibleView`.

EDIT: This PR also makes all props inside `useCalendar` reactive and adds a watcher to update the `CalendarGrid` on props update.

cc @sadeghbarati for reporting this 🚀 