### PR TITLE
refactor: remove calendar step prop

### DIFF
--- a/docs/content/components/calendar.md
+++ b/docs/content/components/calendar.md
@@ -63,7 +63,6 @@ import {
   CalendarHeadCell,
   CalendarHeader,
   CalendarHeading,
-
   CalendarNext,
   CalendarPrev,
   CalendarRoot

--- a/docs/content/meta/CalendarNext.md
+++ b/docs/content/meta/CalendarNext.md
@@ -19,12 +19,5 @@
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go forward</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false,
-    'default': '\'month\''
   }
 ]" />

--- a/docs/content/meta/CalendarPrev.md
+++ b/docs/content/meta/CalendarPrev.md
@@ -19,12 +19,5 @@
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go back</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false,
-    'default': '\'month\''
   }
 ]" />

--- a/docs/content/meta/DatePickerNext.md
+++ b/docs/content/meta/DatePickerNext.md
@@ -19,11 +19,5 @@
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go forward</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false
   }
 ]" />

--- a/docs/content/meta/DatePickerPrev.md
+++ b/docs/content/meta/DatePickerPrev.md
@@ -19,11 +19,5 @@
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go back</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false
   }
 ]" />

--- a/docs/content/meta/DateRangePickerNext.md
+++ b/docs/content/meta/DateRangePickerNext.md
@@ -19,11 +19,5 @@
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go forward</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false
   }
 ]" />

--- a/docs/content/meta/DateRangePickerPrev.md
+++ b/docs/content/meta/DateRangePickerPrev.md
@@ -19,11 +19,5 @@
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go forward</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false
   }
 ]" />

--- a/docs/content/meta/ListboxRoot.md
+++ b/docs/content/meta/ListboxRoot.md
@@ -72,7 +72,7 @@
   {
     'name': 'selectionBehavior',
     'description': '<p>How multiple selection should behave in the collection.</p>\n',
-    'type': '\'replace\' | \'toggle\'',
+    'type': '\'toggle\' | \'replace\'',
     'required': false,
     'default': '\'toggle\''
   }

--- a/docs/content/meta/RangeCalendarNext.md
+++ b/docs/content/meta/RangeCalendarNext.md
@@ -19,11 +19,5 @@
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go forward</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false
   }
 ]" />

--- a/docs/content/meta/RangeCalendarPrev.md
+++ b/docs/content/meta/RangeCalendarPrev.md
@@ -19,11 +19,5 @@
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
     'type': '((placeholder: DateValue) => DateValue)',
     'required': false
-  },
-  {
-    'name': 'step',
-    'description': '<p>The calendar unit to go forward</p>\n',
-    'type': '\'month\' | \'year\'',
-    'required': false
   }
 ]" />

--- a/docs/content/meta/TreeRoot.md
+++ b/docs/content/meta/TreeRoot.md
@@ -77,7 +77,7 @@
   {
     'name': 'selectionBehavior',
     'description': '<p>How multiple selection should behave in the collection.</p>\n',
-    'type': '\'replace\' | \'toggle\'',
+    'type': '\'toggle\' | \'replace\'',
     'required': false,
     'default': '\'toggle\''
   }

