### PR TITLE
fix(Splitter): not updating `SplitterResizeHandle` cursor style properly when `direction` changes

### DIFF
--- a/packages/radix-vue/src/Splitter/SplitterGroup.vue
+++ b/packages/radix-vue/src/Splitter/SplitterGroup.vue
@@ -6,7 +6,7 @@ import {
   savePanelGroupState,
 } from './utils/storage'
 import { areEqual, createContext, useDirection, useForwardExpose, useId } from '@/shared'
-import { type CSSProperties, type Ref, computed, ref, watch, watchEffect } from 'vue'
+import { type CSSProperties, type Ref, computed, ref, toRefs, watch, watchEffect } from 'vue'
 import { useWindowSplitterPanelGroupBehavior } from './utils/composables/useWindowSplitterPanelGroupBehavior'
 
 export interface SplitterGroupProps extends PrimitiveProps {
@@ -46,7 +46,7 @@ const defaultStorage: PanelGroupStorage = {
 }
 
 export type PanelGroupContext = {
-  direction: 'horizontal' | 'vertical'
+  direction: Ref<Direction>
   dragState: DragState | null
   groupId: string
   reevaluatePanelConstraints: (panelData: PanelData, prevConstraints: PanelConstraints) => void
@@ -111,6 +111,7 @@ const debounceMap: {
   [key: string]: typeof savePanelGroupState
 } = {}
 
+const { direction } = toRefs(props)
 const groupId = useId(props.id, 'radix-vue-splitter-group')
 const dir = useDirection()
 const { forwardRef, currentElement: panelGroupElementRef } = useForwardExpose()
@@ -660,7 +661,7 @@ function isPanelExpanded(panelData: PanelData) {
 }
 
 providePanelGroupContext({
-  direction: props.direction,
+  direction,
   dragState: dragState.value,
   groupId,
   reevaluatePanelConstraints,

--- a/packages/radix-vue/src/Splitter/story/SplitterDirection.story.vue
+++ b/packages/radix-vue/src/Splitter/story/SplitterDirection.story.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from '../'
+import type { DataOrientation } from '@/shared/types'
+
+const direction = ref<DataOrientation>('horizontal')
+</script>
+
+<template>
+  <Story
+    title="Splitter/Direction"
+    :layout="{ type: 'single', width: '100%', iframe: false }"
+  >
+    <Variant title="default">
+      <div class="w-full">
+        <div>
+          <button
+            class="px-3 py-1.5 text-sm rounded bg-white hover:bg-slate-100 text-slate-800 capitalize"
+            @click="direction = direction === 'horizontal' ? 'vertical' : 'horizontal'"
+          >
+            {{ direction }}
+          </button>
+        </div>
+        <div class="w-full mt-4 h-48">
+          <SplitterGroup :direction="direction">
+            <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+              Panel A
+            </SplitterPanel>
+            <SplitterResizeHandle
+              class="data-[state=active]:bg-white transition"
+              :class="direction === 'horizontal' ? 'w-2' : 'h-2'"
+            />
+            <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+              Panel B
+            </SplitterPanel>
+          </SplitterGroup>
+        </div>
+      </div>
+    </Variant>
+  </Story>
+</template>

--- a/packages/radix-vue/src/Splitter/utils/registry.ts
+++ b/packages/radix-vue/src/Splitter/utils/registry.ts
@@ -3,6 +3,7 @@ import { resetGlobalCursorStyle, setGlobalCursorStyle } from './style'
 import { getResizeEventCoordinates } from './events'
 import { intersects } from './rects'
 import { compare } from './stackingOrder'
+import type { Ref } from 'vue'
 
 export type ResizeHandlerAction = 'down' | 'move' | 'up'
 export type SetResizeHandlerState = (
@@ -17,7 +18,7 @@ export type PointerHitAreaMargins = {
 }
 
 export type ResizeHandlerData = {
-  direction: Direction
+  direction: Ref<Direction>
   element: HTMLElement
   hitAreaMargins: PointerHitAreaMargins
   setResizeHandlerState: SetResizeHandlerState
@@ -45,7 +46,7 @@ const registeredResizeHandlers = new Set<ResizeHandlerData>()
 export function registerResizeHandle(
   resizeHandleId: string,
   element: HTMLElement,
-  direction: Direction,
+  direction: Ref<Direction>,
   hitAreaMargins: PointerHitAreaMargins,
   setResizeHandlerState: SetResizeHandlerState,
 ) {
@@ -230,7 +231,7 @@ function updateCursor() {
   intersectingHandles.forEach((data) => {
     const { direction } = data
 
-    if (direction === 'horizontal')
+    if (direction.value === 'horizontal')
       intersectsHorizontal = true
     else
       intersectsVertical = true


### PR DESCRIPTION
### Problem

When toggling direction on `SplitterGroup`
```
 <SplitterGroup :direction="direction">
 ...
 </SplitterGroup>
 ```
 resize cursor styles stick to its initial values (https://stackblitz.com/edit/gdyqde?file=src%2FApp.vue)
 
 
![image](https://github.com/user-attachments/assets/55887e07-272c-428d-acbb-87c084ef48da)
 
 ### Solution
 
Made `SplitterGroup` to provide a reactive `direction`