### PR TITLE
fix(pagination): set pageCount minimal value is 1

### DIFF
--- a/packages/radix-vue/src/Pagination/Pagination.test.ts
+++ b/packages/radix-vue/src/Pagination/Pagination.test.ts
@@ -167,3 +167,27 @@ describe('given small total value', () => {
     })
   })
 })
+
+describe('given 0 total value', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Pagination>>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(Pagination, { attachTo: document.body, props: { total: 0 } })
+  })
+
+  it('should pass axe accessibility tests', async () => {
+    expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  it('should have first page selected by default', () => {
+    expect(wrapper.find('[aria-label="Page 1"]').attributes('data-selected')).toBe('true')
+  })
+
+  it('all button should disabled', () => {
+    expect(wrapper.find('[aria-label="First Page"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('[aria-label="Previous Page"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('[aria-label="Next Page"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('[aria-label="Last Page"]').attributes('disabled')).toBeDefined()
+  })
+})

--- a/packages/radix-vue/src/Pagination/PaginationRoot.vue
+++ b/packages/radix-vue/src/Pagination/PaginationRoot.vue
@@ -72,7 +72,7 @@ const page = useVModel(props, 'page', emits, {
   passive: (props.page === undefined) as false,
 }) as Ref<number>
 
-const pageCount = computed(() => Math.ceil(props.total / props.itemsPerPage))
+const pageCount = computed(() => Math.max(1, Math.ceil(props.total / props.itemsPerPage)))
 
 providePaginationRootContext({
   page,


### PR DESCRIPTION
this PR to fix Pagination component abnormal behaviours when total is 0:
1. `PaginationList` items is [] when total is 0
2. `PaginationNext` is clickable when total is 0

### Demo
<img width="194" alt="image" src="https://github.com/radix-vue/radix-vue/assets/30513719/966a38d5-ae84-495a-96fd-105b34e3d7bd">
