### PR TITLE
fix: add missing semicolon in CalendarGridRow class styling within demo

### DIFF
--- a/docs/components/demo/Calendar/css/styles.css
+++ b/docs/components/demo/Calendar/css/styles.css
@@ -66,7 +66,7 @@
 }
 
 .CalendarGridRow {
-  display: grid
+  display: grid;
   margin-bottom: 0.25rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   width: 100%;

--- a/docs/components/demo/CalendarSelect/css/styles.css
+++ b/docs/components/demo/CalendarSelect/css/styles.css
@@ -66,7 +66,7 @@
 }
 
 .CalendarGridRow {
-  display: grid
+  display: grid;
   margin-bottom: 0.25rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   width: 100%;

--- a/docs/components/demo/CalendarYearIncrement/css/styles.css
+++ b/docs/components/demo/CalendarYearIncrement/css/styles.css
@@ -66,7 +66,7 @@
 }
 
 .CalendarGridRow {
-  display: grid
+  display: grid;
   margin-bottom: 0.25rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   width: 100%;

--- a/docs/components/demo/DatePicker/css/styles.css
+++ b/docs/components/demo/DatePicker/css/styles.css
@@ -115,7 +115,7 @@
 }
 
 .CalendarGridRow {
-  display: grid
+  display: grid;
   margin-bottom: 0.25rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   width: 100%;

--- a/docs/components/demo/DateRangePicker/css/styles.css
+++ b/docs/components/demo/DateRangePicker/css/styles.css
@@ -115,7 +115,7 @@
 }
 
 .CalendarGridRow {
-  display: grid
+  display: grid;
   margin-bottom: 0.25rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   width: 100%;

--- a/docs/components/demo/RangeCalendar/css/styles.css
+++ b/docs/components/demo/RangeCalendar/css/styles.css
@@ -61,7 +61,7 @@
 }
 
 .CalendarGridRow {
-  display: grid
+  display: grid;
   margin-bottom: 0.25rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   width: 100%;


### PR DESCRIPTION
Add missing semicolon in CalendarGridRow class styling within demo.

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/b1079b6c-1c93-4617-bae6-614282840025">
