### PR TITLE
fix(Combobox): clear modelValue on empty search term

### DIFF
--- a/packages/radix-vue/src/Combobox/Combobox.test.ts
+++ b/packages/radix-vue/src/Combobox/Combobox.test.ts
@@ -37,6 +37,13 @@ describe('given default Combobox', () => {
     expect(wrapper.html()).toContain('Placeholder...')
   })
 
+  it('should clear the selection when the searchTerm is empty', async () => {
+    const input = wrapper.find('input')
+    input.element.value = ''
+    const selection = wrapper.findAll('[role=option]')
+    expect(selection.some(item => item.attributes('data-state') === 'checked')).toBe(false)
+  })
+
   describe('opening the popup', () => {
     beforeEach(async () => {
       await wrapper.find('button').trigger('click')

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -191,6 +191,7 @@ function resetSearchTerm() {
   else {
     searchTerm.value = ''
   }
+  
 }
 
 const activeIndex = computed(() => filteredOptions.value.findIndex(i => isEqual(i, selectedValue.value)))
@@ -200,6 +201,11 @@ const selectedElement = computed(() => {
 
 const stringifiedModelValue = computed(() => JSON.stringify(modelValue.value))
 
+watch(searchTerm, (val)=> {
+  if (val === '')
+    //@ts-expect-error ignore type error
+    modelValue.value = multiple.value ? [] : undefined
+})
 // nextTick() are required in the following watchers as we are waiting for DOM element to be mounted first the only apply following logic
 watch(stringifiedModelValue, async () => {
   await nextTick()


### PR DESCRIPTION
Hello,

Along with #954, fix #953.

This PR adds a watcher for the `searchTerm`, clearing the `modelValue` if the `searchTerm` is ever empty.