### PR TITLE
feat(tabs): tabs components accepts string or number values

### DIFF
--- a/docs/content/meta/TabsContent.md
+++ b/docs/content/meta/TabsContent.md
@@ -23,7 +23,7 @@
   {
     'name': 'value',
     'description': '<p>A unique value that associates the content with a trigger.</p>\n',
-    'type': 'string',
+    'type': 'string | number',
     'required': true
   }
 ]" />

--- a/docs/content/meta/TabsRoot.md
+++ b/docs/content/meta/TabsRoot.md
@@ -24,7 +24,7 @@
   {
     'name': 'defaultValue',
     'description': '<p>The value of the tab that should be active when initially rendered. Use when you do not need to control the state of the tabs</p>\n',
-    'type': 'string',
+    'type': 'string | number',
     'required': false
   },
   {
@@ -36,7 +36,7 @@
   {
     'name': 'modelValue',
     'description': '<p>The controlled value of the tab to activate. Can be bind as <code>v-model</code>.</p>\n',
-    'type': 'string',
+    'type': 'string | number',
     'required': false
   },
   {
@@ -52,6 +52,6 @@
   {
     'name': 'update:modelValue',
     'description': '<p>Event handler called when the value changes</p>\n',
-    'type': '[payload: string]'
+    'type': '[payload: StringOrNumber]'
   }
 ]" />

--- a/docs/content/meta/TabsTrigger.md
+++ b/docs/content/meta/TabsTrigger.md
@@ -24,7 +24,7 @@
   {
     'name': 'value',
     'description': '<p>A unique value that associates the trigger with a content.</p>\n',
-    'type': 'string',
+    'type': 'string | number',
     'required': true
   }
 ]" />

--- a/packages/radix-vue/src/Tabs/Tabs.test.ts
+++ b/packages/radix-vue/src/Tabs/Tabs.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { axe } from 'vitest-axe'
 import Tabs from './story/_Tabs.vue'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
