### PR TITLE
feat: triggerElement prop for DialogRoot

### DIFF
--- a/packages/radix-vue/src/Dialog/Dialog.test.ts
+++ b/packages/radix-vue/src/Dialog/Dialog.test.ts
@@ -128,12 +128,10 @@ describe('given a default Dialog', () => {
       it('should close the content', () => {
         expect(document.body.innerHTML).not.toContain(closeButton.innerHTML)
       })
-    })
 
-    it('should focus trigger after closing', async () => {
-      await fireEvent.click(closeButton)
-      await nextTick()
-      expect(document.activeElement?.textContent).toBe(trigger.element.textContent)
+      it('should focus trigger', async () => {
+        expect(document.activeElement).toBe(trigger.element)
+      })
     })
   })
 })

--- a/packages/radix-vue/src/Dialog/Dialog.test.ts
+++ b/packages/radix-vue/src/Dialog/Dialog.test.ts
@@ -23,7 +23,7 @@ const NoLabelDialogTest = defineComponent({
 
 const UndefinedDescribedByDialog = defineComponent({
   components: { DialogRoot, DialogTrigger, DialogOverlay, DialogContent, DialogClose, DialogTitle },
-  template: `  <DialogRoot>
+  template: `<DialogRoot>
   <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
   <DialogOverlay />
   <DialogContent :aria-describedby="undefined">
@@ -128,6 +128,12 @@ describe('given a default Dialog', () => {
       it('should close the content', () => {
         expect(document.body.innerHTML).not.toContain(closeButton.innerHTML)
       })
+    })
+
+    it('should focus trigger after closing', async () => {
+      await fireEvent.click(closeButton)
+      await nextTick()
+      expect(document.activeElement?.textContent).toBe(trigger.element.textContent)
     })
   })
 })

--- a/packages/radix-vue/src/Dialog/DialogContentImpl.vue
+++ b/packages/radix-vue/src/Dialog/DialogContentImpl.vue
@@ -52,7 +52,10 @@ rootContext.descriptionId ||= useId(undefined, 'radix-vue-dialog-description')
 
 onMounted(() => {
   rootContext.contentElement = contentElement
-  rootContext.triggerElement.value = document.activeElement as HTMLElement
+
+  // Preserve the `DialogTrigger` element in case it was triggerred programatically
+  if (document.activeElement !== document.body)
+    rootContext.triggerElement.value = document.activeElement as HTMLElement
 })
 
 // eslint-disable-next-line n/prefer-global/process

--- a/packages/radix-vue/src/Dialog/DialogContentImpl.vue
+++ b/packages/radix-vue/src/Dialog/DialogContentImpl.vue
@@ -52,6 +52,7 @@ rootContext.descriptionId ||= useId(undefined, 'radix-vue-dialog-description')
 
 onMounted(() => {
   rootContext.contentElement = contentElement
+  rootContext.triggerElement.value = document.activeElement as HTMLElement
 })
 
 // eslint-disable-next-line n/prefer-global/process

--- a/packages/radix-vue/src/Dialog/DialogContentImpl.vue
+++ b/packages/radix-vue/src/Dialog/DialogContentImpl.vue
@@ -53,7 +53,7 @@ rootContext.descriptionId ||= useId(undefined, 'radix-vue-dialog-description')
 onMounted(() => {
   rootContext.contentElement = contentElement
 
-  // Preserve the `DialogTrigger` element in case it was triggerred programatically
+  // Preserve the `DialogTrigger` element in case it was triggered programmatically
   if (document.activeElement !== document.body)
     rootContext.triggerElement.value = document.activeElement as HTMLElement
 })

