### PR TITLE
fix(Calendar): sometimes first day of next month is missing

### DIFF
--- a/packages/radix-vue/src/Calendar/Calendar.test.ts
+++ b/packages/radix-vue/src/Calendar/Calendar.test.ts
@@ -250,21 +250,19 @@ describe('calendar', async () => {
       return calendar.querySelectorAll('[data-week]').length
     }
 
-    function getFirstDayOfNextMonth() {
-      return calendar.querySelector('[data-week]:nth-child(n+4) [data-outside-view]') as HTMLElement
-    }
-
     const nextButton = getByTestId('next-button')
+
+    expect(getByTestId('date-1-1')).toHaveTextContent('1')
 
     for (let i = 0; i < 12; i++) {
       expect(getNumberOfWeeks()).toBe(6)
-      expect(getFirstDayOfNextMonth()).toHaveTextContent('1')
       await user.click(nextButton)
     }
 
+    expect(getByTestId('date-2-1')).toHaveTextContent('1')
+
     for (let i = 0; i < 24; i++) {
       expect(getNumberOfWeeks()).toBe(6)
-      expect(getFirstDayOfNextMonth()).toHaveTextContent('1')
       await user.click(nextButton)
     }
   })

--- a/packages/radix-vue/src/Calendar/Calendar.test.ts
+++ b/packages/radix-vue/src/Calendar/Calendar.test.ts
@@ -241,7 +241,7 @@ describe('calendar', async () => {
   it('always renders six weeks when `fixedWeeks` is `true`', async () => {
     const { getByTestId, calendar, user } = setup({
       calendarProps: {
-        modelValue: calendarDate,
+        modelValue: new CalendarDate(2024, 8, 1),
         fixedWeeks: true,
       },
     })
@@ -252,14 +252,14 @@ describe('calendar', async () => {
 
     const nextButton = getByTestId('next-button')
 
-    expect(getByTestId('date-1-1')).toHaveTextContent('1')
+    expect(getByTestId('date-8-1')).toHaveTextContent('1')
 
     for (let i = 0; i < 12; i++) {
       expect(getNumberOfWeeks()).toBe(6)
       await user.click(nextButton)
     }
 
-    expect(getByTestId('date-2-1')).toHaveTextContent('1')
+    expect(getByTestId('date-9-1')).toHaveTextContent('1')
 
     for (let i = 0; i < 24; i++) {
       expect(getNumberOfWeeks()).toBe(6)

--- a/packages/radix-vue/src/Calendar/Calendar.test.ts
+++ b/packages/radix-vue/src/Calendar/Calendar.test.ts
@@ -250,15 +250,21 @@ describe('calendar', async () => {
       return calendar.querySelectorAll('[data-week]').length
     }
 
+    function getFirstDayOfNextMonth() {
+      return calendar.querySelector('[data-week]:nth-child(n+4) [data-outside-view]') as HTMLElement
+    }
+
     const nextButton = getByTestId('next-button')
 
     for (let i = 0; i < 12; i++) {
       expect(getNumberOfWeeks()).toBe(6)
+      expect(getFirstDayOfNextMonth()).toHaveTextContent('1')
       await user.click(nextButton)
     }
 
     for (let i = 0; i < 24; i++) {
       expect(getNumberOfWeeks()).toBe(6)
+      expect(getFirstDayOfNextMonth()).toHaveTextContent('1')
       await user.click(nextButton)
     }
   })

--- a/packages/radix-vue/src/Calendar/story/CalendarFixedWeeksForLocales.story.vue
+++ b/packages/radix-vue/src/Calendar/story/CalendarFixedWeeksForLocales.story.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import Calendar from './_DummyCalendar.vue'
+import { BuddhistCalendar, CalendarDate, HebrewCalendar, JapaneseCalendar, PersianCalendar, TaiwanCalendar } from '@internationalized/date'
+
+const gregorian = new CalendarDate(2024, 8, 31)
+
+const persian = new CalendarDate(
+  new PersianCalendar(),
+  1404,
+  5,
+  31,
+)
+const japanese = new CalendarDate(
+  new JapaneseCalendar(),
+  'heisei',
+  31,
+  4,
+  30,
+
+)
+const buddhist = new CalendarDate(
+  new BuddhistCalendar(),
+  2563,
+  10,
+  31,
+)
+const taiwan = new CalendarDate(
+  new TaiwanCalendar(),
+  109,
+  10,
+  31,
+)
+
+const hebrew = new CalendarDate(
+  new HebrewCalendar(),
+  5781,
+  6,
+  29,
+)
+</script>
+
+<template>
+  <Story
+    title="Calendar/Fixed Weeks For Locales"
+    :layout="{ type: 'grid', width: '50%' }"
+  >
+    <Variant title="Gregorian">
+      <Calendar
+        :default-value="gregorian"
+        fixed-weeks
+        locale="en"
+      />
+    </Variant>
+
+    <Variant title="Japanese">
+      <Calendar
+        :default-value="japanese"
+        fixed-weeks
+        locale="ja"
+      />
+    </Variant>
+
+    <Variant title="Persian">
+      <Calendar
+        :default-value="persian"
+        fixed-weeks
+        locale="fa-IR"
+      />
+    </Variant>
+
+    <Variant title="Taiwan">
+      <Calendar
+        :default-value="taiwan"
+        fixed-weeks
+        locale="zh-TW"
+      />
+    </Variant>
+
+    <Variant title="Buddhist">
+      <Calendar
+        :default-value="buddhist"
+        fixed-weeks
+        locale="th"
+      />
+    </Variant>
+
+    <Variant title="Hebrew">
+      <Calendar
+        :default-value="hebrew"
+        fixed-weeks
+        locale="he"
+      />
+    </Variant>
+  </Story>
+</template>

--- a/packages/radix-vue/src/date/calendar.ts
+++ b/packages/radix-vue/src/date/calendar.ts
@@ -78,7 +78,7 @@ export function createMonth(props: CreateMonthProps): Grid<DateValue> {
     let startFrom = nextMonthDays[nextMonthDays.length - 1]
 
     if (!startFrom)
-      startFrom = dateObj.add({ months: 1 }).set({ day: 1 })
+      startFrom = dateObj.add({ months: 1 }).set({ day: 1 }).subtract({ days: 1 })
 
     const extraDaysArray = Array.from({ length: extraDays }, (_, i) => {
       const incr = i + 1

--- a/packages/radix-vue/src/date/calendar.ts
+++ b/packages/radix-vue/src/date/calendar.ts
@@ -78,7 +78,7 @@ export function createMonth(props: CreateMonthProps): Grid<DateValue> {
     let startFrom = nextMonthDays[nextMonthDays.length - 1]
 
     if (!startFrom)
-      startFrom = dateObj.add({ months: 1 }).set({ day: 1 }).subtract({ days: 1 })
+      startFrom = endOfMonth(dateObj)
 
     const extraDaysArray = Array.from({ length: extraDays }, (_, i) => {
       const incr = i + 1


### PR DESCRIPTION
When fixedWeeks is true and next month starts in another row of Calendar first day was missing:
![before](https://github.com/radix-vue/radix-vue/assets/54781638/39c436d3-feb8-4bf0-ba93-90bb1d358dcc)

After the fix:
![after](https://github.com/radix-vue/radix-vue/assets/54781638/102a1930-4817-4b0f-a959-882ba8052dfa)

Fix is quite simple but I've also extended the test case and added a new story for fixedWeeks. 

I do not know if you want to have all fixes covered by a test case but taking in to account that on my machine Calendar tests took 15 seconds before and now 2 seconds were added I would personally not merge my test.

I think the new story is also not providing that much value but it helped me test the fix so I included it as well.

Thank you for this library and for shadcn/vue :) 