### PR TITLE
fix(Splitter): splitter-panel works based on the old layout after props change

### DIFF
--- a/packages/radix-vue/src/Splitter/SplitterGroup.vue
+++ b/packages/radix-vue/src/Splitter/SplitterGroup.vue
@@ -415,7 +415,9 @@ function resizePanel(panelData: PanelData, unsafePanelSize: number) {
 
 function reevaluatePanelConstraints(panelData: PanelData, prevConstraints: PanelConstraints) {
   const { layout, panelDataArray } = eagerValuesRef.value
-
+  const index = findPanelDataIndex(panelDataArray, panelData)
+  panelDataArray[index] = panelData
+  eagerValuesRef.value.panelDataArrayChanged = true
   const {
     collapsedSize: prevCollapsedSize = 0,
     collapsible: prevCollapsible,

--- a/packages/radix-vue/src/Splitter/SplitterPanel.vue
+++ b/packages/radix-vue/src/Splitter/SplitterPanel.vue
@@ -107,7 +107,7 @@ const panelDataRef = computed(() => ({
   order: props.order,
 }) satisfies PanelData)
 
-watch(() => panelDataRef.value.constraints, (prevConstraints, constraints) => {
+watch(() => panelDataRef.value.constraints, (constraints, prevConstraints) => {
   // If constraints have changed, we should revisit panel sizes.
   // This is uncommon but may happen if people are trying to implement pixel based constraints.
   if (


### PR DESCRIPTION
fix #1112 
after I update `eagerValuesRef` . `Splitter` will be reset to default size. I'm not sure is this a bug or feature.

