### PR TITLE
refactor(useCalendar): include calendar identifier when computing heading value

### DIFF
--- a/docs/components/demo/CalendarSelect/css/index.vue
+++ b/docs/components/demo/CalendarSelect/css/index.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { createCalendar, getLocalTimeZone, toCalendar, today } from '@internationalized/date'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot, Label, SelectContent, SelectItem, SelectItemIndicator, SelectItemText, SelectPortal, SelectRoot, SelectScrollUpButton, SelectTrigger, SelectValue, SelectViewport } from 'radix-vue'
+import { computed, ref } from 'vue'
+
+const preferences = [
+  { locale: 'en-US', label: 'Default', ordering: 'gregory' },
+  { label: 'Arabic (Algeria)', locale: 'ar-DZ', territories: 'DJ DZ EH ER IQ JO KM LB LY MA MR OM PS SD SY TD TN YE', ordering: 'gregory islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (United Arab Emirates)', locale: 'ar-AE', territories: 'AE BH KW QA', ordering: 'gregory islamic-umalqura islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (Egypt)', locale: 'AR-EG', territories: 'EG', ordering: 'gregory coptic islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (Saudi Arabia)', locale: 'ar-SA', territories: 'SA', ordering: 'islamic-umalqura gregory islamic islamic-rgsa' },
+  { label: 'Farsi (Afghanistan)', locale: 'fa-AF', territories: 'AF IR', ordering: 'persian gregory islamic islamic-civil islamic-tbla' },
+  { label: 'Amharic (Ethiopia)', locale: 'am-ET', territories: 'ET', ordering: 'gregory ethiopic ethioaa' },
+  { label: 'Hebrew (Israel)', locale: 'he-IL', territories: 'IL', ordering: 'gregory hebrew islamic islamic-civil islamic-tbla' },
+  { label: 'Hindi (India)', locale: 'hi-IN', territories: 'IN', ordering: 'gregory indian' },
+  { label: 'Japanese (Japan)', locale: 'ja-JP', territories: 'JP', ordering: 'gregory japanese' },
+  { label: 'Thai (Thailand)', locale: 'th-TH', territories: 'TH', ordering: 'buddhist gregory' },
+  { label: 'Chinese (Taiwan)', locale: 'zh-TW', territories: 'TW', ordering: 'gregory roc chinese' },
+]
+
+const calendars = [
+  { key: 'gregory', name: 'Gregorian' },
+  { key: 'japanese', name: 'Japanese' },
+  { key: 'buddhist', name: 'Buddhist' },
+  { key: 'roc', name: 'Taiwan' },
+  { key: 'persian', name: 'Persian' },
+  { key: 'indian', name: 'Indian' },
+  { key: 'islamic-umalqura', name: 'Islamic (Umm al-Qura)' },
+  { key: 'islamic-civil', name: 'Islamic Civil' },
+  { key: 'islamic-tbla', name: 'Islamic Tabular' },
+  { key: 'hebrew', name: 'Hebrew' },
+  { key: 'coptic', name: 'Coptic' },
+  { key: 'ethiopic', name: 'Ethiopic' },
+  { key: 'ethioaa', name: 'Ethiopic (Amete Alem)' },
+]
+
+const locale = ref(preferences[0].locale)
+const calendar = ref(calendars[0].key)
+
+const pref = computed(() => preferences.find(p => p.locale === locale.value))
+const preferredCalendars = computed(() => pref.value ? pref.value.ordering.split(' ').map(p => calendars.find(c => c.key === p)).filter(Boolean) : [calendars[0]])
+const otherCalendars = computed(() => calendars.filter(c => !preferredCalendars.value.some(p => p!.key === c.key)))
+
+function updateLocale(newLocale: string) {
+  locale.value = newLocale
+  calendar.value = pref.value!.ordering.split(' ')[0]
+}
+const value = computed(() => toCalendar(today(getLocalTimeZone()), createCalendar(calendar.value)))
+</script>
+
+<template>
+  <div class="Wrapper">
+    <Label class="Label">Locale</Label>
+    <SelectRoot v-model="locale" @update:model-value="updateLocale">
+      <SelectTrigger
+        class="SelectTrigger"
+        aria-label="Select a locale"
+      >
+        <SelectValue placeholder="Please select a locale">
+          {{ pref!.label }}
+        </SelectValue>
+        <Icon icon="radix-icons:chevron-down" class="Icon" />
+      </SelectTrigger>
+
+      <SelectPortal>
+        <SelectContent
+          class="SelectContent"
+          :side-offset="5"
+        >
+          <SelectScrollUpButton class="SelectScrollButton">
+            <Icon icon="radix-icons:chevron-up" />
+          </SelectScrollUpButton>
+
+          <SelectViewport class="SelectViewport">
+            <SelectItem
+              v-for="(option, index) in preferences"
+              :key="index"
+              class="SelectItem"
+              :value="option.locale"
+            >
+              <SelectItemIndicator class="SelectItemIndicator">
+                <Icon icon="radix-icons:check" />
+              </SelectItemIndicator>
+              <SelectItemText>
+                {{ option.label }}
+              </SelectItemText>
+            </SelectItem>
+          </SelectViewport>
+
+          <SelectScrollDownButton class="SelectScrollButton">
+            <Icon icon="radix-icons:chevron-down" />
+          </SelectScrollDownButton>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+    <Label class="Label">Calendar</Label>
+    <SelectRoot v-model="calendar">
+      <SelectTrigger
+        class="SelectTrigger"
+        aria-label="Select a calendar"
+      >
+        <SelectValue placeholder="Please select a calendar">
+          {{ calendars.find(c => c.key === calendar)?.name }}
+        </SelectValue>
+
+        <Icon icon="radix-icons:chevron-down" class="Icon" />
+      </SelectTrigger>
+
+      <SelectPortal>
+        <SelectContent
+          class="SelectContent"
+          :side-offset="5"
+        >
+          <SelectScrollUpButton class="SelectScrollButton">
+            <Icon icon="radix-icons:chevron-up" />
+          </SelectScrollUpButton>
+
+          <SelectViewport class="SelectViewport">
+            <SelectLabel class="SelectLabel">
+              Preferred
+            </SelectLabel>
+            <SelectGroup>
+              <SelectItem
+                v-for="(option, index) in preferredCalendars"
+                :key="index"
+                class="SelectItem"
+                :value="option!.key"
+              >
+                <SelectItemIndicator class="SelectItemIndicator">
+                  <Icon icon="radix-icons:check" />
+                </SelectItemIndicator>
+                <SelectItemText>
+                  {{ option!.name }}
+                </SelectItemText>
+              </SelectItem>
+            </SelectGroup>
+            <SelectSeparator class="SelectSeparator" />
+            <SelectLabel class="SelectLabel">
+              Other
+            </SelectLabel>
+            <SelectGroup>
+              <SelectItem
+                v-for="(option, index) in otherCalendars"
+                :key="index"
+                class="SelectItem"
+                :value="option.key"
+              >
+                <SelectItemIndicator class="SelectItemIndicator">
+                  <Icon icon="radix-icons:check" />
+                </SelectItemIndicator>
+                <SelectItemText>
+                  {{ option.name }}
+                </SelectItemText>
+              </SelectItem>
+            </SelectGroup>
+          </SelectViewport>
+
+          <SelectScrollDownButton class="SelectScrollButton">
+            <Icon icon="radix-icons:chevron-down" />
+          </SelectScrollDownButton>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+    <CalendarRoot
+      v-slot="{ weekDays, grid }"
+      :model-value="value"
+      :locale="locale"
+      class="Calendar"
+      fixed-weeks
+    >
+      <CalendarHeader class="CalendarHeader">
+        <CalendarPrev
+          class="CalendarNavButton"
+        >
+          <Icon icon="radix-icons:chevron-left" class="Icon" />
+        </CalendarPrev>
+        <CalendarHeading class="CalendarHeading" />
+        <CalendarNext
+          class="CalendarNavButton"
+        >
+          <Icon icon="radix-icons:chevron-right" class="Icon" />
+        </CalendarNext>
+      </CalendarHeader>
+      <div
+        class="CalendarWrapper"
+      >
+        <CalendarGrid v-for="month in grid" :key="month.value.toString()" class="CalendarGrid">
+          <CalendarGridHead>
+            <CalendarGridRow class="CalendarGridRow">
+              <CalendarHeadCell
+                v-for="day in weekDays" :key="day"
+                class="CalendarHeadCell"
+              >
+                {{ day }}
+              </CalendarHeadCell>
+            </CalendarGridRow>
+          </CalendarGridHead>
+          <CalendarGridBody class="CalendarGridWrapper">
+            <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="CalendarGridRow">
+              <CalendarCell
+                v-for="weekDate in weekDates"
+                :key="weekDate.toString()"
+                :date="weekDate"
+                class="CalendarCell"
+              >
+                <CalendarCellTrigger
+                  :day="weekDate"
+                  :month="month.value"
+                  class="CalendarCellTrigger"
+                />
+              </CalendarCell>
+            </CalendarGridRow>
+          </CalendarGridBody>
+        </CalendarGrid>
+      </div>
+    </CalendarRoot>
+  </div>
+</template>

