### PR TITLE
feat: export CalendarRoot props

### DIFF
--- a/packages/radix-vue/src/Calendar/CalendarRoot.vue
+++ b/packages/radix-vue/src/Calendar/CalendarRoot.vue
@@ -83,14 +83,14 @@ interface BaseCalendarRootProps extends PrimitiveProps {
   dir?: Direction
 }
 
-interface MultipleCalendarRootProps extends BaseCalendarRootProps {
+export interface MultipleCalendarRootProps extends BaseCalendarRootProps {
   /** The controlled checked state of the calendar. Can be bound as `v-model`. */
   modelValue?: DateValue[] | undefined
   /** Whether or not multiple dates can be selected */
   multiple: true
 }
 
-interface SingleCalendarRootProps extends BaseCalendarRootProps {
+export interface SingleCalendarRootProps extends BaseCalendarRootProps {
   /** The controlled checked state of the calendar. Can be bound as `v-model`. */
   modelValue?: DateValue | undefined
   /** Whether or not multiple dates can be selected */


### PR DESCRIPTION
### Description

Export typo `MultipleCalendarRootProps` and  `SingleCalendarRootProps` used by `CalendarRootProps`.

### Motivation 

I was working on build an UI library based on radix-vue/shadcn-vue, this error shows up when build:

![image](https://github.com/radix-vue/radix-vue/assets/33137074/33bb5841-a01e-428e-83cf-ce94a4325b42)

This seems a typescript limitation that interface of type alias should also be exposed.

I have also tried:

```ts
interface CalendarRootProps extends MultipleCalendarRootProps, SingleCalendarRootProps {
}
```

which will also work because it's an interface, but I think they are not functionally equivalent.