### PR TITLE
fix(Toast): check if window exists to run startTimer in CSR only

### DIFF
--- a/packages/radix-vue/src/Toast/ToastRootImpl.vue
+++ b/packages/radix-vue/src/Toast/ToastRootImpl.vue
@@ -80,6 +80,11 @@ const remainingRaf = useRafFn(() => {
 function startTimer(duration: number) {
   if (!duration || duration === Number.POSITIVE_INFINITY)
     return
+  // startTimer is used inside a watch with immediate set to true.
+  // This results in code execution during SSR.
+  // Ensure this code only runs in a browser environment
+  if (typeof window === 'undefined')
+    return
   window.clearTimeout(closeTimerRef.value)
   closeTimerStartTimeRef.value = new Date().getTime()
   closeTimerRef.value = window.setTimeout(handleClose, duration)


### PR DESCRIPTION
fix issue #1246 