+import { axe } from 'vitest-axe'
 
 describe('given default Tabs', () => {
   let wrapper: VueWrapper<InstanceType<typeof Tabs>>
@@ -18,6 +18,7 @@ describe('given default Tabs', () => {
 
   it('should render tab\'s content', () => {
     expect(wrapper.find('[role=tabpanel]').exists()).toBeTruthy()
+
     expect(wrapper.html()).toContain('Make changes')
   })
 

--- a/packages/radix-vue/src/Tabs/TabsContent.vue
+++ b/packages/radix-vue/src/Tabs/TabsContent.vue
@@ -29,6 +29,7 @@ const triggerId = computed(() => makeTriggerId(rootContext.baseId, props.value))
 const contentId = computed(() => makeContentId(rootContext.baseId, props.value))
 
 const isSelected = computed(() => props.value === rootContext.modelValue.value)
+
 const isMountAnimationPreventedRef = ref(isSelected.value)
 
 onMounted(() => {

--- a/packages/radix-vue/src/Tabs/TabsContent.vue
+++ b/packages/radix-vue/src/Tabs/TabsContent.vue
@@ -1,10 +1,11 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
+import type { StringOrNumber } from '@/shared/types'
 
 export interface TabsContentProps extends PrimitiveProps {
   /** A unique value that associates the content with a trigger. */
-  value: string
+  value: StringOrNumber
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.

--- a/packages/radix-vue/src/Tabs/TabsRoot.vue
+++ b/packages/radix-vue/src/Tabs/TabsRoot.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
-import type { DataOrientation, Direction } from '../shared/types'
+import type { DataOrientation, Direction, StringOrNumber } from '../shared/types'
 import { createContext, useDirection, useForwardExpose, useId } from '@/shared'
 
 export interface TabsRootContext {
-  modelValue: Ref<string | undefined>
-  changeModelValue: (value: string) => void
+  modelValue: Ref<StringOrNumber | undefined>
+  changeModelValue: (value: StringOrNumber) => void
   orientation: Ref<DataOrientation>
   dir: Ref<Direction>
   activationMode: 'automatic' | 'manual'
@@ -18,7 +18,7 @@ export interface TabsRootProps extends PrimitiveProps {
   /**
    * The value of the tab that should be active when initially rendered. Use when you do not need to control the state of the tabs
    */
-  defaultValue?: string
+  defaultValue?: StringOrNumber
   /**
    * The orientation the tabs are layed out.
    * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
@@ -35,11 +35,11 @@ export interface TabsRootProps extends PrimitiveProps {
    */
   activationMode?: 'automatic' | 'manual'
   /** The controlled value of the tab to activate. Can be bind as `v-model`. */
-  modelValue?: string
+  modelValue?: StringOrNumber
 }
 export type TabsRootEmits = {
   /** Event handler called when the value changes */
-  'update:modelValue': [payload: string]
+  'update:modelValue': [payload: StringOrNumber]
 }
 
 export const [injectTabsRootContext, provideTabsRootContext]
@@ -69,7 +69,7 @@ const tabsList = ref<HTMLElement>()
 
 provideTabsRootContext({
   modelValue,
-  changeModelValue: (value: string) => {
+  changeModelValue: (value: StringOrNumber) => {
     modelValue.value = value
   },
   orientation,

--- a/packages/radix-vue/src/Tabs/TabsTrigger.vue
+++ b/packages/radix-vue/src/Tabs/TabsTrigger.vue
@@ -1,10 +1,11 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
+import type { StringOrNumber } from '@/shared/types'
 
 export interface TabsTriggerProps extends PrimitiveProps {
   /** A unique value that associates the trigger with a content. */
-  value: string
+  value: StringOrNumber
   /** When `true`, prevents the user from interacting with the tab. */
   disabled?: boolean
 }

--- a/packages/radix-vue/src/Tabs/story/_Tabs.vue
+++ b/packages/radix-vue/src/Tabs/story/_Tabs.vue
@@ -5,7 +5,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '../'
 <template>
   <TabsRoot
     class="flex flex-col w-[300px] shadow-[0_2px_10px] shadow-blackA4"
-    default-value="tab1"
+    :default-value="1"
   >
     <TabsList
       class="shrink-0 flex border-b border-mauve6"
@@ -13,7 +13,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '../'
     >
       <TabsTrigger
         class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none first:rounded-tl-md last:rounded-tr-md hover:text-violet11 data-[state=active]:text-violet11 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=active]:shadow-current data-[state=active]:focus:relative data-[state=active]:focus:shadow-[0_0_0_2px] data-[state=active]:focus:shadow-black outline-none cursor-default"
-        value="tab1"
+        :value="1"
       >
         Account
       </TabsTrigger>
@@ -26,7 +26,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '../'
     </TabsList>
     <TabsContent
       class="grow p-5 bg-white rounded-b-md outline-none focus:shadow-[0_0_0_2px] focus:shadow-black"
-      value="tab1"
+      :value="1"
     >
       <p class="mb-5 text-mauve11 text-[15px] leading-normal">
         Make changes to your account here. Click save when you're done.

--- a/packages/radix-vue/src/Tabs/utils.ts
+++ b/packages/radix-vue/src/Tabs/utils.ts
@@ -1,7 +1,9 @@
-export function makeTriggerId(baseId: string, value: string) {
+import type { StringOrNumber } from '@/shared/types'
+
+export function makeTriggerId(baseId: string, value: StringOrNumber) {
   return `${baseId}-trigger-${value}`
 }
 
-export function makeContentId(baseId: string, value: string) {
+export function makeContentId(baseId: string, value: StringOrNumber) {
   return `${baseId}-content-${value}`
 }

--- a/packages/radix-vue/src/shared/types.ts
+++ b/packages/radix-vue/src/shared/types.ts
@@ -43,4 +43,6 @@ type ScrollBodyOption = {
   margin?: boolean | number
 }
 
-export type { DataOrientation, Direction, Type, SingleOrMultipleProps, SingleOrMultipleType, ScrollBodyOption }
+type StringOrNumber = string | number
+
+export type { DataOrientation, Direction, Type, SingleOrMultipleProps, SingleOrMultipleType, ScrollBodyOption, StringOrNumber }


### PR DESCRIPTION
Hi! 👋🏻 Closes #820 

## Changed
- `TabsTrigger`, `TabsRoot`, `TabsContent` components now accept `string` or `number` values
- `defaultValue` in `TabsRoot` component now accept `string` or `number` values
- utils function for generating contentId and triggerId now accept value as `string` or `number`

## Types

- create type `StringOrNumber` in `shared/types`.

## Tests
- update testing component template for using numbers and strings. All tests passed

## Docs
- gen docs