### PR TITLE
fix(Combobox,Listbox): `update:modelValue` with `multiple:true` does not get emitted

### DIFF
--- a/packages/radix-vue/src/Combobox/Combobox.test.ts
+++ b/packages/radix-vue/src/Combobox/Combobox.test.ts
@@ -10,6 +10,7 @@ import { handleSubmit } from '@/test'
 describe('given default Combobox', () => {
   let wrapper: VueWrapper<InstanceType<typeof Combobox>>
   let valueBox: DOMWrapper<HTMLInputElement>
+  let items: DOMWrapper<Element>[]
   window.HTMLElement.prototype.releasePointerCapture = vi.fn()
   window.HTMLElement.prototype.hasPointerCapture = vi.fn()
   window.HTMLElement.prototype.scrollIntoView = vi.fn()
@@ -41,6 +42,7 @@ describe('given default Combobox', () => {
     beforeEach(async () => {
       await wrapper.find('button').trigger('click')
       await nextTick()
+      items = wrapper.findAll('[role=option]')
     })
 
     it('should pass axe accessibility tests', async () => {
@@ -73,7 +75,7 @@ describe('given default Combobox', () => {
 
     describe('after selecting a value', () => {
       beforeEach(async () => {
-        const selection = wrapper.findAll('[role=option]')[1]
+        const selection = items[1]
         await selection.trigger('click')
       })
 
@@ -86,6 +88,10 @@ describe('given default Combobox', () => {
         expect(group.exists()).toBeFalsy()
       })
 
+      it('should emit `update:modelValue` event', () => {
+        expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toBe(items[1].text())
+      })
+
       describe('after opening the modal again', () => {
         beforeEach(async () => {
           await wrapper.find('button').trigger('click')
@@ -93,12 +99,12 @@ describe('given default Combobox', () => {
         })
 
         it('should focus on the selected value', () => {
-          const selection = wrapper.findAll('[role=option]')[1]
+          const selection = items[1]
           expect(selection.attributes('data-state')).toBe('checked')
         })
 
         it('should render the icon', () => {
-          const selection = wrapper.findAll('[role=option]')[1]
+          const selection = items[1]
           expect(selection.html()).toContain('svg')
         })
       })
@@ -141,6 +147,7 @@ describe('given default Combobox', () => {
 describe('given a Combobox with multiple prop', async () => {
   let wrapper: VueWrapper<InstanceType<typeof Combobox>>
   let valueBox: DOMWrapper<HTMLInputElement>
+  let items: DOMWrapper<Element>[]
 
   beforeEach(() => {
     document.body.innerHTML = ''
@@ -152,6 +159,7 @@ describe('given a Combobox with multiple prop', async () => {
     beforeEach(async () => {
       await wrapper.find('button').trigger('click')
       await nextTick()
+      items = wrapper.findAll('[role=option]')
     })
 
     it('should show the popup content', () => {
@@ -160,7 +168,7 @@ describe('given a Combobox with multiple prop', async () => {
 
     describe('after selecting a value', () => {
       beforeEach(async () => {
-        const selection = wrapper.findAll('[role=option]')[1]
+        const selection = items[1]
         await selection.trigger('click')
       })
 
@@ -171,6 +179,10 @@ describe('given a Combobox with multiple prop', async () => {
       it('should keep popup open', () => {
         const group = wrapper.find('[role=group]')
         expect(group.exists()).toBeTruthy()
+      })
+
+      it('should emit `update:modelValue` event', () => {
+        expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toEqual([items[1].text()])
       })
     })
   })

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -150,7 +150,9 @@ async function onOpenChange(val: boolean) {
 function onValueChange(val: T) {
   if (Array.isArray(modelValue.value) && multiple.value) {
     const index = modelValue.value.findIndex(i => isEqual(i, val))
-    index === -1 ? modelValue.value.push(val) : modelValue.value.splice(index, 1)
+    const modelArray = [...modelValue.value]
+    index === -1 ? modelArray.push(val) : modelArray.splice(index, 1)
+    modelValue.value = modelArray
   }
   else {
     modelValue.value = val

--- a/packages/radix-vue/src/Combobox/story/_Combobox.vue
+++ b/packages/radix-vue/src/Combobox/story/_Combobox.vue
@@ -1,21 +1,23 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { ComboboxAnchor, ComboboxContent, ComboboxEmpty, ComboboxGroup, ComboboxInput, ComboboxItem, ComboboxItemIndicator, ComboboxLabel, ComboboxRoot, type ComboboxRootProps, ComboboxSeparator, ComboboxTrigger, ComboboxViewport } from '../'
+import { ComboboxAnchor, ComboboxContent, ComboboxEmpty, ComboboxGroup, ComboboxInput, ComboboxItem, ComboboxItemIndicator, ComboboxLabel, ComboboxRoot, type ComboboxRootEmits, type ComboboxRootProps, ComboboxSeparator, ComboboxTrigger, ComboboxViewport } from '../'
 import { Icon } from '@iconify/vue'
+import { useForwardPropsEmits } from '@/shared'
 
 const props = defineProps<ComboboxRootProps>()
+const emits = defineEmits<ComboboxRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
 const v = ref<any>(props.multiple ? [] : '')
+
 const options = ['Apple', 'Banana', 'Blueberry', 'Grapes', 'Pineapple']
 const vegetables = ['Aubergine', 'Broccoli', 'Carrot', 'Courgette', 'Leek']
-
-const open = ref(props.open)
 </script>
 
 <template>
   <ComboboxRoot
-    v-bind="props"
+    v-bind="forwarded"
     v-model="v"
-    v-model:open="open"
     name="test"
   >
     <ComboboxAnchor class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-grass11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-grass9 outline-none">

--- a/packages/radix-vue/src/Listbox/Listbox.test.ts
+++ b/packages/radix-vue/src/Listbox/Listbox.test.ts
@@ -166,6 +166,19 @@ describe('given multiple `true` Listbox', () => {
     expect(items[4].attributes('aria-selected')).toBe('true')
   })
 
+  it('should emit `update:modelValue` event', async () => {
+    await content.trigger('keydown', { key: kbd.ENTER })
+    await content.trigger('keydown', { key: kbd.ARROW_DOWN })
+    await content.trigger('keydown', { key: kbd.ENTER })
+    await content.trigger('keydown', { key: kbd.ARROW_UP })
+    await content.trigger('keydown', { key: kbd.ENTER })
+    expect(wrapper.emitted('update:modelValue')).toEqual([
+      [[items[0].text()]],
+      [[items[0].text(), items[1].text()]],
+      [[items[1].text()]],
+    ])
+  })
+
   describe('when selection behavior `replace`', () => {
     beforeEach(async () => {
       wrapper.setProps({ selectionBehavior: 'replace' })
@@ -185,6 +198,17 @@ describe('given multiple `true` Listbox', () => {
       expect(document.activeElement).toBe(item.element)
       await newItem.trigger('click')
       expect(document.activeElement).toBe(newItem.element)
+    })
+
+    it('should emit `update:modelValue` event', async () => {
+      await content.trigger('keydown', { key: kbd.ENTER })
+      await content.trigger('keydown', { key: kbd.ARROW_DOWN })
+      await content.trigger('keydown', { key: kbd.ENTER })
+      expect(wrapper.emitted('update:modelValue')).toEqual([
+        [[items[0].text()]],
+        [[items[0].text()]], // there's a bug here, it shouldn't emit the same value twice
+        [[items[1].text()]],
+      ])
     })
 
     describe('when keypress Shift + ArrowDown', () => {

--- a/packages/radix-vue/src/Listbox/ListboxRoot.vue
+++ b/packages/radix-vue/src/Listbox/ListboxRoot.vue
@@ -115,7 +115,9 @@ function onValueChange(val: T) {
   if (Array.isArray(modelValue.value)) {
     const index = modelValue.value.findIndex(i => compare(i, val, props.by))
     if (props.selectionBehavior === 'toggle') {
-      index === -1 ? modelValue.value.push(val) : modelValue.value.splice(index, 1)
+      const modelArray = [...modelValue.value]
+      index === -1 ? modelArray.push(val) : modelArray.splice(index, 1)
+      modelValue.value = modelArray
     }
     else {
       modelValue.value = [val]


### PR DESCRIPTION
When using `v-model` with `multiple:true`, the `update:modelValue` event doesn't get emitted. Please see the reproduction link: https://codesandbox.io/p/sandbox/radix-vue-combobox-forked-9pqcs3

I noticed this behavior on Listbox and Combobox components. Searching through the code, there doesn't seem to be an issue with other components that accept single or multiple values as vModel. 
Alternatively, Listbox and Combobox components could be refactored to use `useSingleOrMultipleValue` composable (like ToggleGroup or Accordion use), however, the fix was pretty simple, and refactoring would take a lot more time (and I'm also not sure if it is a direction you'd want to go in), so I opted to just fix the problem.

When writing tests for the Listbox with `selectionBehavior: replace`, I found another bug - the `update:modelValue` event get's emitted twice for the same value (I only changed the code for `selectionBehavior: toggle`), but I couldn't find a root cause of the issue.