### PR TITLE
fix(Popper): use `watchPostEffect` for `placed` update

### DIFF
--- a/packages/radix-vue/src/Popper/PopperContent.vue
+++ b/packages/radix-vue/src/Popper/PopperContent.vue
@@ -140,7 +140,7 @@ export const [injectPopperContentContext, providePopperContentContext]
 </script>
 
 <script setup lang="ts">
-import { computed, ref, watchEffect } from 'vue'
+import { computed, ref, watchEffect, watchPostEffect } from 'vue'
 import { computedEager } from '@vueuse/core'
 import {
   autoUpdate,
@@ -289,7 +289,7 @@ const placedAlign = computed(
   () => getSideAndAlignFromPlacement(placement.value)[1],
 )
 
-watchEffect(() => {
+watchPostEffect(() => {
   if (isPositioned.value)
     emits('placed')
 })


### PR DESCRIPTION
**Problem**

When floating-ui returned isPositioned=true, radix-vue immediately emitted an event to focus on the selected item in the Select component. However, at this point, the PopperContent element did not yet have the correct transform CSS property set, resulting in the Popper being positioned at coordinates (0, -200%).

**Solution**

I changed the watchEffect to watchPostEffect to ensure that the event is emitted only after the DOM has been updated and the Popper is correctly positioned on the page (e.g., at coordinates 84px, 231px). This ensures that focusSelectedItem is called only after the Popper has been properly positioned.

**Changes**
- Replaced watchEffect with watchPostEffect to emit the positioning event after DOM updates.
