### PR TITLE
fix(MenuRadioGroup): update:modelValue payload type

### DIFF
--- a/docs/content/meta/DropdownMenuRadioGroup.md
+++ b/docs/content/meta/DropdownMenuRadioGroup.md
@@ -26,6 +26,6 @@
   {
     'name': 'update:modelValue',
     'description': '<p>Event handler called when the value changes.</p>\n',
-    'type': '[payload: boolean]'
+    'type': '[payload: string]'
   }
 ]" />

--- a/docs/content/meta/MenubarRadioGroup.md
+++ b/docs/content/meta/MenubarRadioGroup.md
@@ -26,6 +26,6 @@
   {
     'name': 'update:modelValue',
     'description': '<p>Event handler called when the value changes.</p>\n',
-    'type': '[payload: boolean]'
+    'type': '[payload: string]'
   }
 ]" />

--- a/packages/radix-vue/src/Menu/MenuRadioGroup.vue
+++ b/packages/radix-vue/src/Menu/MenuRadioGroup.vue
@@ -15,7 +15,7 @@ export interface MenuRadioGroupProps extends MenuGroupProps {
 
 export type MenuRadioGroupEmits = {
   /** Event handler called when the value changes. */
-  'update:modelValue': [payload: boolean]
+  'update:modelValue': [payload: string]
 }
 
 export const [injectMenuRadioGroupContext, provideMenuRadioGroupContext]


### PR DESCRIPTION
When using the `DropdownMenuRadioGroup` using `@update:model-value` instead of binding `v-model` we noticed that the payload was type `boolean` when we expected `string`. This type is also in line with similar components (`RadioGroupRoot`).

With this PR the type is updated to reflect the payload value, along with the docs.