### PR TITLE
feat(Calendar/RangeCalendar): step calendar increment buttons

### DIFF
--- a/docs/components/demo/CalendarYearIncrement/css/index.vue
+++ b/docs/components/demo/CalendarYearIncrement/css/index.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot, type CalendarRootProps } from 'radix-vue'
+import './styles.css'
+
+const isDateUnavailable: CalendarRootProps['isDateUnavailable'] = (date) => {
+  return date.day === 17 || date.day === 18
+}
+</script>
+
+<template>
+  <CalendarRoot
+    v-slot="{ weekDays, grid }"
+    :is-date-unavailable="isDateUnavailable"
+    class="Calendar"
+    fixed-weeks
+  >
+    <CalendarHeader class="CalendarHeader">
+      <CalendarPrev
+        class="CalendarNavButton"
+        step="year"
+      >
+        <Icon icon="radix-icons:double-arrow-left" class="Icon" />
+      </CalendarPrev>
+      <CalendarPrev
+        class="CalendarNavButton"
+      >
+        <Icon icon="radix-icons:chevron-left" class="Icon" />
+      </CalendarPrev>
+      <CalendarHeading class="CalendarHeading" />
+      <CalendarNext
+        class="CalendarNavButton"
+      >
+        <Icon icon="radix-icons:chevron-right" class="Icon" />
+      </CalendarNext>
+
+      <CalendarNext
+        class="CalendarNavButton"
+        step="year"
+      >
+        <Icon icon="radix-icons:double-arrow-right" class="Icon" />
+      </CalendarNext>
+    </CalendarHeader>
+    <div
+      class="CalendarWrapper"
+    >
+      <CalendarGrid v-for="month in grid" :key="month.value.toString()" class="CalendarGrid">
+        <CalendarGridHead>
+          <CalendarGridRow class="CalendarGridRow">
+            <CalendarHeadCell
+              v-for="day in weekDays" :key="day"
+              class="CalendarHeadCell"
+            >
+              {{ day }}
+            </CalendarHeadCell>
+          </CalendarGridRow>
+        </CalendarGridHead>
+        <CalendarGridBody class="CalendarGridWrapper">
+          <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="CalendarGridRow">
+            <CalendarCell
+              v-for="weekDate in weekDates"
+              :key="weekDate.toString()"
+              :date="weekDate"
+              class="CalendarCell"
+            >
+              <CalendarCellTrigger
+                :day="weekDate"
+                :month="month.value"
+                class="CalendarCellTrigger"
+              />
+            </CalendarCell>
+          </CalendarGridRow>
+        </CalendarGridBody>
+      </CalendarGrid>
+    </div>
+  </CalendarRoot>
+</template>

