### PR TITLE
docs: reference hydration section in SSR page

### DIFF
--- a/docs/content/guides/server-side-rendering.md
+++ b/docs/content/guides/server-side-rendering.md
@@ -17,11 +17,6 @@ Static rendering is another similar approach. Instead it pre-renders pages to HT
 
 You should be able to use all of our primitives with both approaches, for example with [Nuxt.js](https://nuxt.com/).
 
-::: info
-Some components' state might not rendered correctly in server-side, we are working on fixing it. If you encoutered any issue, feel free to open a ticket.
-:::
-
-
 ## Nuxt Hydration issue (Vue < 3.5) 
 
 Radix Vue offers a [Nuxt module](/overview/installation.html#nuxt-modules) that supports auto importing components. However, if you are using Vue < 3.5, minor hydration issues might arise because as of vue <= 3.4 there is [currently no way](https://github.com/vuejs/rfcs/discussions/557) to ensure consistent DOM element `id` between the client and server renders. This is something that Radix Vue relies on.

--- a/docs/content/guides/server-side-rendering.md
+++ b/docs/content/guides/server-side-rendering.md
@@ -1,10 +1,7 @@
 ---
-
 title: Server side rendering
 description: Radix Primitives can be rendered on the server.
 ---
-
-
 
 # Server side rendering
 
@@ -23,3 +20,12 @@ You should be able to use all of our primitives with both approaches, for exampl
 ::: info
 Some components' state might not rendered correctly in server-side, we are working on fixing it. If you encoutered any issue, feel free to open a ticket.
 :::
+
+
+## Nuxt Hydration issue (Vue < 3.5) 
+
+Radix Vue offers a [Nuxt module](/overview/installation.html#nuxt-modules) that supports auto importing components. However, if you are using Vue < 3.5, minor hydration issues might arise because as of vue <= 3.4 there is [currently no way](https://github.com/vuejs/rfcs/discussions/557) to ensure consistent DOM element `id` between the client and server renders. This is something that Radix Vue relies on.
+
+As a temporary workaround, we expose a way to allow Nuxt (with version > `3.10`) inject it's `useId` implementation to `radix-vue`. 
+
+To provide a custom `useId` implementation, please follow this [guide](/utilities/config-provider.html#hydration-issue-vue-3-5).


### PR DESCRIPTION
Thanks for supporting custom `useId` implementation ! It seems it went under my radar.
Since this is an SSR issue, I've added some information on SSR page from `ConfigProvider` section.