### PR TITLE
fix(Combobox): workaround for maximum recursion update issues

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxInput.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxInput.vue
@@ -13,7 +13,7 @@ export interface ComboboxInputProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, watchSyncEffect } from 'vue'
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
 import { Primitive } from '@/Primitive'
 
@@ -42,6 +42,10 @@ onMounted(() => {
 })
 
 const disabled = computed(() => props.disabled || rootContext.disabled.value || false)
+
+// This is a hack to prevent Vue from throwing "max recursion" errors.
+const activedescendant = ref<string | undefined>()
+watchSyncEffect(() => activedescendant.value = rootContext.selectedElement.value?.id)
 
 function handleKeyDown(ev: KeyboardEvent) {
   if (!rootContext.open.value)
@@ -76,7 +80,7 @@ function handleInput(event: Event) {
     :aria-expanded="rootContext.open.value"
     :aria-controls="rootContext.contentId"
     :aria-disabled="disabled ?? undefined"
-    :aria-activedescendant="rootContext.selectedElement.value?.id"
+    :aria-activedescendant="activedescendant"
     aria-autocomplete="list"
     role="combobox"
     autocomplete="false"

--- a/packages/radix-vue/src/Combobox/story/_Combobox1k.vue
+++ b/packages/radix-vue/src/Combobox/story/_Combobox1k.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { ComboboxAnchor, ComboboxContent, ComboboxEmpty, ComboboxInput, ComboboxItem, ComboboxItemIndicator, ComboboxRoot, type ComboboxRootEmits, type ComboboxRootProps, ComboboxTrigger, ComboboxViewport } from '../'
+import { Icon } from '@iconify/vue'
+import { useForwardPropsEmits } from '@/shared'
+
+const props = defineProps<ComboboxRootProps>()
+const emits = defineEmits<ComboboxRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+const v = ref<string>()
+</script>
+
+<template>
+  <ComboboxRoot
+    v-bind="forwarded"
+    v-model="v"
+    name="test"
+    :display-value="(val) => `Option #${val}`"
+    :filter-function="(opts: any[], search: string) => opts.filter((opt) => opt.includes(search))"
+  >
+    <ComboboxAnchor class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-grass11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-grass9 outline-none">
+      <ComboboxInput
+        class="bg-transparent outline-none text-grass11 placeholder-gray-400"
+        placeholder="Placeholder..."
+      />
+      <ComboboxTrigger>
+        <Icon
+          icon="radix-icons:chevron-down"
+          class="h-4 w-4 text-grass11"
+        />
+      </ComboboxTrigger>
+    </ComboboxAnchor>
+    <ComboboxContent class="mt-2 min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade">
+      <ComboboxViewport class="p-[5px]">
+        <ComboboxEmpty class="text-gray-400  text-xs font-medium text-center py-2" />
+
+        <ComboboxItem
+          v-for="i in 1000"
+          :key="i"
+          :value="`${i}`"
+        >
+          <ComboboxItemIndicator
+            class="absolute left-0 w-[25px] inline-flex items-center justify-center"
+          >
+            <Icon icon="radix-icons:check" />
+          </ComboboxItemIndicator>
+          <span>
+            Option #{{ i }}
+          </span>
+        </ComboboxItem>
+      </ComboboxViewport>
+    </ComboboxContent>
+  </ComboboxRoot>
+</template>


### PR DESCRIPTION
This is a hacky solution that fixes #1040 and works fine with 100+ options in a combobox. As v2 is being developed and the combobox gets reworked to better handle these cases, I assume a better solution will be implemented - the purpose of this fix is to unblock people stuck on 1.8.3 due to this bug.