### PR TITLE
fix(ComboBox): flush option changes later

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -154,7 +154,10 @@ const options = ref<T[]>([]) as Ref<T[]>
 
 watch(() => itemMapSize.value, () => {
   options.value = getItems().map(i => i.value)
-}, { immediate: true })
+}, {
+  immediate: true,
+  flush: 'post',
+})
 
 const filteredOptions = computed(() => {
   if (isUserInputted.value) {


### PR DESCRIPTION
Fixes #843 

I have a couple other fixes that actually manages to make `ComboboxAsync.story.vue` somewhat usable. But wanted to quickly get this fix out of the way first.