### PR TITLE
fix(Combobox): error log when opening content

### DIFF
--- a/packages/radix-vue/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxContentImpl.vue
@@ -59,7 +59,7 @@ const rootContext = injectComboboxRootContext()
 useBodyScrollLock(props.bodyLock)
 
 const { forwardRef, currentElement } = useForwardExpose()
-useHideOthers(currentElement)
+useHideOthers(rootContext.parentElement)
 
 const pickedProps = computed(() => {
   if (props.position === 'popper')


### PR DESCRIPTION
the `ComboboxInput` was hidden away wrongly. We should hide away other element other than `parentElement`