--- a/packages/radix-vue/src/Dialog/DialogRoot.vue
+++ b/packages/radix-vue/src/Dialog/DialogRoot.vue
@@ -57,10 +57,11 @@ const contentElement = ref<HTMLElement>()
 const { modal } = toRefs(props)
 
 onMounted(() => {
-  watch(() => props.triggerElement, (el) => {
-    if (!el)
-      return
-    triggerElement.value = typeof el === 'string' ? document.querySelector(el) : el
+  watch(() => props.triggerElement, (value) => {
+    const el = typeof value === 'string' ? document.querySelector<HTMLElement>(value) : value
+
+    if (el)
+      triggerElement.value = el
   }, {
     immediate: true,
   })

--- a/packages/radix-vue/src/Dialog/DialogRoot.vue
+++ b/packages/radix-vue/src/Dialog/DialogRoot.vue
@@ -37,7 +37,7 @@ export const [injectDialogRootContext, provideDialogRootContext]
 </script>
 
 <script setup lang="ts">
-import { onMounted, ref, toRefs, watch } from 'vue'
+import { ref, toRefs } from 'vue'
 import { useVModel } from '@vueuse/core'
 
 const props = withDefaults(defineProps<DialogRootProps>(), {
@@ -55,17 +55,6 @@ const open = useVModel(props, 'open', emit, {
 const triggerElement = ref<HTMLElement>()
 const contentElement = ref<HTMLElement>()
 const { modal } = toRefs(props)
-
-onMounted(() => {
-  watch(() => props.triggerElement, (value) => {
-    const el = typeof value === 'string' ? document.querySelector<HTMLElement>(value) : value
-
-    if (el)
-      triggerElement.value = el
-  }, {
-    immediate: true,
-  })
-})
 
 provideDialogRootContext({
   open,

--- a/packages/radix-vue/src/Dialog/DialogRoot.vue
+++ b/packages/radix-vue/src/Dialog/DialogRoot.vue
@@ -10,8 +10,6 @@ export interface DialogRootProps {
   /** The modality of the dialog When set to `true`, <br>
    * interaction with outside elements will be disabled and only dialog content will be visible to screen readers. */
   modal?: boolean
-  /** The element that triggers the dialog. */
-  triggerElement?: string | HTMLElement
 }
 
 export type DialogRootEmits = {

--- a/packages/radix-vue/src/Dialog/DialogRoot.vue
+++ b/packages/radix-vue/src/Dialog/DialogRoot.vue
@@ -10,6 +10,8 @@ export interface DialogRootProps {
   /** The modality of the dialog When set to `true`, <br>
    * interaction with outside elements will be disabled and only dialog content will be visible to screen readers. */
   modal?: boolean
+  /** The element that triggers the dialog. */
+  triggerElement?: string | HTMLElement
 }
 
 export type DialogRootEmits = {
@@ -35,7 +37,7 @@ export const [injectDialogRootContext, provideDialogRootContext]
 </script>
 
 <script setup lang="ts">
-import { ref, toRefs } from 'vue'
+import { onMounted, ref, toRefs, watch } from 'vue'
 import { useVModel } from '@vueuse/core'
 
 const props = withDefaults(defineProps<DialogRootProps>(), {
@@ -53,6 +55,16 @@ const open = useVModel(props, 'open', emit, {
 const triggerElement = ref<HTMLElement>()
 const contentElement = ref<HTMLElement>()
 const { modal } = toRefs(props)
+
+onMounted(() => {
+  watch(() => props.triggerElement, (el) => {
+    if (!el)
+      return
+    triggerElement.value = typeof el === 'string' ? document.querySelector(el) : el
+  }, {
+    immediate: true,
+  })
+})
 
 provideDialogRootContext({
   open,

--- a/packages/radix-vue/src/Dialog/DialogTrigger.vue
+++ b/packages/radix-vue/src/Dialog/DialogTrigger.vue
@@ -5,6 +5,7 @@ export interface DialogTriggerProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { injectDialogRootContext } from './DialogRoot.vue'
 import { useForwardExpose, useId } from '@/shared'
 import { Primitive } from '@/Primitive'
@@ -13,9 +14,12 @@ const props = withDefaults(defineProps<DialogTriggerProps>(), {
   as: 'button',
 })
 const rootContext = injectDialogRootContext()
-const { forwardRef } = useForwardExpose()
+const { forwardRef, currentElement } = useForwardExpose()
 
 rootContext.contentId ||= useId(undefined, 'radix-vue-dialog-content')
+onMounted(() => {
+  rootContext.triggerElement.value = currentElement.value
+})
 </script>
 
 <template>

--- a/packages/radix-vue/src/Dialog/DialogTrigger.vue
+++ b/packages/radix-vue/src/Dialog/DialogTrigger.vue
@@ -13,7 +13,7 @@ const props = withDefaults(defineProps<DialogTriggerProps>(), {
   as: 'button',
 })
 const rootContext = injectDialogRootContext()
-const { forwardRef, currentElement } = useForwardExpose()
+const { forwardRef } = useForwardExpose()
 
 rootContext.contentId ||= useId(undefined, 'radix-vue-dialog-content')
 </script>

--- a/packages/radix-vue/src/Dialog/DialogTrigger.vue
+++ b/packages/radix-vue/src/Dialog/DialogTrigger.vue
@@ -5,7 +5,6 @@ export interface DialogTriggerProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
 import { injectDialogRootContext } from './DialogRoot.vue'
 import { useForwardExpose, useId } from '@/shared'
 import { Primitive } from '@/Primitive'
@@ -17,9 +16,6 @@ const rootContext = injectDialogRootContext()
 const { forwardRef, currentElement } = useForwardExpose()
 
 rootContext.contentId ||= useId(undefined, 'radix-vue-dialog-content')
-onMounted(() => {
-  rootContext.triggerElement = currentElement
-})
 </script>
 
 <template>

--- a/packages/radix-vue/src/Dialog/story/DialogExternalTrigger.story.vue
+++ b/packages/radix-vue/src/Dialog/story/DialogExternalTrigger.story.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+} from '..'
+import { ref } from 'vue'
+
+const open = ref(false)
+</script>
+
+<template>
+  <Story title="Dialog/External Trigger" :layout="{ type: 'single', iframe: false }">
+    <Variant title="default">
+      <div>
+        <button
+          class="mr-2 text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
+          @click="open = true"
+        >
+          External Trigger
+        </button>
+        <DialogRoot v-model:open="open">
+          <DialogTrigger
+            class="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
+          >
+            Main Trigger
+          </DialogTrigger>
+          <DialogPortal>
+            <Transition name="fade">
+              <DialogOverlay class="bg-blackA9 fixed inset-0" />
+            </Transition>
+            <Transition name="fade">
+              <DialogContent
+                class="fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none"
+              >
+                <DialogTitle class="text-mauve12 m-0 text-[17px] font-medium">
+                  Edit profile
+                </DialogTitle>
+                <DialogDescription class="text-mauve11 mt-[10px] mb-5 text-[15px] leading-normal">
+                  Make changes to your
+                  profile here. Click save when you're done.
+                </DialogDescription>
+                <DialogClose
+                  class="text-violet11 hover:bg-violet4 focus:shadow-violet7 absolute top-[10px] right-[10px] inline-flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-full focus:shadow-[0_0_0_2px] focus:outline-none"
+                  aria-label="Close"
+                >
+                  <Icon icon="lucide:x" />
+                </DialogClose>
+              </DialogContent>
+            </Transition>
+          </DialogPortal>
+        </DialogRoot>
+      </div>
+    </Variant>
+  </Story>
+</template>

--- a/packages/radix-vue/src/Dialog/story/DialogWithDropdown.story.vue
+++ b/packages/radix-vue/src/Dialog/story/DialogWithDropdown.story.vue
@@ -12,7 +12,7 @@ import DropdownMenu from '../../DropdownMenu/story/_DropdownMenu.vue'
 </script>
 
 <template>
-  <Story title="Dialog/WithDropdown" :layout="{ type: 'single', iframe: false }">
+  <Story title="Dialog/With Dropdown" :layout="{ type: 'single', iframe: false }">
     <Variant title="default">
       <DialogRoot>
         <DialogTrigger


### PR DESCRIPTION
Closes #921 

Adds a `triggerElement` prop to the DialogRoot so that the user can specify which trigger was used to open the dialog.