### PR TITLE
feat(Stepper): expose slotProps functions

### DIFF
--- a/packages/radix-vue/src/Stepper/StepperRoot.vue
+++ b/packages/radix-vue/src/Stepper/StepperRoot.vue
@@ -134,6 +134,16 @@ provideStepperRootContext({
   linear,
   totalStepperItems,
 })
+
+defineExpose({
+  modelValue,
+  totalSteps: totalStepperItems.value.size,
+  isNextDisabled,
+  isPrevDisabled,
+  isFirstStep,
+  isLastStep,
+  goToStep,
+})
 </script>
 
 <template>


### PR DESCRIPTION
slotProps are accessible inside the `Stepper` component

in order to access it outside the component template with [`Ref on Component`](https://vuejs.org/guide/essentials/template-refs.html#ref-on-component), added same slotProps functions to the `defineExpose` macro


for example, take a look at [`StepperForm`](https://github.com/radix-vue/shadcn-vue/blob/dev/apps/www/src/lib/registry/default/example/StepperForm.vue#L223) example in shadcn-vue

I need the `isNextDisabled` there.

@epr3 Can I move the `Stepper` component upper so buttons could access that slotProp? or `Stepper` should be placed before the `StepperItem` components