### PR TITLE
fix(Tabs): recalculate `tabs indicator position` on direction change

### DIFF
--- a/packages/radix-vue/src/Tabs/TabsIndicator.vue
+++ b/packages/radix-vue/src/Tabs/TabsIndicator.vue
@@ -25,7 +25,7 @@ const indicatorStyle = ref<IndicatorStyle>({
   position: null,
 })
 
-watch(() => context.modelValue.value, async (n) => {
+watch(() => [context.modelValue.value, context?.dir.value], async () => {
   await nextTick()
   updateIndicatorStyle()
 }, { immediate: true })


### PR DESCRIPTION
**Problem**

When the dir attribute of the page was changed dynamically, the indicator position in the Tabs component did not adjust to reflect the new text direction. This caused the indicator to remain in the incorrect position, resulting in a poor user experience.

**Solution**

I updated the Tabs component to correctly update the indicator position when the dir attribute of the page changes. This ensures that the indicator is always positioned correctly according to the current text direction.

**Changes**

- Added a watcher for the dir attribute to dynamically update the indicator position in the Tabs component when the text direction changes.

<img width="1200" alt="Screenshot 2024-08-07 at 19 13 24" src="https://github.com/user-attachments/assets/a4a96129-c4de-4fbf-846e-a89acb8ee32b">