--- a/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/radix-vue/src/Calendar/CalendarCellTrigger.vue
@@ -123,7 +123,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex < 0) {
-    if (rootContext.isPrevButtonDisabled('month'))
+    if (rootContext.isPrevButtonDisabled())
       return
     rootContext.prevPage()
     nextTick(() => {
@@ -138,7 +138,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex >= allCollectionItems.length) {
-    if (rootContext.isNextButtonDisabled('month'))
+    if (rootContext.isNextButtonDisabled())
       return
     rootContext.nextPage()
     nextTick(() => {

--- a/packages/radix-vue/src/Calendar/CalendarNext.vue
+++ b/packages/radix-vue/src/Calendar/CalendarNext.vue
@@ -1,14 +1,8 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import type { CalendarIncrement } from '@/shared/date'
 import type { DateValue } from '@internationalized/date'
 
 export interface CalendarNextProps extends PrimitiveProps {
-/**
- * The calendar unit to go forward
- * @deprecated Use `nextPage` instead
- */
-  step?: CalendarIncrement
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the `CalendarRoot`. */
   nextPage?: (placeholder: DateValue) => DateValue
 }
@@ -29,10 +23,10 @@ const rootContext = injectCalendarRootContext()
     :as-child="props.asChild"
     aria-label="Next page"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isNextButtonDisabled(props.step, props.nextPage) || undefined"
-    :data-disabled="rootContext.isNextButtonDisabled(props.step, props.nextPage) || undefined"
-    :disabled="rootContext.isNextButtonDisabled(props.step, props.nextPage)"
-    @click="rootContext.nextPage(props.step, props.nextPage)"
+    :aria-disabled="rootContext.isNextButtonDisabled(props.nextPage) || undefined"
+    :data-disabled="rootContext.isNextButtonDisabled(props.nextPage) || undefined"
+    :disabled="rootContext.isNextButtonDisabled(props.nextPage)"
+    @click="rootContext.nextPage(props.nextPage)"
   >
     <slot>Next page</slot>
   </Primitive>

--- a/packages/radix-vue/src/Calendar/CalendarPrev.vue
+++ b/packages/radix-vue/src/Calendar/CalendarPrev.vue
@@ -1,14 +1,8 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import type { CalendarIncrement } from '@/shared/date'
 import type { DateValue } from '@internationalized/date'
 
 export interface CalendarPrevProps extends PrimitiveProps {
-/**
- * The calendar unit to go back
- * @deprecated Use `prevPage` instead
- */
-  step?: CalendarIncrement
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the `CalendarRoot`. */
   prevPage?: (placeholder: DateValue) => DateValue
 }
@@ -29,10 +23,10 @@ const rootContext = injectCalendarRootContext()
     :as="props.as"
     :as-child="props.asChild"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isPrevButtonDisabled(props.step, props.prevPage) || undefined"
-    :data-disabled="rootContext.isPrevButtonDisabled(props.step, props.prevPage) || undefined"
-    :disabled="rootContext.isPrevButtonDisabled(props.step, props.prevPage)"
-    @click="rootContext.prevPage(props.step, props.prevPage)"
+    :aria-disabled="rootContext.isPrevButtonDisabled(props.prevPage) || undefined"
+    :data-disabled="rootContext.isPrevButtonDisabled(props.prevPage) || undefined"
+    :disabled="rootContext.isPrevButtonDisabled(props.prevPage)"
+    @click="rootContext.prevPage(props.prevPage)"
   >
     <slot>Prev page</slot>
   </Primitive>

--- a/packages/radix-vue/src/Calendar/CalendarRoot.vue
+++ b/packages/radix-vue/src/Calendar/CalendarRoot.vue
@@ -6,7 +6,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import { type Formatter, createContext, useDirection } from '@/shared'
 
 import { useCalendar, useCalendarState } from './useCalendar'
-import { type CalendarIncrement, getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
+import { getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
 import type { Grid, Matcher, WeekDayFormat } from '@/date'
 import type { Direction } from '@/shared/types'
 
@@ -34,10 +34,10 @@ type CalendarRootContext = {
   isDateSelected: Matcher
   isDateUnavailable?: Matcher
   isOutsideVisibleView: (date: DateValue) => boolean
-  prevPage: (step?: CalendarIncrement, prevPageFunc?: (date: DateValue) => DateValue) => void
-  nextPage: (step?: CalendarIncrement, nextPageFunc?: (date: DateValue) => DateValue) => void
-  isNextButtonDisabled: (step?: CalendarIncrement, nextPageFunc?: (date: DateValue) => DateValue) => boolean
-  isPrevButtonDisabled: (step?: CalendarIncrement, prevPageFunc?: (date: DateValue) => DateValue) => boolean
+  prevPage: (prevPageFunc?: (date: DateValue) => DateValue) => void
+  nextPage: (nextPageFunc?: (date: DateValue) => DateValue) => void
+  isNextButtonDisabled: (nextPageFunc?: (date: DateValue) => DateValue) => boolean
+  isPrevButtonDisabled: (prevPageFunc?: (date: DateValue) => DateValue) => boolean
   formatter: Formatter
   dir: Ref<Direction>
 }

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -158,7 +158,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex < 0) {
-    if (rootContext.isPrevButtonDisabled('month'))
+    if (rootContext.isPrevButtonDisabled())
       return
     rootContext.prevPage()
     nextTick(() => {
@@ -171,7 +171,7 @@ function handleArrowKey(e: KeyboardEvent) {
   }
 
   if (newIndex >= allCollectionItems.length) {
-    if (rootContext.isNextButtonDisabled('month'))
+    if (rootContext.isNextButtonDisabled())
       return
     rootContext.nextPage()
     nextTick(() => {

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarNext.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarNext.vue
@@ -1,14 +1,8 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import type { CalendarIncrement } from '@/shared/date'
 import type { DateValue } from '@internationalized/date'
 
 export interface RangeCalendarNextProps extends PrimitiveProps {
-/**
- * The calendar unit to go forward
- * @deprecated Use `nextPage` instead
- */
-  step?: CalendarIncrement
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the `RangeCalendarRoot`. */
   nextPage?: (placeholder: DateValue) => DateValue
 }
@@ -28,10 +22,10 @@ const rootContext = injectRangeCalendarRootContext()
     v-bind="props"
     aria-label="Next page"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isNextButtonDisabled(props.step, props.nextPage) || undefined"
-    :data-disabled="rootContext.isNextButtonDisabled(props.step, props.nextPage) || undefined"
-    :disabled="rootContext.isNextButtonDisabled(props.step, props.nextPage)"
-    @click="rootContext.nextPage(props.step, props.nextPage)"
+    :aria-disabled="rootContext.isNextButtonDisabled(props.nextPage) || undefined"
+    :data-disabled="rootContext.isNextButtonDisabled(props.nextPage) || undefined"
+    :disabled="rootContext.isNextButtonDisabled(props.nextPage)"
+    @click="rootContext.nextPage(props.nextPage)"
   >
     <slot>Next page</slot>
   </Primitive>

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarPrev.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarPrev.vue
@@ -1,14 +1,8 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import type { CalendarIncrement } from '@/shared/date'
 import type { DateValue } from '@internationalized/date'
 
 export interface RangeCalendarPrevProps extends PrimitiveProps {
-/**
- * The calendar unit to go forward
- * @deprecated Use `prevPage` instead
- */
-  step?: CalendarIncrement
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the `RangeCalendarRoot`. */
   prevPage?: (placeholder: DateValue) => DateValue
 }
@@ -28,10 +22,10 @@ const rootContext = injectRangeCalendarRootContext()
     v-bind="props"
     aria-label="Previous page"
     :type="as === 'button' ? 'button' : undefined"
-    :aria-disabled="rootContext.isPrevButtonDisabled(props.step, props.prevPage) || undefined"
-    :data-disabled="rootContext.isPrevButtonDisabled(props.step, props.prevPage) || undefined"
-    :disabled="rootContext.isPrevButtonDisabled(props.step, props.prevPage)"
-    @click="rootContext.prevPage(props.step, props.prevPage)"
+    :aria-disabled="rootContext.isPrevButtonDisabled(props.prevPage) || undefined"
+    :data-disabled="rootContext.isPrevButtonDisabled(props.prevPage) || undefined"
+    :disabled="rootContext.isPrevButtonDisabled(props.prevPage)"
+    @click="rootContext.prevPage(props.prevPage)"
   >
     <slot>Prev page</slot>
   </Primitive>

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
@@ -6,7 +6,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import { type Formatter, createContext, useDirection } from '@/shared'
 import { getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
 import { type Grid, type Matcher, type WeekDayFormat, isBefore } from '@/date'
-import type { CalendarIncrement, DateRange } from '@/shared/date'
+import type { DateRange } from '@/shared/date'
 import { useRangeCalendarState } from './useRangeCalendar'
 import { useCalendar } from '@/Calendar/useCalendar'
 import type { Direction } from '@/shared/types'
@@ -40,10 +40,10 @@ type RangeCalendarRootContext = {
   isSelected: (date: DateValue) => boolean
   isSelectionEnd: (date: DateValue) => boolean
   isSelectionStart: (date: DateValue) => boolean
-  prevPage: (step?: CalendarIncrement, prevPageFunc?: (date: DateValue) => DateValue) => void
-  nextPage: (step?: CalendarIncrement, nextPageFunc?: (date: DateValue) => DateValue) => void
-  isNextButtonDisabled: (step?: CalendarIncrement, nextPageFunc?: (date: DateValue) => DateValue) => boolean
-  isPrevButtonDisabled: (step?: CalendarIncrement, prevPageFunc?: (date: DateValue) => DateValue) => boolean
+  prevPage: (prevPageFunc?: (date: DateValue) => DateValue) => void
+  nextPage: (nextPageFunc?: (date: DateValue) => DateValue) => void
+  isNextButtonDisabled: (nextPageFunc?: (date: DateValue) => DateValue) => boolean
+  isPrevButtonDisabled: (prevPageFunc?: (date: DateValue) => DateValue) => boolean
   formatter: Formatter
   dir: Ref<Direction>
 }
@@ -129,7 +129,6 @@ const props = withDefaults(defineProps<RangeCalendarRootProps>(), {
   locale: 'en',
   isDateDisabled: undefined,
   isDateUnavailable: undefined,
-  initialView: 'month',
 })
 const emits = defineEmits<RangeCalendarRootEmits>()
 

--- a/packages/radix-vue/src/RangeCalendar/story/_RangeCalendar.vue
+++ b/packages/radix-vue/src/RangeCalendar/story/_RangeCalendar.vue
@@ -7,6 +7,12 @@ const props = defineProps<{
   calendarProps?: RangeCalendarRootProps
   emits?: { 'onUpdate:modelValue'?: (data: DateValue) => void }
 }>()
+
+function pagingFunc(date: DateValue, sign: -1 | 1) {
+  if (sign === -1)
+    return date.subtract({ years: 1 })
+  return date.add({ years: 1 })
+}
 </script>
 
 <template>
@@ -19,7 +25,7 @@ const props = defineProps<{
     <RangeCalendarHeader data-testid="header">
       <RangeCalendarPrev
         data-testid="prev-year-button"
-        step="year"
+        :prev-page="(date: DateValue) => pagingFunc(date, -1)"
       />
       <RangeCalendarPrev
         data-testid="prev-button"
@@ -30,7 +36,7 @@ const props = defineProps<{
       />
       <RangeCalendarNext
         data-testid="next-year-button"
-        step="year"
+        :next-page="(date: DateValue) => pagingFunc(date, 1)"
       />
     </RangeCalendarHeader>
 

--- a/packages/radix-vue/src/shared/date/index.ts
+++ b/packages/radix-vue/src/shared/date/index.ts
@@ -3,7 +3,6 @@ export {
   getDefaultDate,
 } from './comparators'
 export type {
-  CalendarIncrement,
   DateRange,
   DayOfWeek,
   HourCycle,

--- a/packages/radix-vue/src/shared/date/types.ts
+++ b/packages/radix-vue/src/shared/date/types.ts
@@ -11,8 +11,6 @@ export type DayOfWeek = {
   daysOfWeek: (typeof daysOfWeek)[number][]
 }
 
-export type CalendarIncrement = 'month' | 'year'
-
 export type DateRange = {
   start: DateValue | undefined
   end: DateValue | undefined


### PR DESCRIPTION
Hello,

This PR fully removes the `step` property from the `CalendarNext`/`CalendarPrev` components, plus adjusts the utility functions to take this change into account.

I've marked this PR with the `v2` label to keep track of it.