### PR TITLE
Fix: improve consistency of calendar cell triggers

### DIFF
--- a/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
@@ -86,7 +86,6 @@ function handleClick() {
 }
 
 function handleArrowKey(e: KeyboardEvent) {
-  const currentCell = e.target as HTMLDivElement
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!

--- a/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
@@ -9,7 +9,7 @@ import {
 } from '@internationalized/date'
 import { computed, nextTick } from 'vue'
 import { useKbd } from '@/shared'
-import { parseStringToDateValue, toDate } from '@/date'
+import { toDate } from '@/date'
 
 export interface CalendarCellTriggerProps extends PrimitiveProps {
   /** The date value provided to the cell trigger */
@@ -112,12 +112,7 @@ function handleArrowKey(e: KeyboardEvent) {
       break
     case kbd.ENTER:
     case kbd.SPACE_CODE:
-      changeDate(
-        parseStringToDateValue(
-          currentCell!.getAttribute('data-value')!,
-          rootContext.placeholder.value,
-        ),
-      )
+      changeDate(props.day)
       return
     default:
       return

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -9,7 +9,7 @@ import {
 } from '@internationalized/date'
 import { computed, nextTick } from 'vue'
 import { useKbd } from '@/shared'
-import { isBetweenInclusive, parseStringToDateValue, toDate } from '@/date'
+import { isBetweenInclusive, toDate } from '@/date'
 
 export interface RangeCalendarCellTriggerProps extends PrimitiveProps {
   day: DateValue
@@ -109,25 +109,17 @@ function changeDate(date: DateValue) {
   }
 }
 
-function handleClick(e: Event) {
-  const date = parseStringToDateValue((e.target as HTMLDivElement).getAttribute('data-value')!, rootContext.placeholder.value)
-
-  if (rootContext.isDateDisabled(date) || rootContext.isDateUnavailable?.(date))
-    return
-
-  changeDate(date)
+function handleClick() {
+  changeDate(props.day)
 }
 
-function handleFocus(e: Event) {
-  const date = parseStringToDateValue((e.target as HTMLDivElement).getAttribute('data-value')!, rootContext.placeholder.value)
-
-  if (rootContext.isDateDisabled(date) || rootContext.isDateUnavailable?.(date))
+function handleFocus() {
+  if (rootContext.isDateDisabled(props.day) || rootContext.isDateUnavailable?.(props.day))
     return
-  rootContext.focusedValue.value = date.copy()
+  rootContext.focusedValue.value = props.day.copy()
 }
 
 function handleArrowKey(e: KeyboardEvent) {
-  const currentCell = e.target as HTMLDivElement
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!
@@ -154,7 +146,7 @@ function handleArrowKey(e: KeyboardEvent) {
       break
     case kbd.ENTER:
     case kbd.SPACE_CODE:
-      changeDate(parseStringToDateValue(currentCell!.getAttribute('data-value')!, rootContext.placeholder.value))
+      changeDate(props.day)
       return
     default:
       return


### PR DESCRIPTION
Hello,

This PR adjusts the `CalendarCellTrigger`/`RangeCalendarCellTrigger` to depend on the `props.day` value on both its `keydown` and `mousedown` events, therefore improving the consistency of the implementation on both components.