### PR TITLE
Docs(accordion): fix aria-hidden attribute in examples

### DIFF
--- a/docs/components/demo/Accordion/css/index.vue
+++ b/docs/components/demo/Accordion/css/index.vue
@@ -34,7 +34,7 @@ const accordionItems = [
         <AccordionHeader class="AccordionHeader">
           <AccordionTrigger class="AccordionTrigger">
             <span>{{ item.title }}</span>
-            <Icon icon="radix-icons:chevron-down" class="AccordionChevron" aria-hidden />
+            <Icon icon="radix-icons:chevron-down" class="AccordionChevron" />
           </AccordionTrigger>
         </AccordionHeader>
         <AccordionContent class="AccordionContent">

--- a/docs/components/demo/Accordion/tailwind/index.vue
+++ b/docs/components/demo/Accordion/tailwind/index.vue
@@ -36,7 +36,6 @@ const accordionItems = [
             <Icon
               icon="radix-icons:chevron-down"
               class="text-green10 ease-[cubic-bezier(0.87,_0,_0.13,_1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
-              aria-hidden
             />
           </AccordionTrigger>
         </AccordionHeader>

--- a/docs/components/demo/NavigationMenu/css/index.vue
+++ b/docs/components/demo/NavigationMenu/css/index.vue
@@ -29,7 +29,6 @@ const currentTrigger = ref('')
           <Icon
             icon="radix-icons:caret-down"
             class="CaretDown"
-            aria-hidden
           />
         </NavigationMenuTrigger>
         <NavigationMenuContent
@@ -70,7 +69,6 @@ const currentTrigger = ref('')
           <Icon
             icon="radix-icons:caret-down"
             class="CaretDown"
-            aria-hidden
           />
         </NavigationMenuTrigger>
         <NavigationMenuContent class="NavigationMenuContent">

--- a/docs/components/demo/NavigationMenu/tailwind/index.vue
+++ b/docs/components/demo/NavigationMenu/tailwind/index.vue
@@ -27,7 +27,6 @@ const currentTrigger = ref('')
           <Icon
             icon="radix-icons:caret-down"
             class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-            aria-hidden
           />
         </NavigationMenuTrigger>
         <NavigationMenuContent
@@ -68,7 +67,6 @@ const currentTrigger = ref('')
           <Icon
             icon="radix-icons:caret-down"
             class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-            aria-hidden
           />
         </NavigationMenuTrigger>
         <NavigationMenuContent class="data-[motion=from-start]:animate-enterFromLeft data-[motion=from-end]:animate-enterFromRight data-[motion=to-start]:animate-exitToLeft data-[motion=to-end]:animate-exitToRight absolute top-0 left-0 w-full sm:w-auto">

--- a/docs/content/components/accordion.md
+++ b/docs/content/components/accordion.md
@@ -235,7 +235,7 @@ import './styles.css'
       <AccordionHeader>
         <AccordionTrigger class="AccordionTrigger">
           <span>Trigger text</span>
-          <Icon icon="radix-icons:chevron-down" class="AccordionChevron" aria-hidden />
+          <Icon icon="radix-icons:chevron-down" class="AccordionChevron" />
         </AccordionTrigger>
       </AccordionHeader>
       <AccordionContent>…</AccordionContent>

--- a/packages/radix-vue/src/NavigationMenu/story/NavigationMenuBasic.story.vue
+++ b/packages/radix-vue/src/NavigationMenu/story/NavigationMenuBasic.story.vue
@@ -40,7 +40,6 @@ const state = reactive({
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
 
@@ -68,7 +67,6 @@ const state = reactive({
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -92,7 +90,6 @@ const state = reactive({
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent

--- a/packages/radix-vue/src/NavigationMenu/story/NavigationMenuDemo.story.vue
+++ b/packages/radix-vue/src/NavigationMenu/story/NavigationMenuDemo.story.vue
@@ -35,7 +35,6 @@ const currentTrigger = ref('')
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -104,7 +103,6 @@ const currentTrigger = ref('')
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent

--- a/packages/radix-vue/src/NavigationMenu/story/NavigationMenuSubmenus.story.vue
+++ b/packages/radix-vue/src/NavigationMenu/story/NavigationMenuSubmenus.story.vue
@@ -37,7 +37,6 @@ const currentTrigger = ref('')
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
 
@@ -59,7 +58,6 @@ const currentTrigger = ref('')
                         <Icon
                           icon="radix-icons:caret-down"
                           class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                          aria-hidden
                         />
                       </NavigationMenuTrigger>
 
@@ -87,7 +85,6 @@ const currentTrigger = ref('')
                         <Icon
                           icon="radix-icons:caret-down"
                           class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                          aria-hidden
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent
@@ -111,7 +108,6 @@ const currentTrigger = ref('')
                         <Icon
                           icon="radix-icons:caret-down"
                           class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                          aria-hidden
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent
@@ -145,7 +141,6 @@ const currentTrigger = ref('')
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -168,7 +163,6 @@ const currentTrigger = ref('')
                         <Icon
                           icon="radix-icons:caret-down"
                           class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                          aria-hidden
                         />
                       </NavigationMenuTrigger>
 
@@ -196,7 +190,6 @@ const currentTrigger = ref('')
                         <Icon
                           icon="radix-icons:caret-down"
                           class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                          aria-hidden
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent
@@ -220,7 +213,6 @@ const currentTrigger = ref('')
                         <Icon
                           icon="radix-icons:caret-down"
                           class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                          aria-hidden
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent

--- a/packages/radix-vue/src/NavigationMenu/story/NavigationMenuViewport.story.vue
+++ b/packages/radix-vue/src/NavigationMenu/story/NavigationMenuViewport.story.vue
@@ -36,7 +36,6 @@ const currentTrigger = ref('')
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
 
@@ -64,7 +63,6 @@ const currentTrigger = ref('')
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -88,7 +86,6 @@ const currentTrigger = ref('')
                 <Icon
                   icon="radix-icons:caret-down"
                   class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
-                  aria-hidden
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent


### PR DESCRIPTION
This PR is not related to radix-vue itself, but to the usage of `@iconify/vue`. 

@iconify/vue already [adds `aria-hidden` by default](https://github.com/iconify/iconify/blob/59bf4012b5b66fae6b63716fac705fd275da06c2/components/vue/src/render.ts#L24), but if we set the `aria-hidden` attribute without any value, [this check](https://github.com/iconify/iconify/blob/59bf4012b5b66fae6b63716fac705fd275da06c2/components/vue/src/render.ts#L162-L167) will remove it completely, leaving a `role="img"` without name.

If this change is fine and I didn't miss anything, I can submit another to update other examples where we used the attribute on the `Icon` component.