--- a/docs/components/demo/CalendarSelect/css/styles.css
+++ b/docs/components/demo/CalendarSelect/css/styles.css
@@ -1,0 +1,261 @@
+@import '@radix-ui/colors/black-alpha.css';
+@import '@radix-ui/colors/grass.css';
+
+.Icon {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.Calendar {
+  margin-top: 1.5rem;
+  border-width: 1px;
+  border-color: #000000;
+  background-color: #ffffff;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  padding: 22px;
+}
+
+.CalendarHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.CalendarNavButton {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: #000000;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.CalendarNavButton:hover {
+  color: #ffffff;
+  background-color: #000000;
+}
+
+.CalendarHeading {
+  font-weight: 500;
+  color: #000000;
+  color: 15px;
+}
+
+.CalendarWrapper {
+  display: flex;
+  padding-top: 1rem;
+  margin-top: 1rem;
+  flex-direction: column;
+}
+
+@media (min-width: 640px) {
+  .CalendarWrapper {
+    margin-left: 1rem;
+    margin-top: 0;
+    flex-direction: row;
+  }
+}
+
+.CalendarGrid {
+  margin-top: 0.25rem;
+  width: 100%;
+  user-select: none;
+  border-collapse: collapse;
+}
+
+.CalendarGridRow {
+  display: grid
+  margin-bottom: 0.25rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  width: 100%;
+}
+
+.CalendarGridRow[data-radix-vue-calendar-month-view] {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.CalendarHeadCell {
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #000000;
+  font-weight: 400;
+}
+
+.CalendarCell {
+  position: relative;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: center;
+}
+
+.CalendarCellTrigger {
+  display: flex;
+  position: relative;
+  padding: 0.5rem;
+  justify-content: center;
+  align-items: center;
+  border-width: 1px;
+  border-color: transparent;
+  outline-style: none;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  color: #000000;
+  white-space: nowrap;
+  background-color: transparent;
+}
+
+.CalendarCellTrigger:hover {
+  border-color: #000000;
+}
+
+.CalendarCellTrigger:focus {
+  box-shadow: 0 0 0 2px #000000;
+}
+
+.CalendarCellTrigger[data-disabled] {
+  cursor: none;
+  color: rgba(0,0,0,0.3);
+}
+
+.CalendarCellTrigger[data-selected] {
+  background-color: #000000;
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.CalendarCellTrigger[data-selected]::before {
+  background-color: #FFFFFF;
+}
+
+.CalendarCellTrigger[data-unavailable] {
+  color: rgba(0,0,0,0.3);
+  text-decoration: line-through;
+}
+
+.CalendarCellTrigger::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: 0;
+  width: 0.25rem;
+  height: 0.25rem;
+  border-radius: 9999px;
+  background-color: #FFFFFF;
+}
+
+.CalendarCellTrigger[data-today]::before {
+  display: block;
+  background-color: var(--grass-9);
+}
+
+/* reset */
+button {
+  all: unset;
+}
+
+.Wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.Label {
+  color: #fff;
+}
+
+.SelectTrigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  padding: 0 15px;
+  font-size: 13px;
+  line-height: 1;
+  height: 35px;
+  gap: 5px;
+  background-color: white;
+  color: var(--grass-11);
+  box-shadow: 0 2px 10px var(--black-a7);
+}
+.SelectTrigger:hover {
+  background-color: var(--mauve-3);
+}
+.SelectTrigger:focus {
+  box-shadow: 0 0 0 2px black;
+}
+.SelectTrigger[data-placeholder] {
+  color: var(--grass-9);
+}
+
+.SelectIcon {
+  color: Var(--grass-11);
+}
+
+.SelectContent {
+  overflow: hidden;
+  background-color: white;
+  border-radius: 6px;
+  box-shadow: 0px 10px 38px -10px rgba(22, 23, 24, 0.35), 0px 10px 20px -15px rgba(22, 23, 24, 0.2);
+}
+
+.SelectViewport {
+  padding: 5px;
+}
+
+.SelectItem {
+  font-size: 13px;
+  line-height: 1;
+  color: var(--grass-11);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  height: 25px;
+  padding: 0 35px 0 25px;
+  position: relative;
+  user-select: none;
+}
+.SelectItem[data-disabled] {
+  color: var(--mauve-8);
+  pointer-events: none;
+}
+.SelectItem[data-highlighted] {
+  outline: none;
+  background-color: var(--grass-9);
+  color: var(--grass-1);
+}
+
+.SelectLabel {
+  padding: 0 25px;
+  font-size: 12px;
+  line-height: 25px;
+  color: var(--mauve-11);
+}
+
+.SelectSeparator {
+  height: 1px;
+  background-color: var(--grass-6);
+  margin: 5px;
+}
+
+.SelectItemIndicator {
+  position: absolute;
+  left: 0;
+  width: 25px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.SelectScrollButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 25px;
+  background-color: white;
+  color: var(--grass-11);
+  cursor: default;
+}

--- a/docs/components/demo/CalendarSelect/tailwind/index.vue
+++ b/docs/components/demo/CalendarSelect/tailwind/index.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { createCalendar, getLocalTimeZone, toCalendar, today } from '@internationalized/date'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot, Label, SelectContent, SelectItem, SelectItemIndicator, SelectItemText, SelectPortal, SelectRoot, SelectScrollUpButton, SelectTrigger, SelectValue, SelectViewport } from 'radix-vue'
+import { computed, ref } from 'vue'
+
+const preferences = [
+  { locale: 'en-US', label: 'Default', ordering: 'gregory' },
+  { label: 'Arabic (Algeria)', locale: 'ar-DZ', territories: 'DJ DZ EH ER IQ JO KM LB LY MA MR OM PS SD SY TD TN YE', ordering: 'gregory islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (United Arab Emirates)', locale: 'ar-AE', territories: 'AE BH KW QA', ordering: 'gregory islamic-umalqura islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (Egypt)', locale: 'AR-EG', territories: 'EG', ordering: 'gregory coptic islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (Saudi Arabia)', locale: 'ar-SA', territories: 'SA', ordering: 'islamic-umalqura gregory islamic islamic-rgsa' },
+  { label: 'Farsi (Afghanistan)', locale: 'fa-AF', territories: 'AF IR', ordering: 'persian gregory islamic islamic-civil islamic-tbla' },
+  { label: 'Amharic (Ethiopia)', locale: 'am-ET', territories: 'ET', ordering: 'gregory ethiopic ethioaa' },
+  { label: 'Hebrew (Israel)', locale: 'he-IL', territories: 'IL', ordering: 'gregory hebrew islamic islamic-civil islamic-tbla' },
+  { label: 'Hindi (India)', locale: 'hi-IN', territories: 'IN', ordering: 'gregory indian' },
+  { label: 'Japanese (Japan)', locale: 'ja-JP', territories: 'JP', ordering: 'gregory japanese' },
+  { label: 'Thai (Thailand)', locale: 'th-TH', territories: 'TH', ordering: 'buddhist gregory' },
+  { label: 'Chinese (Taiwan)', locale: 'zh-TW', territories: 'TW', ordering: 'gregory roc chinese' },
+]
+
+const calendars = [
+  { key: 'gregory', name: 'Gregorian' },
+  { key: 'japanese', name: 'Japanese' },
+  { key: 'buddhist', name: 'Buddhist' },
+  { key: 'roc', name: 'Taiwan' },
+  { key: 'persian', name: 'Persian' },
+  { key: 'indian', name: 'Indian' },
+  { key: 'islamic-umalqura', name: 'Islamic (Umm al-Qura)' },
+  { key: 'islamic-civil', name: 'Islamic Civil' },
+  { key: 'islamic-tbla', name: 'Islamic Tabular' },
+  { key: 'hebrew', name: 'Hebrew' },
+  { key: 'coptic', name: 'Coptic' },
+  { key: 'ethiopic', name: 'Ethiopic' },
+  { key: 'ethioaa', name: 'Ethiopic (Amete Alem)' },
+]
+
+const locale = ref(preferences[0].locale)
+const calendar = ref(calendars[0].key)
+
+const pref = computed(() => preferences.find(p => p.locale === locale.value))
+const preferredCalendars = computed(() => pref.value ? pref.value.ordering.split(' ').map(p => calendars.find(c => c.key === p)).filter(Boolean) : [calendars[0]])
+const otherCalendars = computed(() => calendars.filter(c => !preferredCalendars.value.some(p => p!.key === c.key)))
+
+function updateLocale(newLocale: string) {
+  locale.value = newLocale
+  calendar.value = pref.value!.ordering.split(' ')[0]
+}
+const value = computed(() => toCalendar(today(getLocalTimeZone()), createCalendar(calendar.value)))
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <Label class="text-white">Locale</Label>
+    <SelectRoot v-model="locale" @update:model-value="updateLocale">
+      <SelectTrigger
+        class="inline-flex min-w-[160px] items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-grass11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-green9 outline-none"
+        aria-label="Select a locale"
+      >
+        <SelectValue placeholder="Please select a locale">
+          {{ pref!.label }}
+        </SelectValue>
+        <Icon icon="radix-icons:chevron-down" class="h-3.5 w-3.5" />
+      </SelectTrigger>
+
+      <SelectPortal>
+        <SelectContent
+          class="min-w-[160px] bg-white rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade z-[100]"
+          :side-offset="5"
+        >
+          <SelectScrollUpButton class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default">
+            <Icon icon="radix-icons:chevron-up" />
+          </SelectScrollUpButton>
+
+          <SelectViewport class="p-[5px]">
+            <SelectItem
+              v-for="(option, index) in preferences"
+              :key="index"
+              class="text-[13px] leading-none text-grass11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-green9 data-[highlighted]:text-green1"
+              :value="option.locale"
+            >
+              <SelectItemIndicator class="absolute left-0 w-[25px] inline-flex items-center justify-center">
+                <Icon icon="radix-icons:check" />
+              </SelectItemIndicator>
+              <SelectItemText>
+                {{ option.label }}
+              </SelectItemText>
+            </SelectItem>
+          </SelectViewport>
+
+          <SelectScrollDownButton class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default">
+            <Icon icon="radix-icons:chevron-down" />
+          </SelectScrollDownButton>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+    <Label class="text-white">Calendar</Label>
+    <SelectRoot v-model="calendar">
+      <SelectTrigger
+        class="inline-flex min-w-[160px] items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-grass11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-green9 outline-none"
+        aria-label="Select a calendar"
+      >
+        <SelectValue placeholder="Please select a calendar">
+          {{ calendars.find(c => c.key === calendar)?.name }}
+        </SelectValue>
+
+        <Icon icon="radix-icons:chevron-down" class="h-3.5 w-3.5" />
+      </SelectTrigger>
+
+      <SelectPortal>
+        <SelectContent
+          class="min-w-[160px] bg-white rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade z-[100]"
+          :side-offset="5"
+        >
+          <SelectScrollUpButton class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default">
+            <Icon icon="radix-icons:chevron-up" />
+          </SelectScrollUpButton>
+
+          <SelectViewport class="p-[5px]">
+            <SelectLabel class="px-[25px] text-xs leading-[25px] text-mauve11">
+              Preferred
+            </SelectLabel>
+            <SelectGroup>
+              <SelectItem
+                v-for="(option, index) in preferredCalendars"
+                :key="index"
+                class="text-[13px] leading-none text-grass11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-green9 data-[highlighted]:text-green1"
+                :value="option!.key"
+              >
+                <SelectItemIndicator class="absolute left-0 w-[25px] inline-flex items-center justify-center">
+                  <Icon icon="radix-icons:check" />
+                </SelectItemIndicator>
+                <SelectItemText>
+                  {{ option!.name }}
+                </SelectItemText>
+              </SelectItem>
+            </SelectGroup>
+            <SelectSeparator class="h-[1px] bg-green6 m-[5px]" />
+            <SelectLabel class="px-[25px] text-xs leading-[25px] text-mauve11">
+              Other
+            </SelectLabel>
+            <SelectGroup>
+              <SelectItem
+                v-for="(option, index) in otherCalendars"
+                :key="index"
+                class="text-[13px] leading-none text-grass11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-green9 data-[highlighted]:text-green1"
+                :value="option.key"
+              >
+                <SelectItemIndicator class="absolute left-0 w-[25px] inline-flex items-center justify-center">
+                  <Icon icon="radix-icons:check" />
+                </SelectItemIndicator>
+                <SelectItemText>
+                  {{ option.name }}
+                </SelectItemText>
+              </SelectItem>
+            </SelectGroup>
+          </SelectViewport>
+
+          <SelectScrollDownButton class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default">
+            <Icon icon="radix-icons:chevron-down" />
+          </SelectScrollDownButton>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+
+    <CalendarRoot
+      v-slot="{ weekDays, grid }"
+      :model-value="value"
+      :locale="locale"
+      class="mt-6 rounded-xl bg-white p-4 shadow-md"
+      fixed-weeks
+    >
+      <CalendarHeader class="flex items-center justify-between">
+        <CalendarPrev
+          class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-8 h-8 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+        >
+          <Icon icon="radix-icons:chevron-left" class="w-6 h-6" />
+        </CalendarPrev>
+        <CalendarHeading class="text-[15px] text-black font-medium" />
+
+        <CalendarNext
+          class="inline-flex items-center cursor-pointer justify-center text-black rounded-[9px] bg-transparent w-8 h-8 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+        >
+          <Icon icon="radix-icons:chevron-right" class="w-6 h-6" />
+        </CalendarNext>
+      </CalendarHeader>
+      <div
+        class="flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0"
+      >
+        <CalendarGrid v-for="month in grid" :key="month.value.toString()" class="w-full border-collapse select-none space-y-1">
+          <CalendarGridHead>
+            <CalendarGridRow class="mb-1 grid w-full grid-cols-7">
+              <CalendarHeadCell
+                v-for="day in weekDays" :key="day"
+                class="rounded-md text-xs text-green8"
+              >
+                {{ day }}
+              </CalendarHeadCell>
+            </CalendarGridRow>
+          </CalendarGridHead>
+          <CalendarGridBody class="grid">
+            <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="grid grid-cols-7">
+              <CalendarCell
+                v-for="weekDate in weekDates"
+                :key="weekDate.toString()"
+                :date="weekDate"
+                class="relative text-center text-sm"
+              >
+                <CalendarCellTrigger
+                  :day="weekDate"
+                  :month="month.value"
+                  class="relative flex items-center justify-center rounded-full whitespace-nowrap text-sm font-normal text-black w-8 h-8 outline-none focus:shadow-[0_0_0_2px] focus:shadow-black data-[disabled]:text-black/30 data-[selected]:!bg-green10 data-[selected]:text-white hover:bg-green5 data-[highlighted]:bg-green5 data-[unavailable]:pointer-events-none data-[unavailable]:text-black/30 data-[unavailable]:line-through before:absolute before:top-[5px] before:hidden before:rounded-full before:w-1 before:h-1 before:bg-white data-[today]:before:block data-[today]:before:bg-green9 "
+                />
+              </CalendarCell>
+            </CalendarGridRow>
+          </CalendarGridBody>
+        </CalendarGrid>
+      </div>
+    </CalendarRoot>
+  </div>
+</template>

