### PR TITLE
fix(Menu): reduce amount of created listeners

### DIFF
--- a/packages/radix-vue/src/Menu/MenuRoot.vue
+++ b/packages/radix-vue/src/Menu/MenuRoot.vue
@@ -2,6 +2,7 @@
 import type { Ref } from 'vue'
 import type { Direction } from './utils'
 import { createContext, useDirection } from '@/shared'
+import { useIsUsingKeyboard } from '@/shared/useIsUsingKeyboard'
 
 export interface MenuContext {
   open: Ref<boolean>
@@ -66,37 +67,7 @@ const dir = useDirection(propDir)
 const open = useVModel(props, 'open', emits)
 
 const content = ref<HTMLElement>()
-const isUsingKeyboardRef = ref(false)
-
-watchEffect((cleanupFn) => {
-  if (!isClient)
-    return
-  // Capture phase ensures we set the boolean before any side effects execute
-  // in response to the key or pointer event as they might depend on this value.
-  const handleKeyDown = () => {
-    isUsingKeyboardRef.value = true
-    document.addEventListener('pointerdown', handlePointer, {
-      capture: true,
-      once: true,
-    })
-    document.addEventListener('pointermove', handlePointer, {
-      capture: true,
-      once: true,
-    })
-  }
-  const handlePointer = () => (isUsingKeyboardRef.value = false)
-  document.addEventListener('keydown', handleKeyDown, { capture: true })
-
-  cleanupFn(() => {
-    document.removeEventListener('keydown', handleKeyDown, { capture: true })
-    document.removeEventListener('pointerdown', handlePointer, {
-      capture: true,
-    })
-    document.removeEventListener('pointermove', handlePointer, {
-      capture: true,
-    })
-  })
-})
+const isUsingKeyboardRef = useIsUsingKeyboard()
 
 provideMenuContext({
   open,

--- a/packages/radix-vue/src/shared/useIsUsingKeyboard.test.ts
+++ b/packages/radix-vue/src/shared/useIsUsingKeyboard.test.ts
@@ -1,0 +1,45 @@
+import { defineComponent } from 'vue'
+import { useIsUsingKeyboard } from './useIsUsingKeyboard'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { fireEvent } from '@testing-library/vue'
+
+function setupTestComponent() {
+  return defineComponent({
+    setup() {
+      return {
+        isUsingKeyboard: useIsUsingKeyboard(),
+      }
+    },
+    template: '<div></div>',
+  })
+}
+
+describe('useIsUsingKeyboard', () => {
+  it('should be false by default', () => {
+    const wrapper = mount(setupTestComponent())
+    expect(wrapper.vm.isUsingKeyboard).toBe(false)
+  })
+
+  it('should be true after keydown', () => {
+    const wrapper = mount(setupTestComponent())
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(wrapper.vm.isUsingKeyboard).toBe(true)
+  })
+
+  it('should reset to false after pointermove', () => {
+    const wrapper = mount(setupTestComponent())
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(wrapper.vm.isUsingKeyboard).toBe(true)
+    fireEvent.pointerMove(document)
+    expect(wrapper.vm.isUsingKeyboard).toBe(false)
+  })
+
+  it('should reset to false after pointerdown', () => {
+    const wrapper = mount(setupTestComponent())
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(wrapper.vm.isUsingKeyboard).toBe(true)
+    fireEvent.pointerDown(document)
+    expect(wrapper.vm.isUsingKeyboard).toBe(false)
+  })
+})

--- a/packages/radix-vue/src/shared/useIsUsingKeyboard.ts
+++ b/packages/radix-vue/src/shared/useIsUsingKeyboard.ts
@@ -1,0 +1,22 @@
+import { createSharedComposable, useEventListener } from '@vueuse/core'
+import { onMounted, ref } from 'vue'
+
+function useIsUsingKeyboardImpl() {
+  const isUsingKeyboard = ref(false)
+
+  onMounted(() => {
+    // Capture phase ensures we set the boolean before any side effects execute
+    // in response to the key or pointer event as they might depend on this value.
+    useEventListener('keydown', () => {
+      isUsingKeyboard.value = true
+    }, { capture: true, passive: true })
+
+    useEventListener(['pointerdown', 'pointermove'], () => {
+      isUsingKeyboard.value = false
+    }, { capture: true, passive: true })
+  })
+
+  return isUsingKeyboard
+}
+
+export const useIsUsingKeyboard = createSharedComposable(useIsUsingKeyboardImpl)


### PR DESCRIPTION
Fixes #1176.

I extracted `isUsingKeyboard` into a separate composable and wrapped it in [`createSharedComposable`](https://vueuse.org/shared/createSharedComposable/#createsharedcomposable). This should ensure only single copy is created and reused between all instances of `MenuRoot`.

`onMounted` makes it so event handlers won't be created when running on the server. Added simple test to ensure value correctly toggles between true/false on keydown/pointermove/pointerdown events.

Tested it manually with devtools perf view: amount of JS handlers stays constant on typing.