### PR TITLE
fix(NumberField): added missed export of NumberFieldRootEmits

### DIFF
--- a/packages/radix-vue/src/NumberField/index.ts
+++ b/packages/radix-vue/src/NumberField/index.ts
@@ -1,4 +1,4 @@
-export { default as NumberFieldRoot, type NumberFieldRootProps } from './NumberFieldRoot.vue'
+export { default as NumberFieldRoot, type NumberFieldRootProps, type NumberFieldRootEmits } from './NumberFieldRoot.vue'
 export { default as NumberFieldLabel, type NumberFieldLabelProps } from './NumberFieldLabel.vue'
 export { default as NumberFieldInput, type NumberFieldInputProps } from './NumberFieldInput.vue'
 export { default as NumberFieldIncrement, type NumberFieldIncrementProps } from './NumberFieldIncrement.vue'


### PR DESCRIPTION
Hello 👋

Just a small fix that added a missed export of NumberFieldRootEmits. This is needed to create a components like shadcn-vue library do.