### PR TITLE
docs(namespaced): fix reword and typos

### DIFF
--- a/docs/content/guides/namespaced-components.md
+++ b/docs/content/guides/namespaced-components.md
@@ -2,14 +2,14 @@
  
 Radix Vue design pattern is to create primitives for each component, and allow user to construct or [compose](./composition) components however they want.
 
-However, importing all of the neccessary component 1-by-1 can be quite an effort, and user might some time accidentally left out any important components.
+However, importing all the necessary components 1-by-1 can be quite an effort, and the user might sometimes accidentally leave out an important component.
 
-In order to solve this painpoint, we've introduced [Namespaced components](https://vuejs.org/api/sfc-script-setup.html#namespaced-components) since [v.1.2.0](https://github.com/radix-vue/radix-vue/releases/tag/v1.2.0).
+In order to solve this pain point, we've introduced [Namespaced components](https://vuejs.org/api/sfc-script-setup.html#namespaced-components) starting from [v.1.2.0](https://github.com/radix-vue/radix-vue/releases/tag/v1.2.0).
 
 
 ## How to use?
 
-First, you need import components via `radix-vue/namespaced` in your Vue component.
+First, you need to import the namespaced components via `radix-vue/namespaced` in your Vue component.
  
 ```vue line=2
 <script setup lang="ts">
@@ -17,7 +17,7 @@ import { Dialog, DropdownMenu } from 'radix-vue/namespaced'
 </script>
 ```
 
-Then, you can just the imported namespaced component and it will contains all the relevant components.
+Then, you can use all the relevant components within the namespace.
 
 ```vue line=6-17
 <script setup lang="ts">


### PR DESCRIPTION
I found some typos in the [Namespaced](https://www.radix-vue.com/guides/namespaced-components.html) guide. I also reworded some paragraphs, but since English is not my native language, please take it with a grain of salt 😅 .