### PR TITLE
fix: export TreeItemEmits

### DIFF
--- a/packages/radix-vue/src/Tree/index.ts
+++ b/packages/radix-vue/src/Tree/index.ts
@@ -7,6 +7,7 @@ export {
 export {
   default as TreeItem,
   type TreeItemProps,
+  type TreeItemEmits,
   type SelectEvent as TreeItemSelectEvent,
   type ToggleEvent as TreeItemToggleEvent,
 } from './TreeItem.vue'


### PR DESCRIPTION
This PR adds the missing `TreeItemEmits` export to `Tree/index.ts`

Closes #1115