### PR TITLE
Update ComboboxItem error message for empty 'value' prop

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxItem.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxItem.vue
@@ -93,7 +93,7 @@ async function handlePointerMove(event: PointerEvent) {
 
 if (props.value === '') {
   throw new Error(
-    'A <SelectItem /> must have a value prop that is not an empty string. This is because the Select value can be set to an empty string to clear the selection and show the placeholder.',
+    'A <ComboboxItem /> must have a value prop that is not an empty string. This is because the Combobox value can be set to an empty string to clear the selection and show the placeholder.',
   )
 }
 


### PR DESCRIPTION
Looks like it was originally copied from `SelectItem` implementation. So pretty much just fixing a typo.