### PR TITLE
feat(Tree): allow custom children schema

### DIFF
--- a/docs/content/components/tree.md
+++ b/docs/content/components/tree.md
@@ -275,17 +275,16 @@ In `CustomTree.vue`
 
 ### Custom children schema
 
-By default, `<TreeRoot />` expects you to provide the list of node's children by passing a list of `children` for every node. You can overwrite that by providing the `getChildren` prop.
+By default, `<TreeRoot />` expects you to provide the list of node's children by passing a list of `children` for every node. You can override that by providing the `getChildren` prop.
 
 ::: NOTE
 If the node doesn't have any children, `getChildren` should return `undefined` instead of an empty array.
 :::
 
-In `Tree.vue`,
-
-```vue
+```vue line=22
 <script setup lang="ts">
-import { TreeItem } from 'radix-vue'
+import { ref } from 'vue'
+import { TreeRoot } from 'radix-vue'
 
 interface FileNode {
   title: string
@@ -298,47 +297,15 @@ interface DirectoryNode {
   directories?: DirectoryNode[]
   files?: FileNode[]
 }
-
-withDefaults(defineProps<{
-  treeItems: DirectoryNode[]
-  level?: number
-}>(), { level: 0 })
 </script>
 
-<template>
-  <li
-    v-for=" tree in treeItems"
-    :key="tree.title"
-  >
-    <TreeItem
-      v-slot="{ isExpanded }"
-      as-child
-      :level="level"
-      :value="tree"
-    >
-      <button>…</button>
-
-      <ul v-if="isExpanded && tree.children">
-        <Tree
-          :tree-items="tree.children"
-          :level="level + 1"
-        />
-      </ul>
-    </TreeItem>
-  </li>
-</template>
-```
-
-In `CustomTree.vue`
-
-```vue
 <template>
   <TreeRoot
     :items="items"
     :get-key="(item) => item.title"
     :get-children="(item) => (!item.files) ? item.directories : (!item.directories) ? item.files : [...item.directories, ...item.files]"
   >
-    <Tree :tree-items="items" />
+    ...
   </TreeRoot>
 </template>
 ```

--- a/docs/content/components/tree.md
+++ b/docs/content/components/tree.md
@@ -273,6 +273,76 @@ In `CustomTree.vue`
 </template>
 ```
 
+### Custom children schema
+
+By default, `<TreeRoot />` expects you to provide the list of node's children by passing a list of `children` for every node. You can overwrite that by providing the `getChildren` prop.
+
+::: NOTE
+If the node doesn't have any children, `getChildren` should return `undefined` instead of an empty array.
+:::
+
+In `Tree.vue`,
+
+```vue
+<script setup lang="ts">
+import { TreeItem } from 'radix-vue'
+
+interface FileNode {
+  title: string
+  icon: string
+}
+
+interface DirectoryNode {
+  title: string
+  icon: string
+  directories?: DirectoryNode[]
+  files?: FileNode[]
+}
+
+withDefaults(defineProps<{
+  treeItems: DirectoryNode[]
+  level?: number
+}>(), { level: 0 })
+</script>
+
+<template>
+  <li
+    v-for=" tree in treeItems"
+    :key="tree.title"
+  >
+    <TreeItem
+      v-slot="{ isExpanded }"
+      as-child
+      :level="level"
+      :value="tree"
+    >
+      <button>…</button>
+
+      <ul v-if="isExpanded && tree.children">
+        <Tree
+          :tree-items="tree.children"
+          :level="level + 1"
+        />
+      </ul>
+    </TreeItem>
+  </li>
+</template>
+```
+
+In `CustomTree.vue`
+
+```vue
+<template>
+  <TreeRoot
+    :items="items"
+    :get-key="(item) => item.title"
+    :get-children="(item) => (!item.files) ? item.directories : (!item.directories) ? item.files : [...item.directories, ...item.files]"
+  >
+    <Tree :tree-items="items" />
+  </TreeRoot>
+</template>
+```
+
 ### Draggable/Sortable Tree
 
 For more complex draggable `Tree` component, in this example we will be using [pragmatic-drag-and-drop](https://github.com/atlassian/pragmatic-drag-and-drop), as the core package for handling dnd.

--- a/docs/content/meta/TreeRoot.md
+++ b/docs/content/meta/TreeRoot.md
@@ -51,6 +51,12 @@
     'required': true
   },
   {
+    'name': 'getChildren',
+    'description': '<p>This function is passed the index of each item and should return a list of children for that item</p>\n',
+    'type': '(val: Record<string, any>) => Record<string, any>[] | undefined',
+    'required': false
+  },
+  {
     'name': 'items',
     'description': '<p>List of items</p>\n',
     'type': 'Record<string, any>[]',

--- a/packages/radix-vue/src/Tree/Tree.test.ts
+++ b/packages/radix-vue/src/Tree/Tree.test.ts
@@ -187,3 +187,102 @@ describe('given multiple `true` Tree', () => {
     })
   })
 })
