### PR TITLE
docs: improve Tabs docs

### DIFF
--- a/docs/components/demo/Tabs/tailwind/index.vue
+++ b/docs/components/demo/Tabs/tailwind/index.vue
@@ -5,17 +5,17 @@ import { TabsContent, TabsIndicator, TabsList, TabsRoot, TabsTrigger } from 'rad
 <template>
   <TabsRoot class="flex flex-col w-full sm:w-[300px] shadow-[0_2px_10px] shadow-blackA4" default-value="tab1">
     <TabsList class="relative shrink-0 flex border-b border-mauve6" aria-label="Manage your account">
-      <TabsIndicator class="absolute px-8 left-0 h-[2px] bottom-0 w-[--radix-tabs-indicator-size] translate-x-[--radix-tabs-indicator-position] rounded-full">
+      <TabsIndicator class="absolute px-8 left-0 h-[2px] bottom-0 w-[--radix-tabs-indicator-size] translate-x-[--radix-tabs-indicator-position] rounded-full transition-[width,transform] duration-300">
         <div class="bg-grass8 w-full h-full" />
       </TabsIndicator>
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tl-md  hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus:relative focus:shadow-[0_0_0_2px] focus:shadow-black"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tl-md  hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-black"
         value="tab1"
       >
         Account
       </TabsTrigger>
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tr-md hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus:relative focus:shadow-[0_0_0_2px] focus:shadow-black"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tr-md hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-black"
         value="tab2"
       >
         Password

--- a/docs/components/demo/Tabs/tailwind/index.vue
+++ b/docs/components/demo/Tabs/tailwind/index.vue
@@ -5,17 +5,17 @@ import { TabsContent, TabsIndicator, TabsList, TabsRoot, TabsTrigger } from 'rad
 <template>
   <TabsRoot class="flex flex-col w-full sm:w-[300px] shadow-[0_2px_10px] shadow-blackA4" default-value="tab1">
     <TabsList class="relative shrink-0 flex border-b border-mauve6" aria-label="Manage your account">
-      <TabsIndicator class="absolute px-8 left-0 h-[2px] bottom-0 w-[--radix-tabs-indicator-size] translate-x-[--radix-tabs-indicator-position] rounded-full transition-[width,transform] duration-300">
+      <TabsIndicator class="absolute px-8 left-0 h-[2px] bottom-0 w-[--radix-tabs-indicator-size] translate-x-[--radix-tabs-indicator-position] rounded-full">
         <div class="bg-grass8 w-full h-full" />
       </TabsIndicator>
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tl-md  hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tl-md  hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus:relative focus:shadow-[0_0_0_2px] focus:shadow-black"
         value="tab1"
       >
         Account
       </TabsTrigger>
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tr-md hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none  rounded-tr-md hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus:relative focus:shadow-[0_0_0_2px] focus:shadow-black"
         value="tab2"
       >
         Password

--- a/docs/content/meta/TabsRoot.md
+++ b/docs/content/meta/TabsRoot.md
@@ -3,7 +3,7 @@
 <PropsTable :data="[
   {
     'name': 'activationMode',
-    'description': '<p>Whether a tab is activated automatically or manually.</p>\n',
+    'description': '<p>Whether a tab is activated automatically (on focus) or manually (on click).</p>\n',
     'type': '\'automatic\' | \'manual\'',
     'required': false,
     'default': '\'automatic\''

--- a/packages/radix-vue/src/Tabs/TabsRoot.vue
+++ b/packages/radix-vue/src/Tabs/TabsRoot.vue
@@ -30,7 +30,7 @@ export interface TabsRootProps extends PrimitiveProps {
    */
   dir?: Direction
   /**
-   * Whether a tab is activated automatically or manually.
+   * Whether a tab is activated automatically (on focus) or manually (on click).
    * @defaultValue automatic
    */
   activationMode?: 'automatic' | 'manual'


### PR DESCRIPTION
Adds explanation for `activationMode` prop on `TabsRoot`.
Adds outline shadow on `TabsTrigger` focus for Tabs demo. I removed the animation on `TabsIndicator` because it doesn't make sense with the shadow.