### PR TITLE
fix(combobox): when null value passed to VisuallyHiddenInput component

### DIFF
--- a/packages/radix-vue/src/VisuallyHidden/VisuallyHiddenInput.vue
+++ b/packages/radix-vue/src/VisuallyHidden/VisuallyHiddenInput.vue
@@ -28,7 +28,7 @@ const parsedValue = computed(() => {
   }
 
   // if object value
-  else if (typeof props.value === 'object' && !Array.isArray(props.value)) {
+  else if (props.value !== null && typeof props.value === 'object' && !Array.isArray(props.value)) {
     return Object.entries(props.value as object).map(([key, value]) => ({ name: `[${props.name}][${key}]`, value }))
   }
 


### PR DESCRIPTION
Faced with an issue, when null value passed to Combobox component. The parsedValue in VisuallyHiddenInput doesn't provide correct check for null value