### PR TITLE
fix: update eslint configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = false
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,8 @@ export default antfu(
       'ts/consistent-type-definitions': 'off',
       'symbol-description': 'off',
       'no-console': 'warn',
+      'import/first': 'off',
+      'import/order': 'off',
       'max-statements-per-line': ['error', { max: 2 }],
       'vue/one-component-per-file': 'off',
       'unicorn/prefer-dom-node-text-content': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,10 @@ import antfu from '@antfu/eslint-config'
 
 export default antfu(
   {
+    vue: true,
+    typescript: true,
+  },
+  {
     ignores: ['*.js'],
   },
   {
@@ -9,8 +13,6 @@ export default antfu(
       'ts/no-non-null-asserted-optional-chain': 'off',
       'ts/ban-ts-comment': 'warn',
       'ts/consistent-type-definitions': 'off',
-      'import/first': 'off',
-      'import/order': 'off',
       'symbol-description': 'off',
       'no-console': 'warn',
       'max-statements-per-line': ['error', { max: 2 }],
@@ -18,6 +20,15 @@ export default antfu(
       'unicorn/prefer-dom-node-text-content': 'off',
       'unicorn/prefer-number-properties': 'off',
       'regexp/no-super-linear-backtracking': 'off',
+    },
+  },
+  {
+    files: ['**/*.vue'],
+    rules: {
+      'vue/max-attributes-per-line': ['error', {
+        singleline: 1,
+        multiline: 1,
+      }],
     },
   },
   {


### PR DESCRIPTION
Hello,

This PR fixes #996.

I've enabled both the `typescript` and `vue` plugins on the config to make sure they always get loaded.

I've also added a default `.editorconfig` file so that any editor will maintain spacing and carriage return consistency.

I've also enabled the `import` related rules (I recall those being on before ESLint 9) plus added a rule for `vue` `template` HTML attributes that makes them more readable IMO.

Looking forward to any feedback 🚀 