### PR TITLE
Refactor(Editable): add data-focused attr 

### DIFF
--- a/docs/content/components/editable.md
+++ b/docs/content/components/editable.md
@@ -94,6 +94,10 @@ Contains the text parts of an editable component.
     },
     {
       attribute: '[data-focus]',
+      values: 'Present when the editable field is focused. To be deprecated in favor of [data-focused]',
+    },
+    {
+      attribute: '[data-focused]',
       values: 'Present when the editable field is focused',
     }
   ]"

--- a/packages/radix-vue/src/Editable/EditableArea.vue
+++ b/packages/radix-vue/src/Editable/EditableArea.vue
@@ -18,6 +18,7 @@ const context = injectEditableRootContext()
     v-bind="props"
     :data-placeholder-shown="context.isEditing.value ? undefined : ''"
     :data-focus="context.isEditing.value ? '' : undefined"
+    :data-focused="context.isEditing.value ? '' : undefined"
     :data-empty="context.isEmpty.value ? '' : undefined"
     :data-readonly="context.readonly.value ? '' : undefined"
     :data-disabled="context.disabled.value ? '' : undefined"


### PR DESCRIPTION
Hello,

This PR adds a `data-focused` attribute on the `EditableArea` to maintain consistency with other `data-*` attributes.

It also marks the initial `data-focus` attribute for deprecation.