### PR TITLE
fix(Editable): use exposed edit function to trigger edit

### DIFF
--- a/packages/radix-vue/src/Editable/EditablePreview.vue
+++ b/packages/radix-vue/src/Editable/EditablePreview.vue
@@ -17,11 +17,11 @@ const placeholder = computed(() => context.placeholder.value?.preview)
 
 function handleFocus() {
   if (context.activationMode.value === 'focus')
-    context.isEditing.value = true
+    context.edit()
 }
 function handleDoubleClick() {
   if (context.activationMode.value === 'dblclick')
-    context.isEditing.value = true
+    context.edit()
 }
 </script>
 


### PR DESCRIPTION
So the `update:state` event is triggered with the `edit` state