### PR TITLE
fix(Editable): allow space inputs when submitMode is enter

### DIFF
--- a/docs/content/components/editable.md
+++ b/docs/content/components/editable.md
@@ -153,14 +153,6 @@ Contains the cancel trigger of the editable component.
       description: `<span>When focus moves onto the editable field, switches into the editable mode if the <Code>activation-mode</Code> is set to focus.</span>`
     },
     {
-      keys: ['Space'],
-      description:`
-      <span>
-          If the <Code>submit-mode</Code> is set to <Code>enter</Code> or <Code>both</Code>, it submits the changes.
-      </span>
-    ` ,
-    },
-    {
       keys: ['Enter'],
       description:`
       <span>

--- a/packages/radix-vue/src/Editable/EditableInput.vue
+++ b/packages/radix-vue/src/Editable/EditableInput.vue
@@ -44,7 +44,7 @@ watch(context.isEditing, (value) => {
 })
 
 function handleSubmitKeyDown(event: KeyboardEvent) {
-  if ((context.submitMode.value === 'enter' || context.submitMode.value === 'both') && (event.key === kbd.ENTER || event.key === kbd.SPACE) && !event.shiftKey)
+  if ((context.submitMode.value === 'enter' && event.key === kbd.ENTER) || (context.submitMode.value === 'both' && (event.key === kbd.SPACE || event.key === kbd.ENTER) && !event.shiftKey))
     context.submit()
 }
 </script>

--- a/packages/radix-vue/src/Editable/EditableInput.vue
+++ b/packages/radix-vue/src/Editable/EditableInput.vue
@@ -44,7 +44,7 @@ watch(context.isEditing, (value) => {
 })
 
 function handleSubmitKeyDown(event: KeyboardEvent) {
-  if ((context.submitMode.value === 'enter' && event.key === kbd.ENTER) || (context.submitMode.value === 'both' && (event.key === kbd.SPACE || event.key === kbd.ENTER) && !event.shiftKey))
+  if ((context.submitMode.value === 'enter' || context.submitMode.value === 'both') && event.key === kbd.ENTER && !event.shiftKey && !event.metaKey)
     context.submit()
 }
 </script>


### PR DESCRIPTION
Context: https://github.com/radix-vue/radix-vue/issues/1008

Currently editable is very strict and submits on space input, even if submitMode is set to `enter`. This changes it to only enforce shift-space usage when submitMode is `both`.