### PR TITLE
feat: emit native events on form controls

### DIFF
--- a/docs/content/meta/ListboxRoot.md
+++ b/docs/content/meta/ListboxRoot.md
@@ -72,7 +72,7 @@
   {
     'name': 'selectionBehavior',
     'description': '<p>How multiple selection should behave in the collection.</p>\n',
-    'type': '\'replace\' | \'toggle\'',
+    'type': '\'toggle\' | \'replace\'',
     'required': false,
     'default': '\'toggle\''
   }

--- a/docs/content/meta/TreeRoot.md
+++ b/docs/content/meta/TreeRoot.md
@@ -45,16 +45,17 @@
     'required': false
   },
   {
+    'name': 'getChildren',
+    'description': '<p>This function is passed the index of each item and should return a list of children for that item</p>\n',
+    'type': '((val: Record<string, any>) => Record<string, any>[])',
+    'required': false,
+    'default': 'val.children'
+  },
+  {
     'name': 'getKey',
     'description': '<p>This function is passed the index of each item and should return a unique key for that item</p>\n',
     'type': '(val: Record<string, any>) => string',
     'required': true
-  },
-  {
-    'name': 'getChildren',
-    'description': '<p>This function is passed the index of each item and should return a list of children for that item</p>\n',
-    'type': '(val: Record<string, any>) => Record<string, any>[] | undefined',
-    'required': false
   },
   {
     'name': 'items',
@@ -83,7 +84,7 @@
   {
     'name': 'selectionBehavior',
     'description': '<p>How multiple selection should behave in the collection.</p>\n',
-    'type': '\'replace\' | \'toggle\'',
+    'type': '\'toggle\' | \'replace\'',
     'required': false,
     'default': '\'toggle\''
   }

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -243,6 +243,21 @@ function focusOnSelectedElement() {
     selectedElement.value.focus()
 }
 
+const inputRef = ref<HTMLInputElement | null>(null)
+
+watch(modelValue, (_modelValue) => {
+  const input = inputRef.value!
+  const inputProto = window.HTMLInputElement.prototype
+  const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'value') as PropertyDescriptor
+  const setValue = descriptor.set
+
+  if (isFormControl.value && setValue) {
+    const changeEvent = new Event('change', { bubbles: true })
+    setValue.call(input, _modelValue)
+    input.dispatchEvent(changeEvent)
+  }
+})
+
 provideComboboxRootContext({
   searchTerm,
   modelValue,
@@ -309,6 +324,7 @@ provideComboboxRootContext({
 
       <VisuallyHiddenInput
         v-if="isFormControl && props.name"
+        ref="inputRef"
         :name="props.name"
         :value="modelValue"
       />

--- a/packages/radix-vue/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/radix-vue/src/DateRangeField/DateRangeFieldRoot.vue
@@ -3,7 +3,7 @@ import { type DateValue, isEqualDay } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
-import { type Formatter, createContext, useDateFormatter, useDirection, useKbd } from '@/shared'
+import { type Formatter, createContext, useDateFormatter, useDirection, useFormControl, useForwardExpose, useKbd } from '@/shared'
 import {
   type DateRange,
   type Granularity,
@@ -91,7 +91,7 @@ export const [injectDateRangeFieldRootContext, provideDateRangeFieldRootContext]
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, toRefs, watch } from 'vue'
-import { Primitive, usePrimitiveElement } from '@/Primitive'
+import { Primitive } from '@/Primitive'
 import { useVModel } from '@vueuse/core'
 
 defineOptions({
@@ -110,13 +110,13 @@ const emits = defineEmits<DateRangeFieldRootEmits>()
 const { locale, disabled, readonly, isDateUnavailable: propsIsDateUnavailable, dir: propsDir } = toRefs(props)
 
 const formatter = useDateFormatter(props.locale)
-const { primitiveElement, currentElement: parentElement }
-  = usePrimitiveElement()
 const segmentElements = ref<Set<HTMLElement>>(new Set())
 const dir = useDirection(propsDir)
 
+const { forwardRef, currentElement } = useForwardExpose()
+
 onMounted(() => {
-  getSegmentElements(parentElement.value).forEach(item => segmentElements.value.add(item as HTMLElement))
+  getSegmentElements(currentElement.value).forEach(item => segmentElements.value.add(item as HTMLElement))
 })
 
 const modelValue = useVModel(props, 'modelValue', emits, {
@@ -260,7 +260,7 @@ watch(locale, (value) => {
     // Get the focusable elements again on the next tick
     nextTick(() => {
       segmentElements.value.clear()
-      getSegmentElements(parentElement.value).forEach(item => segmentElements.value.add(item as HTMLElement))
+      getSegmentElements(currentElement.value).forEach(item => segmentElements.value.add(item as HTMLElement))
     })
   }
 })
@@ -339,6 +339,25 @@ provideDateRangeFieldRootContext({
   },
 })
 
+const isFormControl = useFormControl(currentElement.value)
+
+const inputRef = ref<HTMLInputElement | null>(null)
+
+watch(modelValue, (_modelValue) => {
+  const input = inputRef.value!
+  const inputProto = window.HTMLInputElement.prototype
+  const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'value') as PropertyDescriptor
+  const setValue = descriptor.set
+
+  if (isFormControl.value && setValue) {
+    const inputEvent = new Event('input', { bubbles: true })
+    const changeEvent = new Event('change', { bubbles: true })
+    setValue.call(input, _modelValue)
+    input.dispatchEvent(inputEvent)
+    input.dispatchEvent(changeEvent)
+  }
+})
+
 defineExpose({
   setFocusedElement,
 })
@@ -347,7 +366,7 @@ defineExpose({
 <template>
   <Primitive
     v-bind="$attrs"
-    ref="primitiveElement"
+    ref="forwardRef"
     role="group"
     :aria-disabled="disabled ? true : undefined"
     :data-disabled="disabled ? '' : undefined"
@@ -363,7 +382,9 @@ defineExpose({
   </Primitive>
 
   <input
+    v-if="isFormControl"
     :id="id"
+    ref="inputRef"
     type="text"
     tabindex="-1"
     aria-hidden

--- a/packages/radix-vue/src/Menu/MenuRoot.vue
+++ b/packages/radix-vue/src/Menu/MenuRoot.vue
@@ -50,9 +50,7 @@ export const [injectMenuRootContext, provideMenuRootContext]
 import {
   ref,
   toRefs,
-  watchEffect,
 } from 'vue'
-import { isClient } from '@vueuse/shared'
 import { useVModel } from '@vueuse/core'
 import { PopperRoot } from '@/Popper'
 

--- a/packages/radix-vue/src/RadioGroup/Radio.vue
+++ b/packages/radix-vue/src/RadioGroup/Radio.vue
@@ -19,7 +19,7 @@ export interface RadioProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, toRefs } from 'vue'
+import { computed, ref, toRefs, watch } from 'vue'
 import { useVModel } from '@vueuse/core'
 import { Primitive } from '@/Primitive'
 import { useFormControl, useForwardExpose } from '@/shared'
@@ -58,6 +58,23 @@ function handleClick(event: MouseEvent) {
     event.stopPropagation()
   }
 }
+
+const inputRef = ref<HTMLInputElement | null>(null)
+
+watch(checked, (_checked, _prevChecked) => {
+  const input = inputRef.value!
+  const inputProto = window.HTMLInputElement.prototype
+  const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'checked') as PropertyDescriptor
+  const setChecked = descriptor.set
+
+  if (isFormControl.value && _prevChecked !== _checked && setChecked) {
+    const changeEvent = new Event('change', { bubbles: true })
+    const inputEvent = new Event('input', { bubbles: true })
+    setChecked.call(input, _checked)
+    input.dispatchEvent(changeEvent)
+    input.dispatchEvent(inputEvent)
+  }
+})
 </script>
 
 <template>
@@ -83,6 +100,7 @@ function handleClick(event: MouseEvent) {
 
     <input
       v-if="isFormControl"
+      ref="inputRef"
       type="radio"
       tabindex="-1"
       aria-hidden

--- a/packages/radix-vue/src/Select/BubbleSelect.vue
+++ b/packages/radix-vue/src/Select/BubbleSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, toRefs } from 'vue'
+import { ref, toRefs, watch } from 'vue'
 import { VisuallyHidden } from '@/VisuallyHidden'
 
 interface BubbleSelectProps {
@@ -20,19 +20,21 @@ const selectElement = ref<HTMLElement>()
 
 // This would bubble "change" event to form, with the target as Select element.
 // We temporary disable this as not sure if it will be needed for Vue
-// watch(value, () => {
-//   const selectProto = window.HTMLSelectElement.prototype;
-//   const descriptor = Object.getOwnPropertyDescriptor(
-//     selectProto,
-//     "value"
-//   ) as PropertyDescriptor;
-//   const setValue = descriptor.set;
-//   if (prevValue.value !== value.value && setValue) {
-//     const event = new Event("change", { bubbles: true });
-//     setValue.call(selectElement.value, value.value);
-//     selectElement.value?.dispatchEvent(event);
-//   }
-// });
+watch(value, (_value, _prevValue) => {
+  const selectProto = window.HTMLSelectElement.prototype
+  const descriptor = Object.getOwnPropertyDescriptor(
+    selectProto,
+    'value',
+  ) as PropertyDescriptor
+  const setValue = descriptor.set
+  if (_prevValue !== _value && setValue) {
+    const changeEvent = new Event('change', { bubbles: true })
+    const inputEvent = new Event('input', { bubbles: true })
+    setValue.call(selectElement.value, value.value)
+    selectElement.value?.dispatchEvent(changeEvent)
+    selectElement.value?.dispatchEvent(inputEvent)
+  }
+})
 
 /**
  * We purposefully use a `select` here to support form autofill as much


### PR DESCRIPTION
Closes #1209.

Hello,

This PR emits native form events on all form controls whenever the `checked` or `modelValue` changes on the respective form element.

Any feedback is appreciated! :rocket: