### PR TITLE
fix(HoverCard): avoid opening for quick hovers

### DIFF
--- a/packages/radix-vue/src/HoverCard/HoverCardContentImpl.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardContentImpl.vue
@@ -2,6 +2,7 @@
 import type { PopperContentProps } from '@/Popper'
 import type { DismissableLayerEmits } from '@/DismissableLayer'
 import { useForwardExpose, useGraceArea } from '@/shared'
+import { syncRef } from '@vueuse/shared'
 
 export type HoverCardContentImplEmits = DismissableLayerEmits
 export interface HoverCardContentImplProps extends PopperContentProps {}
@@ -22,7 +23,9 @@ const forwarded = useForwardProps(props)
 const { forwardRef, currentElement: contentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
 const { isPointerInTransit, onPointerExit } = useGraceArea(rootContext.triggerElement, contentElement)
-rootContext.isPointerInTransit = isPointerInTransit
+
+syncRef(rootContext.isPointerInTransitRef, isPointerInTransit, { direction: 'rtl' })
+
 onPointerExit(() => {
   rootContext.onClose()
 })

--- a/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
@@ -26,8 +26,6 @@ export interface HoverCardRootContext {
   hasSelectionRef: Ref<boolean>
   isPointerDownOnContentRef: Ref<boolean>
   isPointerInTransit: Ref<boolean>
-  isHoveringRef: Ref<boolean>
-  isFocusedRef: Ref<boolean>
   triggerElement: Ref<HTMLElement | undefined>
 }
 
@@ -68,16 +66,11 @@ const closeTimerRef = ref(0)
 const hasSelectionRef = ref(false)
 const isPointerDownOnContentRef = ref(false)
 const isPointerInTransit = ref(false)
-const isHoveringRef = ref(false)
-const isFocusedRef = ref(false)
 const triggerElement = ref<HTMLElement>()
 
 function handleOpen() {
   clearTimeout(closeTimerRef.value)
-  openTimerRef.value = window.setTimeout(() => {
-    if (isHoveringRef.value || isFocusedRef.value)
-      open.value = true
-  }, openDelay.value)
+  openTimerRef.value = window.setTimeout(() => open.value = true, openDelay.value)
 }
 
 function handleClose() {
@@ -102,8 +95,6 @@ provideHoverCardRootContext({
   isPointerDownOnContentRef,
   isPointerInTransit,
   triggerElement,
-  isHoveringRef,
-  isFocusedRef
 })
 </script>
 

--- a/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
@@ -25,7 +25,7 @@ export interface HoverCardRootContext {
   onDismiss: () => void
   hasSelectionRef: Ref<boolean>
   isPointerDownOnContentRef: Ref<boolean>
-  isPointerInTransit: Ref<boolean>
+  isPointerInTransitRef: Ref<boolean>
   triggerElement: Ref<HTMLElement | undefined>
 }
 
@@ -65,7 +65,7 @@ const openTimerRef = ref(0)
 const closeTimerRef = ref(0)
 const hasSelectionRef = ref(false)
 const isPointerDownOnContentRef = ref(false)
-const isPointerInTransit = ref(false)
+const isPointerInTransitRef = ref(false)
 const triggerElement = ref<HTMLElement>()
 
 function handleOpen() {
@@ -93,7 +93,7 @@ provideHoverCardRootContext({
   onDismiss: handleDismiss,
   hasSelectionRef,
   isPointerDownOnContentRef,
-  isPointerInTransit,
+  isPointerInTransitRef,
   triggerElement,
 })
 </script>

--- a/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
@@ -26,6 +26,7 @@ export interface HoverCardRootContext {
   hasSelectionRef: Ref<boolean>
   isPointerDownOnContentRef: Ref<boolean>
   isPointerInTransit: Ref<boolean>
+  isHoveringRef: Ref<boolean>
   triggerElement: Ref<HTMLElement | undefined>
 }
 
@@ -66,11 +67,15 @@ const closeTimerRef = ref(0)
 const hasSelectionRef = ref(false)
 const isPointerDownOnContentRef = ref(false)
 const isPointerInTransit = ref(false)
+const isHoveringRef = ref(false)
 const triggerElement = ref<HTMLElement>()
 
 function handleOpen() {
   clearTimeout(closeTimerRef.value)
-  openTimerRef.value = window.setTimeout(() => open.value = true, openDelay.value)
+  openTimerRef.value = window.setTimeout(() => {
+    if (isHoveringRef.value)
+      open.value = true
+  }, openDelay.value)
 }
 
 function handleClose() {
@@ -95,6 +100,7 @@ provideHoverCardRootContext({
   isPointerDownOnContentRef,
   isPointerInTransit,
   triggerElement,
+  isHoveringRef,
 })
 </script>
 

--- a/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardRoot.vue
@@ -27,6 +27,7 @@ export interface HoverCardRootContext {
   isPointerDownOnContentRef: Ref<boolean>
   isPointerInTransit: Ref<boolean>
   isHoveringRef: Ref<boolean>
+  isFocusedRef: Ref<boolean>
   triggerElement: Ref<HTMLElement | undefined>
 }
 
@@ -68,12 +69,13 @@ const hasSelectionRef = ref(false)
 const isPointerDownOnContentRef = ref(false)
 const isPointerInTransit = ref(false)
 const isHoveringRef = ref(false)
+const isFocusedRef = ref(false)
 const triggerElement = ref<HTMLElement>()
 
 function handleOpen() {
   clearTimeout(closeTimerRef.value)
   openTimerRef.value = window.setTimeout(() => {
-    if (isHoveringRef.value)
+    if (isHoveringRef.value || isFocusedRef.value)
       open.value = true
   }, openDelay.value)
 }
@@ -101,6 +103,7 @@ provideHoverCardRootContext({
   isPointerInTransit,
   triggerElement,
   isHoveringRef,
+  isFocusedRef
 })
 </script>
 

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -18,6 +18,13 @@ withDefaults(defineProps<HoverCardTriggerProps>(), {
 const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
 rootContext.triggerElement = currentElement
+
+function handleLeave() {
+  setTimeout(() => {
+    if (!rootContext.isPointerInTransitRef.value)
+      rootContext.onClose()
+  }, 0)
+}
 </script>
 
 <template>
@@ -28,6 +35,7 @@ rootContext.triggerElement = currentElement
       :as="as"
       :data-state="rootContext.open.value ? 'open' : 'closed'"
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
+      @pointerleave="excludeTouch(handleLeave)($event)"
       @focus="rootContext.onOpen()"
       @blur="rootContext.onClose()"
     >

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -30,6 +30,8 @@ rootContext.triggerElement = currentElement
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
       @focus="rootContext.onOpen()"
       @blur="rootContext.onClose()"
+      @mouseover="rootContext.isHoveringRef.value = true"
+      @mouseleave="rootContext.isHoveringRef.value = false"
     >
       <slot />
     </Primitive>

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -18,11 +18,6 @@ withDefaults(defineProps<HoverCardTriggerProps>(), {
 const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
 rootContext.triggerElement = currentElement
-
-function handleFocus(hoverCardStateChange: () => void) {
-  rootContext.isFocusedRef.value = !rootContext.isFocusedRef.value
-  hoverCardStateChange()
-}
 </script>
 
 <template>
@@ -33,10 +28,8 @@ function handleFocus(hoverCardStateChange: () => void) {
       :as="as"
       :data-state="rootContext.open.value ? 'open' : 'closed'"
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
-      @focus="handleFocus(rootContext.onOpen)"
-      @blur="handleFocus(rootContext.onClose)"
-      @mouseover="rootContext.isHoveringRef.value = true"
-      @mouseleave="rootContext.isHoveringRef.value = false"
+      @focus="rootContext.onOpen()"
+      @blur="rootContext.onClose()"
     >
       <slot />
     </Primitive>

--- a/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/radix-vue/src/HoverCard/HoverCardTrigger.vue
@@ -18,6 +18,11 @@ withDefaults(defineProps<HoverCardTriggerProps>(), {
 const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
 rootContext.triggerElement = currentElement
+
+function handleFocus(hoverCardStateChange: () => void) {
+  rootContext.isFocusedRef.value = !rootContext.isFocusedRef.value
+  hoverCardStateChange()
+}
 </script>
 
 <template>
@@ -28,8 +33,8 @@ rootContext.triggerElement = currentElement
       :as="as"
       :data-state="rootContext.open.value ? 'open' : 'closed'"
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
-      @focus="rootContext.onOpen()"
-      @blur="rootContext.onClose()"
+      @focus="handleFocus(rootContext.onOpen)"
+      @blur="handleFocus(rootContext.onClose)"
       @mouseover="rootContext.isHoveringRef.value = true"
       @mouseleave="rootContext.isHoveringRef.value = false"
     >


### PR DESCRIPTION
Hello!

This pr fix the bug of issue https://github.com/radix-vue/radix-vue/issues/994

A hovering ref was added to check after the open delay time if the mouse is still waiting for the content

New behavior:


https://github.com/radix-vue/radix-vue/assets/10001036/b1c84286-05b6-422b-ab27-439518f76e22