--- a/docs/components/demo/CalendarSelect/tailwind/tailwind.config.js
+++ b/docs/components/demo/CalendarSelect/tailwind/tailwind.config.js
@@ -1,0 +1,16 @@
+const { blackA, grass, green } = require('@radix-ui/colors')
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./**/*.vue'],
+  theme: {
+    extend: {
+      colors: {
+        ...blackA,
+        ...grass,
+        ...green,
+      },
+    },
+  },
+  plugins: [],
+}

--- a/docs/content/components/calendar.md
+++ b/docs/content/components/calendar.md
@@ -281,6 +281,15 @@ Interactable container for displaying the cell dates. Clicking it selects the da
 />
 
 
+## Examples
+
+### Calendar with Locale and Calendar System Selection
+
+This example showcases some of the available locales and how the calendar systems are displayed.
+
+<ComponentPreview name="CalendarSelect" />
+
+
 ## Accessibility
 
 ### Keyboard Interactions

--- a/packages/radix-vue/src/Calendar/story/CalendarSelect.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarSelect.story.vue
@@ -54,7 +54,7 @@ const value = computed(() => toCalendar(today(getLocalTimeZone()), createCalenda
   <Story title="Calendar/Locale and Calendar Select" :layout="{ type: 'single' }">
     <Variant title="default">
       <div class="flex flex-col gap-4">
-        <SelectRoot :model-value="locale" @update:model-value="updateLocale">
+        <SelectRoot v-model="locale" @update:model-value="updateLocale">
           <SelectTrigger
             class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-violet11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-violet9 outline-none"
             aria-label="Customise options"

--- a/packages/radix-vue/src/Calendar/story/CalendarSelect.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarSelect.story.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot } from '../'
+import { SelectContent, SelectGroup, SelectItem, SelectItemIndicator, SelectItemText, SelectLabel, SelectPortal, SelectRoot, SelectScrollDownButton, SelectScrollUpButton, SelectSeparator, SelectTrigger, SelectValue, SelectViewport } from '@/Select'
+import { computed, ref } from 'vue'
+import { createCalendar, getLocalTimeZone, toCalendar, today } from '@internationalized/date'
+
+const preferences = [
+  { locale: 'en-US', label: 'Default', ordering: 'gregory' },
+  { label: 'Arabic (Algeria)', locale: 'ar-DZ', territories: 'DJ DZ EH ER IQ JO KM LB LY MA MR OM PS SD SY TD TN YE', ordering: 'gregory islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (United Arab Emirates)', locale: 'ar-AE', territories: 'AE BH KW QA', ordering: 'gregory islamic-umalqura islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (Egypt)', locale: 'AR-EG', territories: 'EG', ordering: 'gregory coptic islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (Saudi Arabia)', locale: 'ar-SA', territories: 'SA', ordering: 'islamic-umalqura gregory islamic islamic-rgsa' },
+  { label: 'Farsi (Afghanistan)', locale: 'fa-AF', territories: 'AF IR', ordering: 'persian gregory islamic islamic-civil islamic-tbla' },
+  { label: 'Amharic (Ethiopia)', locale: 'am-ET', territories: 'ET', ordering: 'gregory ethiopic ethioaa' },
+  { label: 'Hebrew (Israel)', locale: 'he-IL', territories: 'IL', ordering: 'gregory hebrew islamic islamic-civil islamic-tbla' },
+  { label: 'Hindi (India)', locale: 'hi-IN', territories: 'IN', ordering: 'gregory indian' },
+  { label: 'Japanese (Japan)', locale: 'ja-JP', territories: 'JP', ordering: 'gregory japanese' },
+  { label: 'Thai (Thailand)', locale: 'th-TH', territories: 'TH', ordering: 'buddhist gregory' },
+  { label: 'Chinese (Taiwan)', locale: 'zh-TW', territories: 'TW', ordering: 'gregory roc chinese' },
+]
+
+const calendars = [
+  { key: 'gregory', name: 'Gregorian' },
+  { key: 'japanese', name: 'Japanese' },
+  { key: 'buddhist', name: 'Buddhist' },
+  { key: 'roc', name: 'Taiwan' },
+  { key: 'persian', name: 'Persian' },
+  { key: 'indian', name: 'Indian' },
+  { key: 'islamic-umalqura', name: 'Islamic (Umm al-Qura)' },
+  { key: 'islamic-civil', name: 'Islamic Civil' },
+  { key: 'islamic-tbla', name: 'Islamic Tabular' },
+  { key: 'hebrew', name: 'Hebrew' },
+  { key: 'coptic', name: 'Coptic' },
+  { key: 'ethiopic', name: 'Ethiopic' },
+  { key: 'ethioaa', name: 'Ethiopic (Amete Alem)' },
+]
+
+const locale = ref(preferences[0].locale)
+const calendar = ref(calendars[0].key)
+
+const pref = computed(() => preferences.find(p => p.locale === locale.value))
+const preferredCalendars = computed(() => pref.value ? pref.value.ordering.split(' ').map(p => calendars.find(c => c.key === p)).filter(Boolean) : [calendars[0]])
+const otherCalendars = computed(() => calendars.filter(c => !preferredCalendars.value.some(p => p!.key === c.key)))
+
+function updateLocale(newLocale: string) {
+  locale.value = newLocale
+  calendar.value = pref.value!.ordering.split(' ')[0]
+}
+const value = computed(() => toCalendar(today(getLocalTimeZone()), createCalendar(calendar.value)))
+</script>
+
+<template>
+  <Story title="Calendar/Locale and Calendar Select" :layout="{ type: 'single' }">
+    <Variant title="default">
+      <div class="flex flex-col gap-4">
+        <SelectRoot :model-value="locale" @update:model-value="updateLocale">
+          <SelectTrigger
+            class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-violet11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-violet9 outline-none"
+            aria-label="Customise options"
+          >
+            <SelectValue placeholder="Please select a locale">
+              {{ pref!.label }}
+            </SelectValue>
+            <Icon icon="radix-icons:chevron-down" class="h-4 w-4" />
+          </SelectTrigger>
+
+          <SelectPortal>
+            <SelectContent
+              class="min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade"
+              :side-offset="5"
+            >
+              <SelectScrollUpButton
+                class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+              >
+                <Icon icon="radix-icons:chevron-up" />
+              </SelectScrollUpButton>
+
+              <SelectViewport class="p-[5px]">
+                <SelectItem
+                  v-for="(option, index) in preferences"
+                  :key="index"
+                  class="text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
+                  :value="option.locale"
+                >
+                  <SelectItemIndicator
+                    class="absolute left-0 w-[25px] inline-flex items-center justify-center"
+                  >
+                    <Icon icon="radix-icons:check" />
+                  </SelectItemIndicator>
+                  <SelectItemText>
+                    {{ option.label }}
+                  </SelectItemText>
+                </SelectItem>
+              </SelectViewport>
+
+              <SelectScrollDownButton
+                class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+              >
+                <Icon icon="radix-icons:chevron-down" />
+              </SelectScrollDownButton>
+            </SelectContent>
+          </SelectPortal>
+        </SelectRoot>
+
+        <SelectRoot v-model="calendar">
+          <SelectTrigger
+            class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-violet11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-violet9 outline-none"
+            aria-label="Customise options"
+          >
+            <SelectValue placeholder="Please select a calendar">
+              {{ calendars.find(c => c.key === calendar)?.name }}
+            </SelectValue>
+            <Icon icon="radix-icons:chevron-down" class="h-4 w-4" />
+          </SelectTrigger>
+
+          <SelectPortal>
+            <SelectContent
+              class="min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade"
+              :side-offset="5"
+            >
+              <SelectScrollUpButton
+                class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+              >
+                <Icon icon="radix-icons:chevron-up" />
+              </SelectScrollUpButton>
+
+              <SelectViewport class="p-[5px]">
+                <SelectLabel
+                  class="px-[25px] text-xs leading-[25px] text-mauve11"
+                >
+                  Preferred
+                </SelectLabel>
+                <SelectGroup>
+                  <SelectItem
+                    v-for="(option, index) in preferredCalendars"
+                    :key="index"
+                    class="text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
+                    :value="option!.key"
+                  >
+                    <SelectItemIndicator
+                      class="absolute left-0 w-[25px] inline-flex items-center justify-center"
+                    >
+                      <Icon icon="radix-icons:check" />
+                    </SelectItemIndicator>
+                    <SelectItemText>
+                      {{ option!.name }}
+                    </SelectItemText>
+                  </SelectItem>
+                </SelectGroup>
+                <SelectSeparator class="h-[1px] bg-violet6 m-[5px]" />
+                <SelectLabel
+                  class="px-[25px] text-xs leading-[25px] text-mauve11"
+                >
+                  Other
+                </SelectLabel>
+                <SelectGroup>
+                  <SelectItem
+                    v-for="(option, index) in otherCalendars"
+                    :key="index"
+                    class="text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
+                    :value="option.key"
+                  >
+                    <SelectItemIndicator
+                      class="absolute left-0 w-[25px] inline-flex items-center justify-center"
+                    >
+                      <Icon icon="radix-icons:check" />
+                    </SelectItemIndicator>
+                    <SelectItemText>
+                      {{ option.name }}
+                    </SelectItemText>
+                  </SelectItem>
+                </SelectGroup>
+              </SelectViewport>
+
+              <SelectScrollDownButton
+                class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+              >
+                <Icon icon="radix-icons:chevron-down" />
+              </SelectScrollDownButton>
+            </SelectContent>
+          </SelectPortal>
+        </SelectRoot>
+
+        <CalendarRoot
+          v-slot="{ weekDays, grid }"
+          v-model="value"
+          :locale="locale"
+          class="mt-6 rounded-xl border border-black bg-white p-4 shadow-md"
+        >
+          <CalendarHeader class="flex items-center justify-between">
+            <CalendarPrev
+              class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+            >
+              <Icon icon="radix-icons:chevron-left" class="w-6 h-6" />
+            </CalendarPrev>
+
+            <CalendarHeading class="text-[15px] text-black font-medium" />
+
+            <CalendarNext
+              class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+            >
+              <Icon icon="radix-icons:chevron-right" class="w-6 h-6" />
+            </CalendarNext>
+          </CalendarHeader>
+
+          <div
+            class="flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0"
+          >
+            <CalendarGrid v-for="month in grid" :key="month.value.toString()" class="w-full border-collapse select-none space-y-1">
+              <CalendarGridHead>
+                <CalendarGridRow class="mb-1 grid w-full grid-cols-7">
+                  <CalendarHeadCell
+                    v-for="day in weekDays" :key="day"
+                    class="rounded-md text-xs !font-normal text-black"
+                  >
+                    {{ day }}
+                  </CalendarHeadCell>
+                </CalendarGridRow>
+              </CalendarGridHead>
+              <CalendarGridBody class="grid">
+                <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="grid grid-cols-7">
+                  <CalendarCell
+                    v-for="weekDate in weekDates"
+                    :key="weekDate.toString()"
+                    :date="weekDate"
+                    class="relative text-center text-sm"
+                  >
+                    <CalendarCellTrigger
+                      :day="weekDate"
+                      :month="month.value"
+                      class="relative flex items-center justify-center whitespace-nowrap rounded-lg border border-transparent bg-transparent text-sm font-normal text-black w-8 h-8 outline-none focus:shadow-[0_0_0_2px] focus:shadow-black hover:border-black data-[selected]:bg-black data-[selected]:font-medium data-[disabled]:text-black/30 data-[selected]:text-white data-[unavailable]:text-black/30 data-[unavailable]:line-through before:absolute before:top-[5px] before:hidden before:rounded-full before:w-1 before:h-1 before:bg-white data-[today]:before:block data-[today]:before:bg-grass9 data-[selected]:before:bg-white"
+                    />
+                  </CalendarCell>
+                </CalendarGridRow>
+              </CalendarGridBody>
+            </CalendarGrid>
+          </div>
+        </CalendarRoot>
+      </div>
+    </Variant>
+  </Story>
+</template>

--- a/packages/radix-vue/src/Calendar/story/CalendarSelect.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarSelect.story.vue
@@ -2,6 +2,7 @@
 import { Icon } from '@iconify/vue'
 import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot } from '../'
 import { SelectContent, SelectGroup, SelectItem, SelectItemIndicator, SelectItemText, SelectLabel, SelectPortal, SelectRoot, SelectScrollDownButton, SelectScrollUpButton, SelectSeparator, SelectTrigger, SelectValue, SelectViewport } from '@/Select'
