### PR TITLE
feat(Editable): expose editable functions

### DIFF
--- a/docs/content/meta/EditableRoot.md
+++ b/docs/content/meta/EditableRoot.md
@@ -155,5 +155,20 @@
     'name': 'isEmpty',
     'description': '<p>Whether the editable field is empty</p>\n',
     'type': 'boolean'
+  },
+  {
+    'name': 'submit',
+    'description': '<p>Function to submit the value of the editable</p>\n',
+    'type': ''
+  },
+  {
+    'name': 'cancel',
+    'description': '<p>Function to cancel the value of the editable</p>\n',
+    'type': ''
+  },
+  {
+    'name': 'edit',
+    'description': '<p>Function to set the editable in edit mode</p>\n',
+    'type': ''
   }
 ]" />

--- a/docs/content/meta/EditableRoot.md
+++ b/docs/content/meta/EditableRoot.md
@@ -172,3 +172,21 @@
     'type': ''
   }
 ]" />
+
+<MethodsTable :data="[
+  {
+    'name': 'submit',
+    'description': '',
+    'type': '() => void'
+  },
+  {
+    'name': 'cancel',
+    'description': '',
+    'type': '() => void'
+  },
+  {
+    'name': 'edit',
+    'description': '',
+    'type': '() => void'
+  }
+]" />

--- a/docs/content/meta/EditableRoot.md
+++ b/docs/content/meta/EditableRoot.md
@@ -176,17 +176,17 @@
 <MethodsTable :data="[
   {
     'name': 'submit',
-    'description': '',
+    'description': '<p>Function to submit the value of the editable</p>\n',
     'type': '() => void'
   },
   {
     'name': 'cancel',
-    'description': '',
+    'description': '<p>Function to cancel the value of the editable</p>\n',
     'type': '() => void'
   },
   {
     'name': 'edit',
-    'description': '',
+    'description': '<p>Function to set the editable in edit mode</p>\n',
     'type': '() => void'
   }
 ]" />

--- a/packages/radix-vue/src/Editable/EditableRoot.vue
+++ b/packages/radix-vue/src/Editable/EditableRoot.vue
@@ -166,8 +166,11 @@ function handleDismiss() {
 }
 
 defineExpose({
+  /** Function to submit the value of the editable */
   submit,
+  /** Function to cancel the value of the editable */
   cancel,
+  /** Function to set the editable in edit mode */
   edit,
 })
 

--- a/packages/radix-vue/src/Editable/EditableRoot.vue
+++ b/packages/radix-vue/src/Editable/EditableRoot.vue
@@ -97,7 +97,12 @@ defineSlots<{
     modelValue: typeof modelValue.value
     /** Whether the editable field is empty */
     isEmpty: boolean
-    /** Function to set the value of the editable */
+    /** Function to submit the value of the editable */
+    submit: () => void
+    /** Function to cancel the value of the editable */
+    cancel: () => void
+    /** Function to set the editable in edit mode */
+    edit: () => void
   }) => any
 }>()
 
@@ -199,6 +204,9 @@ provideEditableRootContext({
         :model-value="modelValue"
         :is-editing="isEditing"
         :is-empty="isEmpty"
+        :submit="submit"
+        :cancel="cancel"
+        :edit="edit"
       />
     </Primitive>
   </DismissableLayer>

--- a/packages/radix-vue/src/Editable/EditableRoot.vue
+++ b/packages/radix-vue/src/Editable/EditableRoot.vue
@@ -165,6 +165,12 @@ function handleDismiss() {
     cancel()
 }
 
+defineExpose({
+  submit,
+  cancel,
+  edit,
+})
+
 provideEditableRootContext({
   id,
   name,


### PR DESCRIPTION
Hello,

This PR exposes the internal functions on the `EditableRoot` slot to enable programmatic control of the internal state of the `Editable` component.

Should address the use case in #1021.