### PR TITLE
Feat: add packages to vue, lint and build groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
       "groupName": "test",
       "matchPackageNames": [
         "vitest",
-        "jsdom"
+        "jsdom",
+        "@vue/test-utils"
       ],
       "matchPackagePrefixes": [
         "@vitest",

--- a/renovate.json
+++ b/renovate.json
@@ -42,13 +42,14 @@
         "vite"
       ],
       "matchPackagePrefixes": [
-        "vite",
+        "vite-",
         "@vitejs"
       ]
     },
     {
       "groupName": "lint",
       "matchPackageNames": [
+        "eslint",
         "simple-git-hooks",
         "lint-staged",
         "@antfu/eslint-config"
@@ -56,10 +57,20 @@
       "matchPackagePrefixes": [
         "eslint"
       ]
+    },
+    {
+      "groupName": "vue",
+      "matchPackageNames": [
+        "vue",
+        "vue-tsc"
+      ],
+      "matchPackagePrefixes": [
+        "@vue/",
+        "vue-"
+      ]
     }
   ],
   "ignoreDeps": [
-    "vue",
     "radix-vue",
     "node",
     "typescript"


### PR DESCRIPTION
Hello,

This PR adds the `vue` group for updating the dependencies and also adds several packages to the appropriate groups so that Renovate makes less PRs.