+import { Label } from '@/Label'
 import { computed, ref } from 'vue'
 import { createCalendar, getLocalTimeZone, toCalendar, today } from '@internationalized/date'
 
@@ -54,6 +55,7 @@ const value = computed(() => toCalendar(today(getLocalTimeZone()), createCalenda
   <Story title="Calendar/Locale and Calendar Select" :layout="{ type: 'single' }">
     <Variant title="default">
       <div class="flex flex-col gap-4">
+        <Label class="text-mauve11">Locale</Label>
         <SelectRoot v-model="locale" @update:model-value="updateLocale">
           <SelectTrigger
             class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-violet11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-violet9 outline-none"
@@ -103,6 +105,7 @@ const value = computed(() => toCalendar(today(getLocalTimeZone()), createCalenda
           </SelectPortal>
         </SelectRoot>
 
+        <Label class="text-mauve11">Calendar</Label>
         <SelectRoot v-model="calendar">
           <SelectTrigger
             class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-violet11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-violet9 outline-none"

--- a/packages/radix-vue/src/Calendar/useCalendar.ts
+++ b/packages/radix-vue/src/Calendar/useCalendar.ts
@@ -77,8 +77,6 @@ export function useCalendar(props: UseCalendarProps) {
 
   const headingFormatOptions = computed(() => {
     const options: DateFormatterOptions = {
-      month: 'long',
-      year: 'numeric',
       calendar: props.placeholder.value.calendar.identifier,
     }
 
@@ -212,16 +210,16 @@ export function useCalendar(props: UseCalendarProps) {
 
     if (grid.value.length === 1) {
       const month = grid.value[0].value
-      return `${formatter.custom(toDate(month), headingFormatOptions.value)}`
+      return `${formatter.fullMonthAndYear(toDate(month), headingFormatOptions.value)}`
     }
 
     const startMonth = toDate(grid.value[0].value)
     const endMonth = toDate(grid.value[grid.value.length - 1].value)
 
-    const startMonthName = formatter.custom(startMonth, headingFormatOptions.value)
-    const endMonthName = formatter.custom(endMonth, headingFormatOptions.value)
-    const startMonthYear = formatter.custom(startMonth, headingFormatOptions.value)
-    const endMonthYear = formatter.custom(endMonth, headingFormatOptions.value)
+    const startMonthName = formatter.fullMonth(startMonth, headingFormatOptions.value)
+    const endMonthName = formatter.fullMonth(endMonth, headingFormatOptions.value)
+    const startMonthYear = formatter.fullYear(startMonth, headingFormatOptions.value)
+    const endMonthYear = formatter.fullYear(endMonth, headingFormatOptions.value)
 
     const content
     = startMonthYear === endMonthYear

--- a/packages/radix-vue/src/Calendar/useCalendar.ts
+++ b/packages/radix-vue/src/Calendar/useCalendar.ts
@@ -2,10 +2,11 @@
   * Adapted from https://github.com/melt-ui/melt-ui/blob/develop/src/lib/builders/calendar/create.ts
 */
 
-import { type DateValue, isSameDay, isSameMonth } from '@internationalized/date'
+import { type DateValue, isEqualMonth, isSameDay } from '@internationalized/date'
 import { type Ref, computed, ref, watch } from 'vue'
 import { type Grid, type Matcher, type WeekDayFormat, createMonths, isAfter, isBefore, toDate } from '@/date'
 import { useDateFormatter } from '@/shared'
+import type { DateFormatterOptions } from '@/shared/useDateFormatter'
 
 export type UseCalendarProps = {
   locale: Ref<string>
@@ -74,6 +75,19 @@ export function useCalendarState(props: UseCalendarStateProps) {
 export function useCalendar(props: UseCalendarProps) {
   const formatter = useDateFormatter(props.locale.value)
 
+  const headingFormatOptions = computed(() => {
+    const options: DateFormatterOptions = {
+      month: 'long',
+      year: 'numeric',
+      calendar: props.placeholder.value.calendar.identifier,
+    }
+
+    if (props.placeholder.value.calendar.identifier === 'gregory' && props.placeholder.value.era === 'BC')
+      options.era = 'short'
+
+    return options
+  })
+
   const grid = ref<Grid<DateValue>[]>(createMonths({
     dateObj: props.placeholder.value,
     weekStartsOn: props.weekStartsOn.value,
@@ -87,7 +101,7 @@ export function useCalendar(props: UseCalendarProps) {
   })
 
   function isOutsideVisibleView(date: DateValue) {
-    return !visibleView.value.some(month => isSameMonth(date, month))
+    return !visibleView.value.some(month => isEqualMonth(date, month))
   }
 
   const isNextButtonDisabled = computed(() => {
@@ -168,7 +182,7 @@ export function useCalendar(props: UseCalendarProps) {
   }
 
   watch(props.placeholder, (value) => {
-    if (visibleView.value.some(month => isSameMonth(month, value)))
+    if (visibleView.value.some(month => isEqualMonth(month, value)))
       return
     grid.value = createMonths({
       dateObj: value,
@@ -198,16 +212,16 @@ export function useCalendar(props: UseCalendarProps) {
 
     if (grid.value.length === 1) {
       const month = grid.value[0].value
-      return `${formatter.fullMonthAndYear(toDate(month))}`
+      return `${formatter.custom(toDate(month), headingFormatOptions.value)}`
     }
 
     const startMonth = toDate(grid.value[0].value)
     const endMonth = toDate(grid.value[grid.value.length - 1].value)
 
-    const startMonthName = formatter.fullMonth(startMonth)
-    const endMonthName = formatter.fullMonth(endMonth)
-    const startMonthYear = formatter.fullYear(startMonth)
-    const endMonthYear = formatter.fullYear(endMonth)
+    const startMonthName = formatter.custom(startMonth, headingFormatOptions.value)
+    const endMonthName = formatter.custom(endMonth, headingFormatOptions.value)
+    const startMonthYear = formatter.custom(startMonth, headingFormatOptions.value)
+    const endMonthYear = formatter.custom(endMonth, headingFormatOptions.value)
 
     const content
     = startMonthYear === endMonthYear

--- a/packages/radix-vue/src/shared/useDateFormatter.ts
+++ b/packages/radix-vue/src/shared/useDateFormatter.ts
@@ -17,9 +17,9 @@ export type Formatter = {
   custom: (date: Date, options: DateFormatterOptions) => string
   selectedDate: (date: DateValue, includeTime?: boolean) => string
   dayOfWeek: (date: Date, length?: DateFormatterOptions['weekday']) => string
-  fullMonthAndYear: (date: Date) => string
-  fullMonth: (date: Date) => string
-  fullYear: (date: Date) => string
+  fullMonthAndYear: (date: Date, options?: DateFormatterOptions) => string
+  fullMonth: (date: Date, options?: DateFormatterOptions) => string
+  fullYear: (date: Date, options?: DateFormatterOptions) => string
   dayPeriod: (date: Date) => string
   part: (dateObj: DateValue, type: Intl.DateTimeFormatPartTypes, options?: DateFormatterOptions) => string
   toParts: (date: DateValue, options?: DateFormatterOptions) => Intl.DateTimeFormatPart[]
@@ -63,12 +63,12 @@ export function useDateFormatter(initialLocale: string): Formatter {
     }
   }
 
-  function fullMonthAndYear(date: Date) {
-    return new DateFormatter(locale.value, { month: 'long', year: 'numeric' }).format(date)
+  function fullMonthAndYear(date: Date, options: DateFormatterOptions = {}) {
+    return new DateFormatter(locale.value, { month: 'long', year: 'numeric', ...options }).format(date)
   }
 
-  function fullMonth(date: Date) {
-    return new DateFormatter(locale.value, { month: 'long' }).format(date)
+  function fullMonth(date: Date, options: DateFormatterOptions = {}) {
+    return new DateFormatter(locale.value, { month: 'long', ...options }).format(date)
   }
 
   function getMonths() {
@@ -77,8 +77,8 @@ export function useDateFormatter(initialLocale: string): Formatter {
     return months.map(item => ({ label: fullMonth(toDate(defaultDate.set({ month: item }))), value: item }))
   }
 
-  function fullYear(date: Date) {
-    return new DateFormatter(locale.value, { year: 'numeric' }).format(date)
+  function fullYear(date: Date, options: DateFormatterOptions = {}) {
+    return new DateFormatter(locale.value, { year: 'numeric', ...options }).format(date)
   }
 
   function toParts(date: DateValue, options?: DateFormatterOptions) {

--- a/packages/radix-vue/src/shared/useDateFormatter.ts
+++ b/packages/radix-vue/src/shared/useDateFormatter.ts
@@ -7,18 +7,22 @@ import type { DateValue, ZonedDateTime } from '@internationalized/date'
 import { hasTime, isZonedDateTime, toDate } from '@/date'
 import { ref } from 'vue'
 
+export interface DateFormatterOptions extends Intl.DateTimeFormatOptions {
+  calendar?: string
+}
+
 export type Formatter = {
   getLocale: () => string
   setLocale: (newLocale: string) => void
-  custom: (date: Date, options: Intl.DateTimeFormatOptions) => string
+  custom: (date: Date, options: DateFormatterOptions) => string
   selectedDate: (date: DateValue, includeTime?: boolean) => string
-  dayOfWeek: (date: Date, length?: Intl.DateTimeFormatOptions['weekday']) => string
+  dayOfWeek: (date: Date, length?: DateFormatterOptions['weekday']) => string
   fullMonthAndYear: (date: Date) => string
   fullMonth: (date: Date) => string
   fullYear: (date: Date) => string
   dayPeriod: (date: Date) => string
-  part: (dateObj: DateValue, type: Intl.DateTimeFormatPartTypes, options?: Intl.DateTimeFormatOptions) => string
-  toParts: (date: DateValue, options?: Intl.DateTimeFormatOptions) => Intl.DateTimeFormatPart[]
+  part: (dateObj: DateValue, type: Intl.DateTimeFormatPartTypes, options?: DateFormatterOptions) => string
+  toParts: (date: DateValue, options?: DateFormatterOptions) => Intl.DateTimeFormatPart[]
   getMonths: () => { label: string; value: number }[]
 }
 
@@ -41,7 +45,7 @@ export function useDateFormatter(initialLocale: string): Formatter {
     locale.value = newLocale
   }
 
-  function custom(date: Date, options: Intl.DateTimeFormatOptions) {
+  function custom(date: Date, options: DateFormatterOptions) {
     return new DateFormatter(locale.value, options).format(date)
   }
 
@@ -77,7 +81,7 @@ export function useDateFormatter(initialLocale: string): Formatter {
     return new DateFormatter(locale.value, { year: 'numeric' }).format(date)
   }
 
-  function toParts(date: DateValue, options?: Intl.DateTimeFormatOptions) {
+  function toParts(date: DateValue, options?: DateFormatterOptions) {
     if (isZonedDateTime(date)) {
       return new DateFormatter(locale.value, {
         ...options,
@@ -89,7 +93,7 @@ export function useDateFormatter(initialLocale: string): Formatter {
     }
   }
 
-  function dayOfWeek(date: Date, length: Intl.DateTimeFormatOptions['weekday'] = 'narrow') {
+  function dayOfWeek(date: Date, length: DateFormatterOptions['weekday'] = 'narrow') {
     return new DateFormatter(locale.value, { weekday: length }).format(date)
   }
 
@@ -105,7 +109,7 @@ export function useDateFormatter(initialLocale: string): Formatter {
     return 'AM'
   }
 
-  const defaultPartOptions: Intl.DateTimeFormatOptions = {
+  const defaultPartOptions: DateFormatterOptions = {
     year: 'numeric',
     month: 'numeric',
     day: 'numeric',
@@ -117,7 +121,7 @@ export function useDateFormatter(initialLocale: string): Formatter {
   function part(
     dateObj: DateValue,
     type: Intl.DateTimeFormatPartTypes,
-    options: Intl.DateTimeFormatOptions = {},
+    options: DateFormatterOptions = {},
   ) {
     const opts = { ...defaultPartOptions, ...options }
     const parts = toParts(dateObj, opts)


### PR DESCRIPTION
Hello,

This PR extends the `useDateFormatter` function to also include the `calendar` identifier in its options, so you get the month names translated into your required `locale` and also updated the utility function to be able to accept `options`.

It also updates the `useCalendar` `headingValue` to use the `calendar` identifier when computing the `fullMonth`, `fullYear` and `fullMonthAndYear`.

Plus, the `props.placeholder` function has been updated to use `isEqualMonth` so any calendar system change would update the `grid`.

cc @sadeghbarati for pointing out the bug and providing me with reproductions.
