### PR TITLE
fix(NumberField): always updateModelValue on blur

### DIFF
--- a/packages/radix-vue/src/NumberField/NumberField.test.ts
+++ b/packages/radix-vue/src/NumberField/NumberField.test.ts
@@ -21,7 +21,7 @@ function setup(props?: NumberFieldRootProps) {
 }
 
 const kbd = useKbd()
-describe('NumberField', () => {
+describe('numberField', () => {
   it('should pass axe accessibility tests', async () => {
     const { root } = setup()
     expect(await axe(root)).toHaveNoViolations()
@@ -40,6 +40,17 @@ describe('NumberField', () => {
   it('should show negative sign if less than 0', async () => {
     const { input } = setup({ modelValue: -10 })
     expect(input.value).toBe('-10')
+  })
+
+  it('should restart from 0 when clearing the value', async () => {
+    const { input, increment } = setup({ defaultValue: 5 })
+
+    await userEvent.clear(input)
+
+    expect(input.value).toBe('')
+    await userEvent.click(document.body)
+    await userEvent.click(increment)
+    expect(input.value).toBe('0')
   })
 
   it('should increase and decrease based on default step', async () => {

--- a/packages/radix-vue/src/NumberField/NumberFieldRoot.vue
+++ b/packages/radix-vue/src/NumberField/NumberFieldRoot.vue
@@ -160,19 +160,19 @@ function clampInputValue(val: number) {
 }
 
 function applyInputValue(val: string) {
-  if (!val)
-    return
-
   const parsedValue = numberParser.parse(val)
+
+  modelValue.value = clampInputValue(parsedValue)
+
   // Set to empty state if input value is empty
-  if (!val.length)
-    return setInputValue(modelValue.value === undefined ? '' : textValue.value)
+  if (!val.length) {
+    return setInputValue(val)
+  }
 
   // if it failed to parse, then reset input to formatted version of current number
   if (isNaN(parsedValue))
     return setInputValue(textValue.value)
 
-  modelValue.value = clampInputValue(parsedValue)
   return setInputValue(textValue.value)
 }
 


### PR DESCRIPTION
Hello,

This PR fixes the issue described in #953 on the NumberField. 

It should now start from the `min` value or `0` on `increment`/`decrement` if the input value is cleared.