### PR TITLE
Fix the aria-selected attribute for SelectItem

### DIFF
--- a/packages/radix-vue/src/Select/SelectItem.vue
+++ b/packages/radix-vue/src/Select/SelectItem.vue
@@ -136,7 +136,7 @@ provideSelectItemContext({
     data-radix-vue-collection-item
     :aria-labelledby="textId"
     :data-highlighted="isFocused ? '' : undefined"
-    :aria-selected="isSelected && isFocused"
+    :aria-selected="isSelected"
     :data-state="isSelected ? 'checked' : 'unchecked'"
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled ? '' : undefined"


### PR DESCRIPTION
The bug was that the aria-selected was only true when the option was also highlighted (isFocused). I looked at how this is done in Combobox (where it's working correctly) and adjusted it accordingly.