### PR TITLE
fix(ComboBox): nextTick for render groups

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxGroup.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxGroup.vue
@@ -35,7 +35,9 @@ function checkCollectionItem() {
 }
 
 useMutationObserver(currentElement, () => {
-  checkCollectionItem()
+  nextTick(() => {
+    checkCollectionItem()
+  })
 }, { childList: true })
 
 watch(() => rootContext.searchTerm.value, () => {


### PR DESCRIPTION
Fixes #551 #843

After the last fix (https://github.com/radix-vue/radix-vue/pull/883) we still had a problem with a large list of grouped items (all groups were hidden by v-show).

This PR fixes the grouped lists as well.