+
+describe('given a Tree with a custom children structure', () => {
+  const customItems = [
+    { title: 'index.vue', icon: 'vue' },
+    {
+      title: 'lib',
+      icon: 'folder',
+      directories: [
+        {
+          title: 'tree',
+          icon: 'folder',
+          files: [
+            {
+              title: 'Tree.vue',
+              icon: 'vue',
+            },
+            {
+              title: 'TreeView.vue',
+              icon: 'vue',
+            },
+          ],
+        },
+        {
+          title: 'icons',
+          icon: 'folder',
+          files: [
+            { title: 'JS.vue', icon: 'vue' },
+            { title: 'vue.vue', icon: 'vue' },
+          ],
+        },
+      ],
+      files: [
+        {
+          title: 'index.js',
+          icon: 'js',
+        },
+      ],
+    },
+    {
+      title: 'routes',
+      icon: 'folder',
+      directories: [
+        {
+          title: 'contents',
+          icon: 'folder',
+          files: [
+            {
+              title: '+layout.vue',
+              icon: 'vue',
+            },
+            {
+              title: '+page.vue',
+              icon: 'vue',
+            },
+          ],
+        },
+      ],
+    },
+  ]
+
+  let wrapper: VueWrapper<InstanceType<typeof Tree>>
+  // let content: DOMWrapper<Element>
+  let items: DOMWrapper<Element>[]
+
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    wrapper = mount(Tree, { props: { items: customItems, multiple: true, selectionBehavior: 'toggle', getChildren: val => (!val.files) ? val.directories : (!val.directories) ? val.files : [...val.directories, ...val.files] }, attachTo: document.body })
+    await nextTick()
+    // content = wrapper.find('[role=tree]')
+    items = wrapper.findAll('[role=treeitem]')
+  })
+
+  const updateItems = () => {
+    items = wrapper.findAll('[role=treeitem]')
+  }
+
+  describe('when expand item', async () => {
+    beforeEach(async () => {
+      await items[1].trigger('keydown', { key: kbd.ARROW_RIGHT });
+      (items[1].element as HTMLElement).focus()
+      updateItems()
+    })
+
+    it('should expand the item, revealing it\'s item', () => {
+      expect(items[2].text()).toBe('tree')
+    })
+
+    describe('when expand nested item', async () => {
+      beforeEach(async () => {
+        await items[2].trigger('keydown', { key: kbd.ARROW_RIGHT })
+        updateItems()
+      })
+
+      it('should expand the nested item, revealing it\'s item ', () => {
+        expect(items[3].text()).toBe('Tree.vue')
+      })
+    })
+  })
+})

--- a/packages/radix-vue/src/Tree/TreeItem.vue
+++ b/packages/radix-vue/src/Tree/TreeItem.vue
@@ -51,7 +51,7 @@ defineSlots<{
 const rootContext = injectTreeRootContext()
 const { getItems } = useCollection()
 
-const hasChildren = computed(() => !!props.value.children)
+const hasChildren = computed(() => !!rootContext.getChildren(props.value))
 
 const isExpanded = computed(() => {
   const key = rootContext.getKey(props.value)
@@ -65,7 +65,7 @@ const isSelected = computed(() => {
 
 const isIndeterminate = computed(() => {
   if (rootContext.propagateSelect.value && isSelected.value && hasChildren.value && Array.isArray(rootContext.modelValue.value)) {
-    const children = flatten<T, any>(props.value.children)
+    const children = flatten<T, any>(rootContext.getChildren(props.value))
 
     return !children.every(child => rootContext.modelValue.value.find((v: any) => rootContext.getKey(v) === rootContext.getKey(child)))
   }

--- a/packages/radix-vue/src/Tree/TreeItem.vue
+++ b/packages/radix-vue/src/Tree/TreeItem.vue
@@ -65,7 +65,7 @@ const isSelected = computed(() => {
 
 const isIndeterminate = computed(() => {
   if (rootContext.propagateSelect.value && isSelected.value && hasChildren.value && Array.isArray(rootContext.modelValue.value)) {
-    const children = flatten<T, any>(rootContext.getChildren(props.value))
+    const children = flatten<T, any>(rootContext.getChildren(props.value) || [])
 
     return !children.every(child => rootContext.modelValue.value.find((v: any) => rootContext.getKey(v) === rootContext.getKey(child)))
   }


### PR DESCRIPTION
Adds a new optional prop to `<TreeRoot />`, `getChildren`, which allows the user to provide a custom list of children. This is helpful when you have a custom data schema.

Fixes #1139.

Also adds new tests and updates the docs to account for the change.