### PR TITLE
fix(combobox): when backspacing searchTerm highlight the first available option

### DIFF
--- a/packages/radix-vue/src/Combobox/Combobox.test.ts
+++ b/packages/radix-vue/src/Combobox/Combobox.test.ts
@@ -103,6 +103,38 @@ describe('given default Combobox', () => {
         })
       })
     })
+
+    describe('after keypress input', () => {
+      beforeEach(async () => {
+        await valueBox.setValue('B')
+      })
+
+      describe('if filter-function provided', () => {
+        beforeEach(async () => {
+          await wrapper.setProps({
+            filterFunction: (list: any[], term: string) => {
+              return list.filter(i => i.toLowerCase().includes(term.toLowerCase()))
+            },
+          })
+        })
+        it('should filter with the searchTerm (Bl', async () => {
+          await valueBox.setValue('Bl')
+
+          const selection = wrapper.findAll('[data-highlighted]').filter(i => i.attributes('style') !== 'display: none;')
+          expect(selection.length).toBe(1)
+          expect(selection[0].element.innerHTML).contains('Blueberry')
+        })
+
+        it('should filter with the searchTerm (B', async () => {
+          await valueBox.setValue('Bl')
+          await valueBox.setValue('B')
+
+          const selection = wrapper.findAll('[data-highlighted]').filter(i => i.attributes('style') !== 'display: none;')
+          expect(selection.length).toBe(1)
+          expect(selection[0].element.innerHTML).contains('Banana')
+        })
+      })
+    })
   })
 })
 

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -211,10 +211,10 @@ watch(stringifiedModelValue, async () => {
   immediate: !props.searchTerm,
 })
 
-watch(() => filteredOptions.value.length, async (length) => {
+watch(() => [filteredOptions.value.length, searchTerm.value.length], async ([length, searchTermLength], [oldLength, oldSearchTermLength]) => {
   await nextTick()
   await nextTick()
-  if (length && activeIndex.value === -1)
+  if (length && (oldSearchTermLength > searchTermLength || activeIndex.value === -1))
     selectedValue.value = filteredOptions.value[0]
 })
 


### PR DESCRIPTION
I think current highlighting functionality is unintuitive.

When the user is removing characters (eg: by backspacing) the highlighted option should always be the first matching option from the dropdown list. It should provide the same behavior as typing, but backwards.

for reference please check [shadcn/ui's combobox](https://ui.shadcn.com/docs/components/combobox) or [headleassui's combobox](https://headlessui.com/react/combobox)

this PR is fixing that behavior.

before:
![combobox-before](https://github.com/radix-vue/radix-vue/assets/15650871/58f2e36e-0d62-43c5-b147-2af0f0af55cf)

after the change:
![combobox-after](https://github.com/radix-vue/radix-vue/assets/15650871/fcffa122-0da6-45d0-bfa3-f6a0db171e52)
