### PR TITLE
feat(RangeCalendar): enable same date selection

### DIFF
--- a/packages/radix-vue/src/DateField/DateFieldRoot.vue
+++ b/packages/radix-vue/src/DateField/DateFieldRoot.vue
@@ -123,6 +123,7 @@ onMounted(() => {
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: defaultValue.value,
+  passive: (props.modelValue === undefined) as false,
 }) as Ref<DateValue>
 
 const defaultDate = getDefaultDate({

--- a/packages/radix-vue/src/DatePicker/DatePickerRoot.vue
+++ b/packages/radix-vue/src/DatePicker/DatePickerRoot.vue
@@ -109,6 +109,7 @@ const dir = useDirection(propDir)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: defaultValue.value,
+  passive: (props.modelValue === undefined) as false,
 }) as Ref<DateValue | undefined>
 
 const defaultDate = computed(() => getDefaultDate({
@@ -157,12 +158,15 @@ provideDatePickerRootContext({
   dateFieldRef,
   dir,
   onDateChange(date: DateValue | undefined) {
-    if (!date || !modelValue.value)
+    if (!date || !modelValue.value) {
       modelValue.value = date
-    else if (!preventDeselect.value && isSameDay(modelValue.value as DateValue, date))
+    }
+    else if (!preventDeselect.value && isSameDay(modelValue.value as DateValue, date)) {
       modelValue.value = undefined
-    else
+    }
+    else {
       modelValue.value = date.copy()
+    }
   },
   onPlaceholderChange(date: DateValue) {
     if (!isEqualDay(date, placeholder.value))

--- a/packages/radix-vue/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/radix-vue/src/DateRangeField/DateRangeFieldRoot.vue
@@ -17,6 +17,7 @@ import {
   areAllDaysBetweenValid,
   hasTime,
   isBefore,
+  isBeforeOrSame,
 } from '@/date'
 import { createContent, getSegmentElements, initializeSegmentValues, isSegmentNavigationKey, syncSegmentValues } from '@/DateField/utils'
 import type { Direction } from '@/shared/types'
@@ -121,6 +122,7 @@ onMounted(() => {
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? { start: undefined, end: undefined },
+  passive: (props.modelValue === undefined) as false,
 }) as Ref<DateRange>
 
 const defaultDate = getDefaultDate({
@@ -180,7 +182,7 @@ const isInvalid = computed(() => {
   if (!modelValue.value.start || !modelValue.value.end)
     return false
 
-  if (!isBefore(modelValue.value.start, modelValue.value.end))
+  if (!isBeforeOrSame(modelValue.value.start, modelValue.value.end))
     return true
 
   if (propsIsDateUnavailable.value !== undefined) {

--- a/packages/radix-vue/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/radix-vue/src/DateRangePicker/DateRangePickerRoot.vue
@@ -111,7 +111,8 @@ const {
 const dir = useDirection(propsDir)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
-  defaultValue: props.defaultValue,
+  defaultValue: props.defaultValue ?? { start: undefined, end: undefined },
+  passive: (props.modelValue === undefined) as false,
 }) as Ref<DateRange>
 
 const defaultDate = getDefaultDate({

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -72,7 +72,7 @@ const isFocusedDate = computed(() => {
   return !rootContext.disabled.value && isSameDay(props.day, rootContext.placeholder.value)
 })
 
-function changeDate(date: DateValue) {
+function changeDate(e: MouseEvent | KeyboardEvent, date: DateValue) {
   if (rootContext.readonly.value)
     return
   if (rootContext.isDateDisabled(date) || rootContext.isDateUnavailable?.(date))
@@ -87,14 +87,16 @@ function changeDate(date: DateValue) {
       return
     }
     else if (!rootContext.endValue.value) {
+      e.preventDefault()
       if (rootContext.lastPressedDateValue.value && isSameDay(rootContext.lastPressedDateValue.value, date))
         rootContext.startValue.value = date.copy()
       return
     }
   }
 
-  if (rootContext.startValue.value && isSameDay(rootContext.startValue.value, date) && !rootContext.preventDeselect.value && !rootContext.endValue.value) {
+  if (rootContext.startValue.value && rootContext.endValue.value && isSameDay(rootContext.endValue.value, date) && !rootContext.preventDeselect.value) {
     rootContext.startValue.value = undefined
+    rootContext.endValue.value = undefined
     rootContext.onPlaceholderChange(date)
     return
   }
@@ -111,8 +113,8 @@ function changeDate(date: DateValue) {
   }
 }
 
-function handleClick() {
-  changeDate(props.day)
+function handleClick(e: MouseEvent) {
+  changeDate(e, props.day)
 }
 
 function handleFocus() {
@@ -148,7 +150,7 @@ function handleArrowKey(e: KeyboardEvent) {
       break
     case kbd.ENTER:
     case kbd.SPACE_CODE:
-      changeDate(props.day)
+      changeDate(e, props.day)
       return
     default:
       return

--- a/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/radix-vue/src/RangeCalendar/RangeCalendarRoot.vue
@@ -180,7 +180,7 @@ const lastPressedDateValue = ref() as Ref<DateValue | undefined>
 const focusedValue = ref() as Ref<DateValue | undefined>
 
 const modelValue = useVModel(props, 'modelValue', emits, {
-  defaultValue: props.defaultValue,
+  defaultValue: props.defaultValue ?? { start: undefined, end: undefined },
   passive: (props.modelValue === undefined) as false,
 }) as Ref<DateRange>
 


### PR DESCRIPTION
Closes #1207.

PR fixes:
-  a regression where the `Calendar`-type components were not updating the `DateField`-type components in the `DatePicker` components
- setting the same date on a `DateField`-type component was setting an erroneous invalid state on the field