### PR TITLE
Docs: fix link color in tip blocks on light theme

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -16,7 +16,8 @@
   --vp-c-brand-darker: #047857;
   --vp-c-brand-dimm: rgba(100, 108, 255, 0.08);
   --vp-c-tip-soft: #5bb98c;
-  --vp-c-tip-1: white;
+  --vp-c-tip-1: var(--vp-c-brand-darker);
+
   --vp-code-color: rgba(60, 60, 67);
   --vp-code-block-bg: #292b30;
   --vp-code-block-bg-light: #1e1e20;
@@ -29,6 +30,8 @@
   --vp-c-bg-alt: #161618;
   --vp-c-bg-soft: #252529;
   --vp-code-block-bg: #161618;
+  --vp-c-tip-1: white;
+
 }
 /* --vp-c-bg-elv: #252529;
 --vp-c-bg-elv-up: #313136;


### PR DESCRIPTION
While reading the documentation, I noticed that in light mode, the color of links in the TIP blocks maintains the value of the dark theme. 

This PR sets a more legible color for those links. I selected `--vp-c-brand-darker`, the darker out of the brand colors, because I think the one used elsewhere (`--vp-c-brand-1`) doesn't have enough contrast on the block's background. 

**Before**

<img width="655" alt="image" src="https://github.com/radix-vue/radix-vue/assets/104721/89ed5ba6-2bfc-4a30-87d3-8e08caf8509e">

**After**
<img width="650" alt="image" src="https://github.com/radix-vue/radix-vue/assets/104721/4c833a32-44ee-4ba1-8ac0-8552b5d90957">
