### PR TITLE
fix(FocusScope): add await to userEvent in test

### DIFF
--- a/packages/radix-vue/src/FocusScope/FocusScope.test.ts
+++ b/packages/radix-vue/src/FocusScope/FocusScope.test.ts
@@ -127,8 +127,8 @@ describe('focusScope', () => {
     it('should properly blur the last element in the scope before cycling back', async () => {
       // Tab back and then tab forward to cycle through the scope
       tabbableFirst.focus()
-      userEvent.tab({ shift: true })
-      userEvent.tab()
+      await userEvent.tab({ shift: true })
+      await userEvent.tab()
       waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
     })
   })


### PR DESCRIPTION
Hello,

Fix #956.

This PR adds `await` for a couple of `userEvent` calls which might have caused the error on the pipeline(after the env teardown).