--- a/docs/components/demo/CalendarYearIncrement/css/styles.css
+++ b/docs/components/demo/CalendarYearIncrement/css/styles.css
@@ -1,0 +1,261 @@
+@import '@radix-ui/colors/black-alpha.css';
+@import '@radix-ui/colors/grass.css';
+
+.Icon {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.Calendar {
+  margin-top: 1.5rem;
+  border-width: 1px;
+  border-color: #000000;
+  background-color: #ffffff;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  padding: 22px;
+}
+
+.CalendarHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.CalendarNavButton {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: #000000;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.CalendarNavButton:hover {
+  color: #ffffff;
+  background-color: #000000;
+}
+
+.CalendarHeading {
+  font-weight: 500;
+  color: #000000;
+  color: 15px;
+}
+
+.CalendarWrapper {
+  display: flex;
+  padding-top: 1rem;
+  margin-top: 1rem;
+  flex-direction: column;
+}
+
+@media (min-width: 640px) {
+  .CalendarWrapper {
+    margin-left: 1rem;
+    margin-top: 0;
+    flex-direction: row;
+  }
+}
+
+.CalendarGrid {
+  margin-top: 0.25rem;
+  width: 100%;
+  user-select: none;
+  border-collapse: collapse;
+}
+
+.CalendarGridRow {
+  display: grid
+  margin-bottom: 0.25rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  width: 100%;
+}
+
+.CalendarGridRow[data-radix-vue-calendar-month-view] {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.CalendarHeadCell {
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #000000;
+  font-weight: 400;
+}
+
+.CalendarCell {
+  position: relative;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: center;
+}
+
+.CalendarCellTrigger {
+  display: flex;
+  position: relative;
+  padding: 0.5rem;
+  justify-content: center;
+  align-items: center;
+  border-width: 1px;
+  border-color: transparent;
+  outline-style: none;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  color: #000000;
+  white-space: nowrap;
+  background-color: transparent;
+}
+
+.CalendarCellTrigger:hover {
+  border-color: #000000;
+}
+
+.CalendarCellTrigger:focus {
+  box-shadow: 0 0 0 2px #000000;
+}
+
+.CalendarCellTrigger[data-disabled] {
+  cursor: none;
+  color: rgba(0,0,0,0.3);
+}
+
+.CalendarCellTrigger[data-selected] {
+  background-color: #000000;
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.CalendarCellTrigger[data-selected]::before {
+  background-color: #FFFFFF;
+}
+
+.CalendarCellTrigger[data-unavailable] {
+  color: rgba(0,0,0,0.3);
+  text-decoration: line-through;
+}
+
+.CalendarCellTrigger::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: 0;
+  width: 0.25rem;
+  height: 0.25rem;
+  border-radius: 9999px;
+  background-color: #FFFFFF;
+}
+
+.CalendarCellTrigger[data-today]::before {
+  display: block;
+  background-color: var(--grass-9);
+}
+
+/* reset */
+button {
+  all: unset;
+}
+
+.Wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.Label {
+  color: #fff;
+}
+
+.SelectTrigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  padding: 0 15px;
+  font-size: 13px;
+  line-height: 1;
+  height: 35px;
+  gap: 5px;
+  background-color: white;
+  color: var(--grass-11);
+  box-shadow: 0 2px 10px var(--black-a7);
+}
+.SelectTrigger:hover {
+  background-color: var(--mauve-3);
+}
+.SelectTrigger:focus {
+  box-shadow: 0 0 0 2px black;
+}
+.SelectTrigger[data-placeholder] {
+  color: var(--grass-9);
+}
+
+.SelectIcon {
+  color: Var(--grass-11);
+}
+
+.SelectContent {
+  overflow: hidden;
+  background-color: white;
+  border-radius: 6px;
+  box-shadow: 0px 10px 38px -10px rgba(22, 23, 24, 0.35), 0px 10px 20px -15px rgba(22, 23, 24, 0.2);
+}
+
+.SelectViewport {
+  padding: 5px;
+}
+
+.SelectItem {
+  font-size: 13px;
+  line-height: 1;
+  color: var(--grass-11);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  height: 25px;
+  padding: 0 35px 0 25px;
+  position: relative;
+  user-select: none;
+}
+.SelectItem[data-disabled] {
+  color: var(--mauve-8);
+  pointer-events: none;
+}
+.SelectItem[data-highlighted] {
+  outline: none;
+  background-color: var(--grass-9);
+  color: var(--grass-1);
+}
+
+.SelectLabel {
+  padding: 0 25px;
+  font-size: 12px;
+  line-height: 25px;
+  color: var(--mauve-11);
+}
+
+.SelectSeparator {
+  height: 1px;
+  background-color: var(--grass-6);
+  margin: 5px;
+}
+
+.SelectItemIndicator {
+  position: absolute;
+  left: 0;
+  width: 25px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.SelectScrollButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 25px;
+  background-color: white;
+  color: var(--grass-11);
+  cursor: default;
+}

--- a/docs/components/demo/CalendarYearIncrement/tailwind/index.vue
+++ b/docs/components/demo/CalendarYearIncrement/tailwind/index.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot, type CalendarRootProps } from 'radix-vue'
+
+const isDateUnavailable: CalendarRootProps['isDateUnavailable'] = (date) => {
+  return date.day === 17 || date.day === 18
+}
+</script>
+
+<template>
+  <CalendarRoot
+    v-slot="{ weekDays, grid }"
+    :is-date-unavailable="isDateUnavailable"
+    class="mt-6 rounded-xl bg-white p-4 shadow-md"
+    fixed-weeks
+  >
+    <CalendarHeader class="flex items-center justify-between">
+      <CalendarPrev
+        class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-8 h-8 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+        step="year"
+      >
+        <Icon icon="radix-icons:double-arrow-left" class="w-6 h-6" />
+      </CalendarPrev>
+      <CalendarPrev
+        class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-8 h-8 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+      >
+        <Icon icon="radix-icons:chevron-left" class="w-6 h-6" />
+      </CalendarPrev>
+      <CalendarHeading class="text-[15px] text-black font-medium" />
+
+      <CalendarNext
+        class="inline-flex items-center cursor-pointer justify-center text-black rounded-[9px] bg-transparent w-8 h-8 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+      >
+        <Icon icon="radix-icons:chevron-right" class="w-6 h-6" />
+      </CalendarNext>
+
+      <CalendarNext
+        class="inline-flex items-center cursor-pointer justify-center text-black rounded-[9px] bg-transparent w-8 h-8 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+        step="year"
+      >
+        <Icon icon="radix-icons:double-arrow-right" class="w-6 h-6" />
+      </CalendarNext>
+    </CalendarHeader>
+    <div
+      class="flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0"
+    >
+      <CalendarGrid v-for="month in grid" :key="month.value.toString()" class="w-full border-collapse select-none space-y-1">
+        <CalendarGridHead>
+          <CalendarGridRow class="mb-1 grid w-full grid-cols-7">
+            <CalendarHeadCell
+              v-for="day in weekDays" :key="day"
+              class="rounded-md text-xs text-green8"
+            >
+              {{ day }}
+            </CalendarHeadCell>
+          </CalendarGridRow>
+        </CalendarGridHead>
+        <CalendarGridBody class="grid">
+          <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="grid grid-cols-7">
+            <CalendarCell
+              v-for="weekDate in weekDates"
+              :key="weekDate.toString()"
+              :date="weekDate"
+              class="relative text-center text-sm"
+            >
+              <CalendarCellTrigger
+                :day="weekDate"
+                :month="month.value"
+                class="relative flex items-center justify-center rounded-full whitespace-nowrap text-sm font-normal text-black w-8 h-8 outline-none focus:shadow-[0_0_0_2px] focus:shadow-black data-[disabled]:text-black/30 data-[selected]:!bg-green10 data-[selected]:text-white hover:bg-green5 data-[highlighted]:bg-green5 data-[unavailable]:pointer-events-none data-[unavailable]:text-black/30 data-[unavailable]:line-through before:absolute before:top-[5px] before:hidden before:rounded-full before:w-1 before:h-1 before:bg-white data-[today]:before:block data-[today]:before:bg-green9 "
+              />
+            </CalendarCell>
+          </CalendarGridRow>
+        </CalendarGridBody>
+      </CalendarGrid>
+    </div>
+  </CalendarRoot>
+</template>

