### PR TITLE
fix: made it so that the pnpm build succeeds right after cloning

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "story:dev": "pnpm --filter histoire story:dev",
-    "build": "rimraf packages/radix-vue/dist  && pnpm run -r build",
+    "build": "rimraf packages/radix-vue/dist  && pnpm run --filter radix-vue build && pnpm run --filter plugins build",
     "build-only": "rimraf packages/radix-vue/dist  && pnpm run -r build-only",
     "docs:install": "pnpm --filter docs install",
     "docs:dev": "pnpm --filter docs docs:dev",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@nuxt/kit": "npm:@nuxt/kit@latest",
     "@nuxt/schema": "latest",
-    "radix-vue": "file:../radix-vue",
+    "radix-vue": "link:../radix-vue",
     "tsx": "^4.1.2",
     "unbuild": "^2.0.0",
     "unplugin-vue-components": "^0.25.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: latest
         version: 3.10.3(rollup@3.29.4)
       radix-vue:
-        specifier: file:../radix-vue
-        version: file:packages/radix-vue(vue@3.4.21)
+        specifier: link:../radix-vue
+        version: link:../radix-vue
       tsx:
         specifier: ^4.1.2
         version: 4.7.1
@@ -10725,26 +10725,3 @@ packages:
     optionalDependencies:
       commander: 9.5.0
     dev: true
-
-  file:packages/radix-vue(vue@3.4.21):
-    resolution: {directory: packages/radix-vue, type: directory}
-    id: file:packages/radix-vue
-    name: radix-vue
-    peerDependencies:
-      vue: '>= 3.2.0'
-    dependencies:
-      '@floating-ui/dom': 1.6.3
-      '@floating-ui/vue': 1.0.6(vue@3.4.21)
-      '@internationalized/date': 3.5.2
-      '@tanstack/vue-virtual': 3.1.3(vue@3.4.21)
-      '@vueuse/components': 10.9.0(vue@3.4.21)
-      '@vueuse/core': 10.9.0(vue@3.4.21)
-      '@vueuse/shared': 10.9.0(vue@3.4.21)
-      aria-hidden: 1.2.3
-      defu: 6.1.4
-      fast-deep-equal: 3.1.3
-      nanoid: 5.0.6
-      vue: 3.4.21(typescript@5.4.2)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-    dev: false


### PR DESCRIPTION
I cloned a repository and then ran `pnpm install` followed by `pnpm build`. However, the build failed because it was attempting to build radix-vue and plugins in parallel, even though plugins depends on radix-vue. To fix this, I modified the build command to process the packages sequentially and changed how plugins package references radix-vue from a file protocol to a link protocol.

**Environment**
Developement/Production OS: macOS
Node version: 20.4.0
Package manager: pnpm@8.15.2
Radix Vue version: 1.7.0

**Error Output**
```
Scope: 4 of 5 workspace projects
packages/radix-vue build$ pnpm type-check && pnpm build-only
[6 lines collapsed]
│ ✓ 841 modules transformed.
│ rendering chunks...
│ [vite:dts] Start generate declaration files...
│ computing gzip size...
│ dist/date.js     4.59 kB │ gzip:   1.63 kB
│ dist/index.js  539.27 kB │ gzip: 114.98 kB
│ [vite:dts] Declaration files built in 12029ms.
│ dist/date.umd.cjs     3.65 kB │ gzip:  1.45 kB
│ dist/index.umd.cjs  412.11 kB │ gzip: 97.25 kB
│ ✓ built in 15.15s
└─ Done in 26.7s
packages/plugins build$ unbuild
│ ℹ Building Nuxt module
│ ✔ Build succeeded for Nuxt module
│   ../radix-vue/dist/nuxt/index.cjs (total size: 8.19 kB, chunk size: 8.19 kB, exports: default)
│   ../radix-vue/dist/nuxt/index.mjs (total size: 8.19 kB, chunk size: 8.19 kB, exports: default)
│ Σ Total dist size (byte size): 1.67 MB
│ ℹ Building Unplugin-vue-component Resolver
│ ✔ Build succeeded for Unplugin-vue-component Resolver
│   ../radix-vue/dist/resolver/index.cjs (total size: 7.85 kB, chunk size: 7.85 kB, exports: default)
│   ../radix-vue/dist/resolver/index.mjs (total size: 7.84 kB, chunk size: 7.84 kB, exports: default)
│ Σ Total dist size (byte size): 1.68 MB
│ ℹ Building Namespaced
│ src/namespaced/index.ts(1,4631): error TS2307: Cannot find module 'radix-vue' or its corresponding type declarations.
│  ERROR  Error building /Users/mano/ghq/github.com/shoma-mano/radix-vue/packages/plugins: RollupError: Failed to comp…
│  ERROR  Failed to compile. Check the logs above.
│   at error (/Users/mano/ghq/github.com/shoma-mano/radix-vue/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dis…
│   at Object.error (/Users/mano/ghq/github.com/shoma-mano/radix-vue/node_modules/.pnpm/rollup@3.29.4/node_modules/rol…
│   at Object.error (/Users/mano/ghq/github.com/shoma-mano/radix-vue/node_modules/.pnpm/rollup@3.29.4/node_modules/rol…
│   at generateDtsFromTs (/Users/mano/ghq/github.com/shoma-mano/radix-vue/node_modules/.pnpm/rollup-plugin-dts@6.1.0_r…
│   at Object.transform (/Users/mano/ghq/github.com/shoma-mano/radix-vue/node_modules/.pnpm/rollup-plugin-dts@6.1.0_ro…
│   at /Users/mano/ghq/github.com/shoma-mano/radix-vue/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/sh…
│   at process.processTicksAndRejections (node:internal/process/task_queues:95:5) 
│  ERROR  Failed to compile. Check the logs above.
└─ Failed in 2.8s at /Users/mano/ghq/github.com/shoma-mano/radix-vue/packages/plugins
/Users/mano/ghq/github.com/shoma-mano/radix-vue/packages/plugins:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  plugins@1.7.0 build: `unbuild`
Exit status 1
``