### PR TITLE
docs: fix 404 when clicking on "Date Range Field"  DemoContainer

### DIFF
--- a/docs/components/DemoContainer.vue
+++ b/docs/components/DemoContainer.vue
@@ -11,7 +11,7 @@ defineProps<{
   <div class="w-full" :class="{ 'overflow-x-auto': overflow }">
     <a
       class="capitalize md:text-lg font-semibold mb-2 ml-2 inline-flex items-center group"
-      :href="`/components/${title?.replace(' ', '-')}.html`"
+      :href="`/components/${title?.replace(/\s+/g, '-')}.html`"
     >{{ title }}
 
       <Icon icon="ic-round-arrow-forward" class="ml-2 group-focus:ml-3 group-hover:ml-3 transition-[margin]" />


### PR DESCRIPTION
On the home page, when a user clicks on a demo container with a title containing more than two words, they will get a 404.

For example, "Date Range Picker" generates the link: `/components/date-range%20picker.html` rather than the correct link `/components/date-range-picker.html`.

The component responsible for generating this url is `<DemoContainer>`. It uses the `title` prop to generate the link. When a title has a space, it currently substitutes a hyphen for the space using `title.replace(" ", "-")`.

However, [`.replace()` only replaces the first instance when passed a string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) as the pattern, so only the first `" "` is replaced with a `"-"`.

This updates to use a regex in `title.replace()` so that each instance of whitespace is replaced with a hyphen.

Resolves https://github.com/radix-vue/radix-vue/issues/893