--- a/docs/components/demo/CalendarYearIncrement/tailwind/tailwind.config.js
+++ b/docs/components/demo/CalendarYearIncrement/tailwind/tailwind.config.js
@@ -1,0 +1,16 @@
+const { blackA, grass, green } = require('@radix-ui/colors')
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./**/*.vue'],
+  theme: {
+    extend: {
+      colors: {
+        ...blackA,
+        ...grass,
+        ...green,
+      },
+    },
+  },
+  plugins: [],
+}

--- a/docs/content/components/calendar.md
+++ b/docs/content/components/calendar.md
@@ -283,6 +283,12 @@ Interactable container for displaying the cell dates. Clicking it selects the da
 
 ## Examples
 
+### Calendar with Year Incrementation
+
+This example showcases a calendar which allows incrementing the year.
+
+<ComponentPreview name="CalendarYearIncrement" />
+
 ### Calendar with Locale and Calendar System Selection
 
 This example showcases some of the available locales and how the calendar systems are displayed.

--- a/docs/content/meta/CalendarNext.md
+++ b/docs/content/meta/CalendarNext.md
@@ -13,5 +13,12 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false,
+    'default': '\'month\''
   }
 ]" />

--- a/docs/content/meta/CalendarNext.md
+++ b/docs/content/meta/CalendarNext.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go forward</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false,
     'default': '\'month\''

--- a/docs/content/meta/CalendarPrev.md
+++ b/docs/content/meta/CalendarPrev.md
@@ -13,5 +13,12 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false,
+    'default': '\'month\''
   }
 ]" />

--- a/docs/content/meta/CalendarPrev.md
+++ b/docs/content/meta/CalendarPrev.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go back</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false,
     'default': '\'month\''

--- a/docs/content/meta/DatePickerNext.md
+++ b/docs/content/meta/DatePickerNext.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go forward</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false
   }

--- a/docs/content/meta/DatePickerNext.md
+++ b/docs/content/meta/DatePickerNext.md
@@ -13,5 +13,11 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false
   }
 ]" />

--- a/docs/content/meta/DatePickerPrev.md
+++ b/docs/content/meta/DatePickerPrev.md
@@ -13,5 +13,11 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false
   }
 ]" />

--- a/docs/content/meta/DatePickerPrev.md
+++ b/docs/content/meta/DatePickerPrev.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go back</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false
   }

--- a/docs/content/meta/DateRangePickerNext.md
+++ b/docs/content/meta/DateRangePickerNext.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go forward</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false
   }

--- a/docs/content/meta/DateRangePickerNext.md
+++ b/docs/content/meta/DateRangePickerNext.md
@@ -13,5 +13,11 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false
   }
 ]" />

--- a/docs/content/meta/DateRangePickerPrev.md
+++ b/docs/content/meta/DateRangePickerPrev.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go forward</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false
   }

--- a/docs/content/meta/DateRangePickerPrev.md
+++ b/docs/content/meta/DateRangePickerPrev.md
@@ -13,5 +13,11 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false
   }
 ]" />

--- a/docs/content/meta/RangeCalendarNext.md
+++ b/docs/content/meta/RangeCalendarNext.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go forward</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false
   }

--- a/docs/content/meta/RangeCalendarNext.md
+++ b/docs/content/meta/RangeCalendarNext.md
@@ -13,5 +13,11 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false
   }
 ]" />

--- a/docs/content/meta/RangeCalendarPrev.md
+++ b/docs/content/meta/RangeCalendarPrev.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'step',
-    'description': '',
+    'description': '<p>The calendar unit to go forward</p>\n',
     'type': '\'month\' | \'year\'',
     'required': false
   }

--- a/docs/content/meta/RangeCalendarPrev.md
+++ b/docs/content/meta/RangeCalendarPrev.md
@@ -13,5 +13,11 @@
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.radix-vue.com/guides/composition.html\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'step',
+    'description': '',
+    'type': '\'month\' | \'year\'',
+    'required': false
   }
 ]" />

--- a/packages/radix-vue/src/Calendar/Calendar.test.ts
+++ b/packages/radix-vue/src/Calendar/Calendar.test.ts
@@ -287,6 +287,44 @@ describe('Calendar', async () => {
     expect(heading).toHaveTextContent('November 1979')
   })
 
