### PR TITLE
chore: optimize start-up command to automatically open browser with story:dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "packages/*"
   ],
   "scripts": {
-    "story:dev": "pnpm --filter histoire story:dev",
+    "story:dev": "pnpm --filter histoire story:dev --open",
     "build": "rimraf packages/radix-vue/dist  && pnpm run --filter radix-vue build && pnpm run --filter plugins build",
     "build-only": "rimraf packages/radix-vue/dist  && pnpm run -r build-only",
     "docs:install": "pnpm --filter docs install",


### PR DESCRIPTION
When I launch story, the console messages push the browser access link to the top, which impacts the debugging experience