### PR TITLE
Fix(accordion): remove unused open prop from the CollapsibleContent instance

### DIFF
--- a/packages/radix-vue/src/Accordion/AccordionContent.vue
+++ b/packages/radix-vue/src/Accordion/AccordionContent.vue
@@ -21,7 +21,6 @@ useForwardExpose()
 <template>
   <CollapsibleContent
     role="region"
-    :open="itemContext.open.value"
     :hidden="!itemContext.open.value"
     :as-child="props.asChild"
     :aria-labelledby="itemContext.triggerId"


### PR DESCRIPTION
In `AccordionContent` we are passing a `open` prop to the `CollapsibleContent` instance even if it does not support such prop.

On a related note: I noticed that the `data-disabled` attribute is applied even if the item or the root is not disabled. It might have something to do with the line: 

https://github.com/radix-vue/radix-vue/blob/3a4188c1afbdb7671c0e76a7e9e0253b34defa52/packages/radix-vue/src/Accordion/AccordionItem.vue#L68

but I lack the context to understand if it's a bug or not.