+  it('should navigate one year in the past (prev year button)', async () => {
+    const { getByTestId, user } = setup({
+      calendarProps: {
+        modelValue: calendarDate,
+      },
+    })
+
+    const prevBtn = getByTestId('prev-year-button')
+    await user.click(prevBtn)
+    const heading = getByTestId('heading')
+    expect(heading).toHaveTextContent('January 1979')
+
+    await user.click(prevBtn)
+    expect(heading).toHaveTextContent('January 1978')
+
+    await user.click(prevBtn)
+    expect(heading).toHaveTextContent('January 1977')
+  })
+
+  it('should navigate one year in the future (next year button)', async () => {
+    const { getByTestId, user } = setup({
+      calendarProps: {
+        modelValue: calendarDate,
+      },
+    })
+
+    const nextBtn = getByTestId('next-year-button')
+    await user.click(nextBtn)
+    const heading = getByTestId('heading')
+    expect(heading).toHaveTextContent('January 1981')
+
+    await user.click(nextBtn)
+    expect(heading).toHaveTextContent('January 1982')
+
+    await user.click(nextBtn)
+    expect(heading).toHaveTextContent('January 1983')
+  })
+
   it('should not allow navigation after the `maxValue` (next button)', async () => {
     const { getByTestId, user } = setup({
       calendarProps: {

--- a/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
@@ -124,7 +124,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex < 0) {
-    if (rootContext.isPrevButtonDisabled.value)
+    if (rootContext.isPrevButtonDisabled('month'))
       return
     rootContext.prevPage()
     nextTick(() => {
@@ -139,7 +139,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex >= allCollectionItems.length) {
-    if (rootContext.isNextButtonDisabled.value)
+    if (rootContext.isNextButtonDisabled('month'))
       return
     rootContext.nextPage()
     nextTick(() => {

--- a/packages/radix-vue/src/Calendar/CalendarNext.vue
+++ b/packages/radix-vue/src/Calendar/CalendarNext.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import type { CalendarIncrement } from '@/shared/date'
 
 export interface CalendarNextProps extends PrimitiveProps {
-/* The calendar unit to go forward */
+/** The calendar unit to go forward */
   step?: CalendarIncrement
 }
 </script>

--- a/packages/radix-vue/src/Calendar/CalendarNext.vue
+++ b/packages/radix-vue/src/Calendar/CalendarNext.vue
@@ -1,14 +1,17 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 
-export interface CalendarNextProps extends PrimitiveProps {}
+export interface CalendarNextProps extends PrimitiveProps {
+/* The calendar unit to go forward */
+  step?: 'month' | 'year'
+}
 </script>
 
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
 import { injectCalendarRootContext } from './CalendarRoot.vue'
 
-const props = withDefaults(defineProps<CalendarNextProps>(), { as: 'button' })
+const props = withDefaults(defineProps<CalendarNextProps>(), { as: 'button', step: 'month' })
 
 const rootContext = injectCalendarRootContext()
 </script>
@@ -18,10 +21,10 @@ const rootContext = injectCalendarRootContext()
     v-bind="props"
     aria-label="Next page"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isNextButtonDisabled.value || undefined"
-    :data-disabled="rootContext.isNextButtonDisabled.value || undefined"
-    :disabled="rootContext.isNextButtonDisabled.value"
-    @click="rootContext.nextPage"
+    :aria-disabled="rootContext.isNextButtonDisabled(props.step) || undefined"
+    :data-disabled="rootContext.isNextButtonDisabled(props.step) || undefined"
+    :disabled="rootContext.isNextButtonDisabled(props.step)"
+    @click="rootContext.nextPage(props.step)"
   >
     <slot>Next page</slot>
   </Primitive>

--- a/packages/radix-vue/src/Calendar/CalendarNext.vue
+++ b/packages/radix-vue/src/Calendar/CalendarNext.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import type { CalendarIncrement } from '@/shared/date'
 
 export interface CalendarNextProps extends PrimitiveProps {
 /* The calendar unit to go forward */
-  step?: 'month' | 'year'
+  step?: CalendarIncrement
 }
 </script>
 

--- a/packages/radix-vue/src/Calendar/CalendarPrev.vue
+++ b/packages/radix-vue/src/Calendar/CalendarPrev.vue
@@ -1,14 +1,17 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 
-export interface CalendarPrevProps extends PrimitiveProps { }
+export interface CalendarPrevProps extends PrimitiveProps {
+/* The calendar unit to go back */
+  step?: 'month' | 'year'
+}
 </script>
 
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
 import { injectCalendarRootContext } from './CalendarRoot.vue'
 
-const props = withDefaults(defineProps<CalendarPrevProps>(), { as: 'button' })
+const props = withDefaults(defineProps<CalendarPrevProps>(), { as: 'button', step: 'month' })
 
 const rootContext = injectCalendarRootContext()
 </script>
@@ -18,10 +21,10 @@ const rootContext = injectCalendarRootContext()
     aria-label="Previous page"
     v-bind="props"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isPrevButtonDisabled.value || undefined"
-    :data-disabled="rootContext.isPrevButtonDisabled.value || undefined"
-    :disabled="rootContext.isPrevButtonDisabled.value"
-    @click="rootContext.prevPage"
+    :aria-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"
+    :data-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"
+    :disabled="rootContext.isPrevButtonDisabled(props.step)"
+    @click="rootContext.prevPage(props.step)"
   >
     <slot>Prev page</slot>
   </Primitive>

--- a/packages/radix-vue/src/Calendar/CalendarPrev.vue
+++ b/packages/radix-vue/src/Calendar/CalendarPrev.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import type { CalendarIncrement } from '@/shared/date'
 
 export interface CalendarPrevProps extends PrimitiveProps {
 /* The calendar unit to go back */
-  step?: 'month' | 'year'
+  step?: CalendarIncrement
 }
 </script>
 

--- a/packages/radix-vue/src/Calendar/CalendarPrev.vue
+++ b/packages/radix-vue/src/Calendar/CalendarPrev.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import type { CalendarIncrement } from '@/shared/date'
 
 export interface CalendarPrevProps extends PrimitiveProps {
-/* The calendar unit to go back */
+/** The calendar unit to go back */
   step?: CalendarIncrement
 }
 </script>

--- a/packages/radix-vue/src/Calendar/CalendarRoot.vue
+++ b/packages/radix-vue/src/Calendar/CalendarRoot.vue
@@ -30,14 +30,14 @@ type CalendarRootContext = {
   parentElement: Ref<HTMLElement | undefined>
   headingValue: Ref<string>
   isInvalid: Ref<boolean>
-  nextPage: () => void
-  prevPage: () => void
   isDateDisabled: Matcher
   isDateSelected: Matcher
   isDateUnavailable?: Matcher
   isOutsideVisibleView: (date: DateValue) => boolean
-  isNextButtonDisabled: Ref<boolean>
-  isPrevButtonDisabled: Ref<boolean>
+  prevPage: (step?: 'month' | 'year') => void
+  nextPage: (step?: 'month' | 'year') => void
+  isNextButtonDisabled: (step?: 'month' | 'year') => boolean
+  isPrevButtonDisabled: (step?: 'month' | 'year') => boolean
   formatter: Formatter
   dir: Ref<Direction>
 }

--- a/packages/radix-vue/src/Calendar/CalendarRoot.vue
+++ b/packages/radix-vue/src/Calendar/CalendarRoot.vue
@@ -6,7 +6,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import { type Formatter, createContext, useDirection } from '@/shared'
 
 import { useCalendar, useCalendarState } from './useCalendar'
-import { getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
+import { type CalendarIncrement, getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
 import { type Grid, type Matcher, type WeekDayFormat } from '@/date'
 import type { Direction } from '@/shared/types'
 
@@ -34,10 +34,10 @@ type CalendarRootContext = {
   isDateSelected: Matcher
   isDateUnavailable?: Matcher
   isOutsideVisibleView: (date: DateValue) => boolean
-  prevPage: (step?: 'month' | 'year') => void
-  nextPage: (step?: 'month' | 'year') => void
-  isNextButtonDisabled: (step?: 'month' | 'year') => boolean
-  isPrevButtonDisabled: (step?: 'month' | 'year') => boolean
+  prevPage: (step?: CalendarIncrement) => void
+  nextPage: (step?: CalendarIncrement) => void
+  isNextButtonDisabled: (step?: CalendarIncrement) => boolean
+  isPrevButtonDisabled: (step?: CalendarIncrement) => boolean
   formatter: Formatter
   dir: Ref<Direction>
 }

--- a/packages/radix-vue/src/Calendar/story/CalendarYearIncrement.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarYearIncrement.story.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNext, CalendarPrev, CalendarRoot } from '../'
+</script>
+
+<template>
+  <Story title="Calendar/With Year Increments" :layout="{ type: 'single' }">
+    <Variant title="default">
+      <CalendarRoot
+        v-slot="{ weekDays, grid }"
+        class="mt-6 rounded-xl border border-black bg-white p-4 shadow-md"
+      >
+        <CalendarHeader class="flex items-center justify-between">
+          <CalendarPrev
+            step="year"
+            class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+          >
+            <Icon icon="radix-icons:double-arrow-left" class="w-6 h-6" />
+          </CalendarPrev>
+          <CalendarPrev
+            class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+          >
+            <Icon icon="radix-icons:chevron-left" class="w-6 h-6" />
+          </CalendarPrev>
+
+          <CalendarHeading class="text-[15px] text-black font-medium" />
+
+          <CalendarNext
+            class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+          >
+            <Icon icon="radix-icons:chevron-right" class="w-6 h-6" />
+          </CalendarNext>
+          <CalendarNext
+            step="year"
+            class="inline-flex items-center cursor-pointer text-black justify-center rounded-[9px] bg-transparent w-10 h-10 hover:bg-black hover:text-white active:scale-98 active:transition-all focus:shadow-[0_0_0_2px] focus:shadow-black"
+          >
+            <Icon icon="radix-icons:double-arrow-right" class="w-6 h-6" />
+          </CalendarNext>
+        </CalendarHeader>
+
+        <div
+          class="flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0"
+        >
+          <CalendarGrid v-for="month in grid" :key="month.value.toString()" class="w-full border-collapse select-none space-y-1">
+            <CalendarGridHead>
+              <CalendarGridRow class="mb-1 grid w-full grid-cols-7">
+                <CalendarHeadCell
+                  v-for="day in weekDays" :key="day"
+                  class="rounded-md text-xs !font-normal text-black"
+                >
+                  {{ day }}
+                </CalendarHeadCell>
+              </CalendarGridRow>
+            </CalendarGridHead>
+            <CalendarGridBody class="grid">
+              <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="grid grid-cols-7">
+                <CalendarCell
+                  v-for="weekDate in weekDates"
+                  :key="weekDate.toString()"
+                  :date="weekDate"
+                  class="relative text-center text-sm"
+                >
+                  <CalendarCellTrigger
+                    :day="weekDate"
+                    :month="month.value"
+                    class="relative flex items-center justify-center whitespace-nowrap rounded-lg border border-transparent bg-transparent text-sm font-normal text-black w-8 h-8 outline-none focus:shadow-[0_0_0_2px] focus:shadow-black hover:border-black data-[selected]:bg-black data-[selected]:font-medium data-[disabled]:text-black/30 data-[selected]:text-white data-[unavailable]:text-black/30 data-[unavailable]:line-through before:absolute before:top-[5px] before:hidden before:rounded-full before:w-1 before:h-1 before:bg-white data-[today]:before:block data-[today]:before:bg-grass9 data-[selected]:before:bg-white"
+                  />
+                </CalendarCell>
+              </CalendarGridRow>
+            </CalendarGridBody>
+          </CalendarGrid>
+        </div>
+      </CalendarRoot>
+    </Variant>
+  </Story>
+</template>

--- a/packages/radix-vue/src/Calendar/story/_Calendar.vue
+++ b/packages/radix-vue/src/Calendar/story/_Calendar.vue
@@ -15,11 +15,19 @@ const props = defineProps<{ calendarProps?: CalendarRootProps; emits?: { 'onUpda
   >
     <CalendarHeader data-testid="header">
       <CalendarPrev
+        step="year"
+        data-testid="prev-year-button"
+      />
+      <CalendarPrev
         data-testid="prev-button"
       />
       <CalendarHeading data-testid="heading" />
       <CalendarNext
         data-testid="next-button"
+      />
+      <CalendarNext
+        step="year"
+        data-testid="next-year-button"
       />
     </CalendarHeader>
 

--- a/packages/radix-vue/src/Calendar/useCalendar.ts
+++ b/packages/radix-vue/src/Calendar/useCalendar.ts
@@ -7,6 +7,7 @@ import { type Ref, computed, ref, watch } from 'vue'
 import { type Grid, type Matcher, type WeekDayFormat, createMonths, isAfter, isBefore, toDate } from '@/date'
 import { useDateFormatter } from '@/shared'
 import type { DateFormatterOptions } from '@/shared/useDateFormatter'
+import type { CalendarIncrement } from '@/shared/date'
 
 export type UseCalendarProps = {
   locale: Ref<string>
@@ -102,7 +103,7 @@ export function useCalendar(props: UseCalendarProps) {
     return !visibleView.value.some(month => isEqualMonth(date, month))
   }
 
-  const isNextButtonDisabled = (step: 'month' | 'year' = 'month') => {
+  const isNextButtonDisabled = (step: CalendarIncrement = 'month') => {
     if (!props.maxValue.value || !grid.value.length)
       return false
     if (props.disabled.value)
@@ -119,7 +120,7 @@ export function useCalendar(props: UseCalendarProps) {
     return isAfter(firstPeriodOfNextPage, props.maxValue.value)
   }
 
-  const isPrevButtonDisabled = (step: 'month' | 'year' = 'month') => {
+  const isPrevButtonDisabled = (step: CalendarIncrement = 'month') => {
     if (!props.minValue.value || !grid.value.length)
       return false
     if (props.disabled.value)
@@ -159,7 +160,7 @@ export function useCalendar(props: UseCalendarProps) {
     })
   })
 
-  const nextPage = (step: 'month' | 'year' = 'month') => {
+  const nextPage = (step: CalendarIncrement = 'month') => {
     const firstDate = grid.value[0].value
     const newDate = step === 'month' ? firstDate.add({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }) : firstDate.add({ years: 1 })
 
@@ -176,7 +177,7 @@ export function useCalendar(props: UseCalendarProps) {
     props.placeholder.value = newGrid[0].value.set({ day: 1 })
   }
 
-  const prevPage = (step: 'month' | 'year' = 'month') => {
+  const prevPage = (step: CalendarIncrement = 'month') => {
     const firstDate = grid.value[0].value
     const newDate = step === 'month' ? firstDate.subtract({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }) : firstDate.subtract({ years: 1 })
 

--- a/packages/radix-vue/src/Calendar/useCalendar.ts
+++ b/packages/radix-vue/src/Calendar/useCalendar.ts
@@ -90,26 +90,38 @@ export function useCalendar(props: UseCalendarProps) {
     return !visibleView.value.some(month => isSameMonth(date, month))
   }
 
-  const isNextButtonDisabled = computed(() => {
+  const isNextButtonDisabled = (step: 'month' | 'year' = 'month') => {
     if (!props.maxValue.value || !grid.value.length)
       return false
     if (props.disabled.value)
       return true
-    const lastPeriodInView = grid.value[grid.value.length - 1].value
 
+    if (step === 'year') {
+      const lastPeriodInView = grid.value[grid.value.length - 1].value
+      const firstPeriodOfNextPage = lastPeriodInView.add({ years: 1 }).set({ day: 1, month: 1 })
+      return isAfter(firstPeriodOfNextPage, props.maxValue.value)
+    }
+
+    const lastPeriodInView = grid.value[grid.value.length - 1].value
     const firstPeriodOfNextPage = lastPeriodInView.add({ months: 1 }).set({ day: 1 })
     return isAfter(firstPeriodOfNextPage, props.maxValue.value)
-  })
+  }
 
-  const isPrevButtonDisabled = computed(() => {
+  const isPrevButtonDisabled = (step: 'month' | 'year' = 'month') => {
     if (!props.minValue.value || !grid.value.length)
       return false
     if (props.disabled.value)
       return true
     const firstPeriodInView = grid.value[0].value
+    if (step === 'year') {
+      const lastPeriodOfPrevPage = firstPeriodInView.subtract({ years: 1 }).set({ day: 35, month: 13 })
+      return isBefore(lastPeriodOfPrevPage, props.minValue.value)
+    }
+
     const lastPeriodOfPrevPage = firstPeriodInView.subtract({ months: 1 }).set({ day: 35 })
+
     return isBefore(lastPeriodOfPrevPage, props.minValue.value)
-  })
+  }
 
   function isDateDisabled(dateObj: DateValue) {
     if (props.isDateDisabled?.(dateObj) || props.disabled.value)
@@ -135,11 +147,12 @@ export function useCalendar(props: UseCalendarProps) {
     })
   })
 
-  const nextPage = () => {
+  const nextPage = (step: 'month' | 'year' = 'month') => {
     const firstDate = grid.value[0].value
+    const newDate = step === 'month' ? firstDate.add({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }) : firstDate.add({ years: 1 })
 
     const newGrid = createMonths({
-      dateObj: firstDate.add({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }),
+      dateObj: newDate,
       weekStartsOn: props.weekStartsOn.value,
       locale: props.locale.value,
       fixedWeeks: props.fixedWeeks.value,
@@ -151,11 +164,12 @@ export function useCalendar(props: UseCalendarProps) {
     props.placeholder.value = newGrid[0].value.set({ day: 1 })
   }
 
-  const prevPage = () => {
+  const prevPage = (step: 'month' | 'year' = 'month') => {
     const firstDate = grid.value[0].value
+    const newDate = step === 'month' ? firstDate.subtract({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }) : firstDate.subtract({ years: 1 })
 
     const newGrid = createMonths({
-      dateObj: firstDate.subtract({ months: props.pagedNavigation.value ? props.numberOfMonths.value : 1 }),
+      dateObj: newDate,
       weekStartsOn: props.weekStartsOn.value,
       locale: props.locale.value,
       fixedWeeks: props.fixedWeeks.value,

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendar.test.ts
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendar.test.ts
@@ -145,6 +145,44 @@ describe('RangeCalendar', () => {
     expect(heading).toHaveTextContent('January 1979')
   })
 
+  it('should navigate one year in the past (prev year button)', async () => {
+    const { getByTestId, user } = setup({
+      calendarProps: {
+        modelValue: calendarDateRange,
+      },
+    })
+
+    const prevBtn = getByTestId('prev-year-button')
+    await user.click(prevBtn)
+    const heading = getByTestId('heading')
+    expect(heading).toHaveTextContent('January 1979')
+
+    await user.click(prevBtn)
+    expect(heading).toHaveTextContent('January 1978')
+
+    await user.click(prevBtn)
+    expect(heading).toHaveTextContent('January 1977')
+  })
+
+  it('should navigate one year in the future (next year button)', async () => {
+    const { getByTestId, user } = setup({
+      calendarProps: {
+        modelValue: calendarDateRange,
+      },
+    })
+
+    const nextBtn = getByTestId('next-year-button')
+    await user.click(nextBtn)
+    const heading = getByTestId('heading')
+    expect(heading).toHaveTextContent('January 1981')
+
+    await user.click(nextBtn)
+    expect(heading).toHaveTextContent('January 1982')
+
+    await user.click(nextBtn)
+    expect(heading).toHaveTextContent('January 1983')
+  })
+
   it('always renders six weeks when `fixedWeeks` is `true`', async () => {
     const { getByTestId, calendar, user } = setup({
       calendarProps: {

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -157,7 +157,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex < 0) {
-    if (rootContext.isPrevButtonDisabled.value)
+    if (rootContext.isPrevButtonDisabled('month'))
       return
     rootContext.prevPage()
     nextTick(() => {
@@ -170,7 +170,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex >= allCollectionItems.length) {
-    if (rootContext.isNextButtonDisabled.value)
+    if (rootContext.isNextButtonDisabled('month'))
       return
     rootContext.nextPage()
     nextTick(() => {

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarNext.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarNext.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import type { CalendarIncrement } from '@/shared/date'
 
 export interface RangeCalendarNextProps extends PrimitiveProps {
-/* The calendar unit to go forward */
+/** The calendar unit to go forward */
   step?: CalendarIncrement
 }
 </script>

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarNext.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarNext.vue
@@ -1,7 +1,11 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import type { CalendarIncrement } from '@/shared/date'
 
-export interface RangeCalendarNextProps extends PrimitiveProps {}
+export interface RangeCalendarNextProps extends PrimitiveProps {
+/* The calendar unit to go forward */
+  step?: CalendarIncrement
+}
 </script>
 
 <script setup lang="ts">
@@ -18,10 +22,10 @@ const rootContext = injectRangeCalendarRootContext()
     v-bind="props"
     aria-label="Next page"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isNextButtonDisabled.value || undefined"
-    :data-disabled="rootContext.isNextButtonDisabled.value || undefined"
-    :disabled="rootContext.isNextButtonDisabled.value"
-    @click="rootContext.nextPage"
+    :aria-disabled="rootContext.isNextButtonDisabled(props.step) || undefined"
+    :data-disabled="rootContext.isNextButtonDisabled(props.step) || undefined"
+    :disabled="rootContext.isNextButtonDisabled(props.step)"
+    @click="rootContext.nextPage(props.step)"
   >
     <slot>Next page</slot>
   </Primitive>

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarPrev.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarPrev.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import type { CalendarIncrement } from '@/shared/date'
 
 export interface RangeCalendarPrevProps extends PrimitiveProps {
-/* The calendar unit to go forward */
+/** The calendar unit to go forward */
   step?: CalendarIncrement
 }
 </script>

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarPrev.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarPrev.vue
@@ -1,7 +1,11 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import type { CalendarIncrement } from '@/shared/date'
 
-export interface RangeCalendarPrevProps extends PrimitiveProps {}
+export interface RangeCalendarPrevProps extends PrimitiveProps {
+/* The calendar unit to go forward */
+  step?: CalendarIncrement
+}
 </script>
 
 <script setup lang="ts">
@@ -18,10 +22,10 @@ const rootContext = injectRangeCalendarRootContext()
     v-bind="props"
     aria-label="Previous page"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isPrevButtonDisabled.value || undefined"
-    :data-disabled="rootContext.isPrevButtonDisabled.value || undefined"
-    :disabled="rootContext.isPrevButtonDisabled.value"
-    @click="rootContext.prevPage"
+    :aria-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"
+    :data-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"
+    :disabled="rootContext.isPrevButtonDisabled(props.step)"
+    @click="rootContext.prevPage(props.step)"
   >
     <slot>Prev page</slot>
   </Primitive>

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
@@ -6,7 +6,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import { type Formatter, createContext, useDirection } from '@/shared'
 import { getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
 import { type Grid, type Matcher, type WeekDayFormat, isBefore } from '@/date'
-import type { DateRange } from '@/shared/date'
+import type { CalendarIncrement, DateRange } from '@/shared/date'
 import { useRangeCalendarState } from './useRangeCalendar'
 import { useCalendar } from '@/Calendar/useCalendar'
 import type { Direction } from '@/shared/types'
@@ -40,10 +40,10 @@ type RangeCalendarRootContext = {
   isSelected: (date: DateValue) => boolean
   isSelectionEnd: (date: DateValue) => boolean
   isSelectionStart: (date: DateValue) => boolean
-  prevPage: () => void
-  nextPage: () => void
-  isNextButtonDisabled: Ref<boolean>
-  isPrevButtonDisabled: Ref<boolean>
+  prevPage: (step?: CalendarIncrement) => void
+  nextPage: (step?: CalendarIncrement) => void
+  isNextButtonDisabled: (step?: CalendarIncrement) => boolean
+  isPrevButtonDisabled: (step?: CalendarIncrement) => boolean
   formatter: Formatter
   dir: Ref<Direction>
 }

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
@@ -31,8 +31,6 @@ type RangeCalendarRootContext = {
   parentElement: Ref<HTMLElement | undefined>
   headingValue: Ref<string>
   isInvalid: Ref<boolean>
-  nextPage: () => void
-  prevPage: () => void
   isDateDisabled: Matcher
   isDateUnavailable?: Matcher
   isOutsideVisibleView: (date: DateValue) => boolean
@@ -42,6 +40,8 @@ type RangeCalendarRootContext = {
   isSelected: (date: DateValue) => boolean
   isSelectionEnd: (date: DateValue) => boolean
   isSelectionStart: (date: DateValue) => boolean
+  prevPage: () => void
+  nextPage: () => void
   isNextButtonDisabled: Ref<boolean>
   isPrevButtonDisabled: Ref<boolean>
   formatter: Formatter

--- a/packages/radix-vue/src/RangeCalendar/story/_RangeCalendar.vue
+++ b/packages/radix-vue/src/RangeCalendar/story/_RangeCalendar.vue
@@ -17,11 +17,19 @@ const props = defineProps<{
   >
     <RangeCalendarHeader data-testid="header">
       <RangeCalendarPrev
+        data-testid="prev-year-button"
+        step="year"
+      />
+      <RangeCalendarPrev
         data-testid="prev-button"
       />
       <RangeCalendarHeading data-testid="heading" />
       <RangeCalendarNext
         data-testid="next-button"
+      />
+      <RangeCalendarNext
+        data-testid="next-year-button"
+        step="year"
       />
     </RangeCalendarHeader>
 

--- a/packages/radix-vue/src/shared/date/index.ts
+++ b/packages/radix-vue/src/shared/date/index.ts
@@ -3,6 +3,7 @@ export {
   getDefaultDate,
 } from './comparators'
 export type {
+  CalendarIncrement,
   DateRange,
   DayOfWeek,
   HourCycle,

--- a/packages/radix-vue/src/shared/date/types.ts
+++ b/packages/radix-vue/src/shared/date/types.ts
@@ -11,6 +11,8 @@ export type DayOfWeek = {
   daysOfWeek: (typeof daysOfWeek)[number][]
 }
 
+export type CalendarIncrement = 'month' | 'year'
+
 export type DateRange = {
   start: DateValue | undefined
   end: DateValue | undefined


### PR DESCRIPTION
Hello,

This PR implements a new property on the `CalendarNext`/`CalendarPrev` buttons named `step` which would be used to control how the `placeholder` is incremented/decremented (by year or by month, the last one being the default).

I believe this feature is implemented on most calendar libraries/packages and could prove useful for a lot of users.

I've also added a story and example in `Calendar` and tests for this new feature.