### PR TITLE
fix(useCalendar): fix grid not working on prev page

### DIFF
--- a/packages/radix-vue/src/Calendar/useCalendar.ts
+++ b/packages/radix-vue/src/Calendar/useCalendar.ts
@@ -162,6 +162,8 @@ export function useCalendar(props: UseCalendarProps) {
       numberOfMonths: props.numberOfMonths.value,
     })
 
+    grid.value = newGrid
+
     props.placeholder.value = newGrid[0].value.set({ day: 1 })
   }
 


### PR DESCRIPTION
This PR fixes an issue with the `Calendar` and `RangeCalendar` not updating the grid if `number-of-months` was larger than 1.

Kudos to @JustinBordage for finding this issue in `shadcn` and providing a fix: https://github.com/radix-vue/shadcn-vue/issues/500.

Should fix downstream issue in `shadcn`.

cc @sadeghbarati 