### PR TITLE
docs: update mentions of `DirectionProvider` to `ConfigProvider`

### DIFF
--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -28,7 +28,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/ContextMenuRoot.md
+++ b/docs/content/meta/ContextMenuRoot.md
@@ -3,7 +3,7 @@
 <PropsTable :data="[
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/DropdownMenuRoot.md
+++ b/docs/content/meta/DropdownMenuRoot.md
@@ -9,7 +9,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/ListboxRoot.md
+++ b/docs/content/meta/ListboxRoot.md
@@ -28,7 +28,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the listbox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the listbox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/MenubarRoot.md
+++ b/docs/content/meta/MenubarRoot.md
@@ -9,7 +9,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/NavigationMenuRoot.md
+++ b/docs/content/meta/NavigationMenuRoot.md
@@ -29,7 +29,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/PinInputRoot.md
+++ b/docs/content/meta/PinInputRoot.md
@@ -22,7 +22,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/RadioGroupRoot.md
+++ b/docs/content/meta/RadioGroupRoot.md
@@ -22,7 +22,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/ScrollAreaRoot.md
+++ b/docs/content/meta/ScrollAreaRoot.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/SelectRoot.md
+++ b/docs/content/meta/SelectRoot.md
@@ -22,7 +22,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/SliderRoot.md
+++ b/docs/content/meta/SliderRoot.md
@@ -23,7 +23,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/StepperRoot.md
+++ b/docs/content/meta/StepperRoot.md
@@ -23,7 +23,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/TabsRoot.md
+++ b/docs/content/meta/TabsRoot.md
@@ -29,7 +29,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/TagsInputRoot.md
+++ b/docs/content/meta/TagsInputRoot.md
@@ -54,7 +54,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/ToggleGroupRoot.md
+++ b/docs/content/meta/ToggleGroupRoot.md
@@ -22,7 +22,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/ToolbarRoot.md
+++ b/docs/content/meta/ToolbarRoot.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/ToolbarToggleGroup.md
+++ b/docs/content/meta/ToolbarToggleGroup.md
@@ -22,7 +22,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the combobox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/docs/content/meta/TreeRoot.md
+++ b/docs/content/meta/TreeRoot.md
@@ -28,7 +28,7 @@
   },
   {
     'name': 'dir',
-    'description': '<p>The reading direction of the listbox when applicable. &lt;br&gt; If omitted, inherits globally from <code>DirectionProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'description': '<p>The reading direction of the listbox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
     'required': false
   },

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -64,7 +64,7 @@ export interface ComboboxRootProps<T = AcceptableValue> extends PrimitiveProps {
   disabled?: boolean
   /** The name of the Combobox. Submitted with its owning form as part of a name/value pair. */
   name?: string
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** The custom filter function for filtering `ComboboxItem`. */
   filterFunction?: (val: ArrayOrWrapped<T>, term: string) => ArrayOrWrapped<T>

--- a/packages/radix-vue/src/Listbox/ListboxRoot.vue
+++ b/packages/radix-vue/src/Listbox/ListboxRoot.vue
@@ -43,7 +43,7 @@ export interface ListboxRootProps<T = AcceptableValue> extends PrimitiveProps {
   multiple?: boolean
   /** The orientation of the listbox. <br>Mainly so arrow navigation is done accordingly (left & right vs. up & down) */
   orientation?: DataOrientation
-  /** The reading direction of the listbox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the listbox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** When `true`, prevents the user from interacting with listbox */
   disabled?: boolean

--- a/packages/radix-vue/src/Menu/MenuRoot.vue
+++ b/packages/radix-vue/src/Menu/MenuRoot.vue
@@ -23,7 +23,7 @@ export interface MenuProps {
   /**
    * The reading direction of the combobox when applicable.
    *
-   * If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode.
+   * If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
   dir?: Direction
   /**

--- a/packages/radix-vue/src/Menubar/MenubarRoot.vue
+++ b/packages/radix-vue/src/Menubar/MenubarRoot.vue
@@ -11,7 +11,7 @@ export interface MenubarRootProps {
   /**
    * The reading direction of the combobox when applicable.
    *
-   *  If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode.
+   *  If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
   dir?: Direction
   /** When `true`, keyboard navigation will loop from last item to first, and vice versa. */

--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuRoot.vue
@@ -17,7 +17,7 @@ export interface NavigationMenuRootProps extends PrimitiveProps {
   /**
    * The reading direction of the combobox when applicable.
    *
-   *  If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode.
+   *  If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
   dir?: Direction
   /** The orientation of the menu. */

--- a/packages/radix-vue/src/PinInput/PinInputRoot.vue
+++ b/packages/radix-vue/src/PinInput/PinInputRoot.vue
@@ -22,7 +22,7 @@ export interface PinInputRootProps extends PrimitiveProps {
   otp?: boolean
   /** Input type for the inputs. */
   type?: 'text' | 'number'
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** The name of the pin input. Submitted with its owning form as part of a name/value pair. */
   name?: string

--- a/packages/radix-vue/src/RadioGroup/RadioGroupRoot.vue
+++ b/packages/radix-vue/src/RadioGroup/RadioGroupRoot.vue
@@ -21,7 +21,7 @@ export interface RadioGroupRootProps extends PrimitiveProps {
   required?: boolean
   /** The orientation of the component. */
   orientation?: DataOrientation
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** When `true`, keyboard navigation will loop from last item to first, and vice versa. */
   loop?: boolean

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaRoot.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaRoot.vue
@@ -38,7 +38,7 @@ export interface ScrollAreaRootProps extends PrimitiveProps {
    * `hover` - when the user is scrolling along its corresponding orientation and when the user is hovering over the scroll area.
    */
   type?: ScrollType
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** If type is set to either `scroll` or `hover`, this prop determines the length of time, in milliseconds, <br> before the scrollbars are hidden after the user stops interacting with scrollbars. */
   scrollHideDelay?: number

--- a/packages/radix-vue/src/Select/SelectRoot.vue
+++ b/packages/radix-vue/src/Select/SelectRoot.vue
@@ -12,7 +12,7 @@ export interface SelectRootProps {
   defaultValue?: string
   /** The controlled value of the Select. Can be bind as `v-model`. */
   modelValue?: string
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** The name of the Select. Submitted with its owning form as part of a name/value pair. */
   name?: string

--- a/packages/radix-vue/src/Slider/SliderRoot.vue
+++ b/packages/radix-vue/src/Slider/SliderRoot.vue
@@ -15,7 +15,7 @@ export interface SliderRootProps extends PrimitiveProps {
   disabled?: boolean
   /** The orientation of the slider. */
   orientation?: DataOrientation
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** Whether the slider is visually inverted. */
   inverted?: boolean

--- a/packages/radix-vue/src/Stepper/StepperRoot.vue
+++ b/packages/radix-vue/src/Stepper/StepperRoot.vue
@@ -29,7 +29,7 @@ export interface StepperRootProps extends PrimitiveProps {
    */
   orientation?: DataOrientation
   /**
-   * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode.
+   * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
   dir?: Direction
   /** The controlled value of the tab to activate. Can be bound as `v-model`. */

--- a/packages/radix-vue/src/Tabs/TabsRoot.vue
+++ b/packages/radix-vue/src/Tabs/TabsRoot.vue
@@ -27,7 +27,7 @@ export interface TabsRootProps<T extends StringOrNumber = StringOrNumber> extend
    */
   orientation?: DataOrientation
   /**
-   * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode.
+   * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
   dir?: Direction
   /**

--- a/packages/radix-vue/src/TagsInput/TagsInputRoot.vue
+++ b/packages/radix-vue/src/TagsInput/TagsInputRoot.vue
@@ -23,7 +23,7 @@ export interface TagsInputRootProps<T = AcceptableInputValue> extends PrimitiveP
   disabled?: boolean
   /** The character to trigger the addition of a new tag. Also used to split tags for `@paste` event */
   delimiter?: string
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** Maximum number of tags. */
   max?: number

--- a/packages/radix-vue/src/ToggleGroup/ToggleGroupRoot.vue
+++ b/packages/radix-vue/src/ToggleGroup/ToggleGroupRoot.vue
@@ -12,7 +12,7 @@ export interface ToggleGroupRootProps<ValidValue = string | string[], ExplicitTy
   disabled?: boolean
   /** The orientation of the component, which determines how focus moves: `horizontal` for left/right arrows and `vertical` for up/down arrows. */
   orientation?: DataOrientation
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** When `loop` and `rovingFocus` is `true`, keyboard navigation will loop from last item to first, and vice versa. */
   loop?: boolean

--- a/packages/radix-vue/src/Toolbar/ToolbarRoot.vue
+++ b/packages/radix-vue/src/Toolbar/ToolbarRoot.vue
@@ -7,7 +7,7 @@ import { createContext, useDirection, useForwardExpose } from '@/shared'
 export interface ToolbarRootProps extends PrimitiveProps {
   /** The orientation of the toolbar */
   orientation?: DataOrientation
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** When `true`, keyboard navigation will loop from last tab to first, and vice versa. */
   loop?: boolean

--- a/packages/radix-vue/src/Tree/TreeRoot.vue
+++ b/packages/radix-vue/src/Tree/TreeRoot.vue
@@ -20,7 +20,7 @@ export interface TreeRootProps<T = Record<string, any>, U extends Record<string,
   selectionBehavior?: 'toggle' | 'replace'
   /** Whether multiple options can be selected or not.  */
   multiple?: boolean
-  /** The reading direction of the listbox when applicable. <br> If omitted, inherits globally from `DirectionProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the listbox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** When `true`, prevents the user from interacting with tree  */
   disabled?: boolean


### PR DESCRIPTION
Noticed this inconsistency in docs as I was working on #1108.

I believe this is just a remnant of Radix UI documentation. We don't have a dedicated `DirectionProvider` and `dir` is configured globally via `ConfigProvider`.