### PR TITLE
Refactor(Calendar): update props management in navigation buttons and grid component 

### DIFF
--- a/packages/radix-vue/src/Calendar/CalendarGrid.vue
+++ b/packages/radix-vue/src/Calendar/CalendarGrid.vue
@@ -1,16 +1,19 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-
 export interface CalendarGridProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
+import { computed } from 'vue';
 import { injectCalendarRootContext } from './CalendarRoot.vue'
 
 const props = withDefaults(defineProps<CalendarGridProps>(), { as: 'table' })
 
 const rootContext = injectCalendarRootContext()
+const disabled = computed(() => rootContext.disabled.value ? true : undefined)
+const readonly = computed(() => rootContext.readonly.value ? true : undefined)
+
 </script>
 
 <template>
@@ -18,10 +21,10 @@ const rootContext = injectCalendarRootContext()
     v-bind="props"
     tabindex="-1"
     role="grid"
-    :aria-readonly="rootContext.readonly ? true : undefined"
-    :aria-disabled="rootContext.disabled ? true : undefined"
-    :data-readonly="rootContext.readonly ? '' : undefined"
-    :data-disabled="rootContext.disabled ? '' : undefined"
+    :aria-readonly="readonly"
+    :aria-disabled="disabled"
+    :data-readonly="readonly && ''"
+    :data-disabled="disabled && ''"
   >
     <slot />
   </Primitive>

--- a/packages/radix-vue/src/Calendar/CalendarNext.vue
+++ b/packages/radix-vue/src/Calendar/CalendarNext.vue
@@ -20,6 +20,7 @@ const rootContext = injectCalendarRootContext()
 <template>
   <Primitive
     :as="props.as"
+    :as-child="props.asChild"
     aria-label="Next page"
     :type="as === 'button' ? 'button' : undefined"
     :aria-disabled="rootContext.isNextButtonDisabled(props.step) || undefined"

--- a/packages/radix-vue/src/Calendar/CalendarNext.vue
+++ b/packages/radix-vue/src/Calendar/CalendarNext.vue
@@ -19,7 +19,7 @@ const rootContext = injectCalendarRootContext()
 
 <template>
   <Primitive
-    v-bind="props"
+    :as="props.as"
     aria-label="Next page"
     :type="as === 'button' ? 'button' : undefined"
     :aria-disabled="rootContext.isNextButtonDisabled(props.step) || undefined"

--- a/packages/radix-vue/src/Calendar/CalendarPrev.vue
+++ b/packages/radix-vue/src/Calendar/CalendarPrev.vue
@@ -20,7 +20,7 @@ const rootContext = injectCalendarRootContext()
 <template>
   <Primitive
     aria-label="Previous page"
-    v-bind="props"
+    :as="props.as"
     :type="as === 'button' ? 'button' : undefined"
     :aria-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"
     :data-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"

--- a/packages/radix-vue/src/Calendar/CalendarPrev.vue
+++ b/packages/radix-vue/src/Calendar/CalendarPrev.vue
@@ -21,6 +21,7 @@ const rootContext = injectCalendarRootContext()
   <Primitive
     aria-label="Previous page"
     :as="props.as"
+    :as-child="props.asChild"
     :type="as === 'button' ? 'button' : undefined"
     :aria-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"
     :data-disabled="rootContext.isPrevButtonDisabled(props.step) || undefined"


### PR DESCRIPTION
This PR refactors/fixes these two small issues:

- f14f28e9bb0d697aa91c5dd9d28a0bd300a56297: in `CalendarNext` and `CalendarPrev` we are passing the `step` prop to `Primitive` even if it doesn't support it.
- 062c6978262a42a6b7e1428f4bbbfa05269d5a37: in `CalendarGrid`, we assign `aria-disabled` and `aria-read-only` by reading from the root context, but those values are refs into an object, and such are not unwrapped by the compiler.