### PR TITLE
added codemods to docs

### DIFF
--- a/docs/content/docs/guides/migration.md
+++ b/docs/content/docs/guides/migration.md
@@ -19,7 +19,13 @@ Congratulation! 🎉 Now that you've installed the above package, let's perform 
 
 #### Codemods
 
-To assist with the upgrade from radix-vue to Reka UI, we have added features that utilize codemods to automatically update your code to many of the new updates and patterns. Run the following commands to automatically update your code for RekaUI migration:
+To assist with the upgrade from radix-vue to Reka UI, we have added features that utilize codemods to automatically update your code to many of the new updates and patterns. Run the following command to automatically update your code for RekaUI migration:
+
+  > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod reka-ui-v2/migration-recipe
+  > ```
 
 
 These will run the following codemods from the radix-vue Codemod repository:
@@ -63,7 +69,7 @@ CSS variable and data attributes names have been updated to use the `reka` prefi
   </template>
   ```
 
-      > **Note**: Codemod for this Change:
+  > **Note**: Codemod for this Change:
   >
   > ```bash
   > npx codemod rekaUI-v2/combobox-root-to-combobox-input

--- a/docs/content/docs/guides/migration.md
+++ b/docs/content/docs/guides/migration.md
@@ -17,6 +17,17 @@ First and foremost, you need to install the latest `reka-ui`.
 
 Congratulation! 🎉 Now that you've installed the above package, let's perform the migration! The first 2 steps are relatively simple. Just do a global search and replace for the following changes.
 
+#### Codemods
+
+To assist with the upgrade from radix-vue to Reka UI, we have added features that utilize codemods to automatically update your code to many of the new updates and patterns. Run the following commands to automatically update your code for RekaUI migration:
+
+
+These will run the following codemods from the radix-vue Codemod repository:
+
+- **Remove filter-function props**
+- **Rename controlled state to v-model**
+- **Remove deprecated step prop**
+
 ## Import Statement Changes
 
 The primary change in imports is replacing `radix-vue` with `reka-ui`.
@@ -52,6 +63,12 @@ CSS variable and data attributes names have been updated to use the `reka` prefi
   </template>
   ```
 
+      > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod rekaUI-v2/combobox-root-to-combobox-input
+  > ```
+
 - [Replace `searchTerm` props of Root to Input's `v-model`](https://github.com/radix-vue/radix-vue/commit/e1bab6598c3533dfbf6a86ad26b471ab826df069#diff-833593a5ce28a8c3fabc7d77462b116405e25df2b93bcab449798b5799e73474)
 - [Move `displayValue` props from Root to Input](https://github.com/radix-vue/radix-vue/commit/e1bab6598c3533dfbf6a86ad26b471ab826df069#diff-833593a5ce28a8c3fabc7d77462b116405e25df2b93bcab449798b5799e73474)
 
@@ -79,6 +96,12 @@ CSS variable and data attributes names have been updated to use the `reka` prefi
     <CheckboxRoot v-model="value" /> // [!code ++]
   </template>
   ```
+
+    > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod rekaUI-v2/searchTerm-props-of-Root-to-Input's-v-model
+  > ```
 
 - [Reposition `VisuallyHidden`](https://github.com/radix-vue/radix-vue/commit/107389a9c230d2c94232887b9cbe2710222564aa) - Previously `VisuallyHidden` were position at the root node, causing style scoped to not be applied.
 
@@ -113,6 +136,12 @@ CSS variable and data attributes names have been updated to use the `reka` prefi
     <CalendarNext :next-page="(date: DateValue) => pagingFunc(date, 1)" /> // [!code ++]
   </template>
   ```
+
+   > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod rekaUI-v2/add-script-setup-and-update-calendar-components
+  > ```
 
 ### Select
 

--- a/docs/content/docs/guides/migration.md
+++ b/docs/content/docs/guides/migration.md
@@ -63,6 +63,12 @@ CSS variable and data attributes names have been updated to use the `reka` prefi
   [data-reka-collection-item] {}  // [!code ++]
 ```
 
+  > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod rekaUI-v2/radix-to-reka-css-and-data-attribute-replacement
+  > ```
+
 ## Component Breaking Changes
 
 ### Combobox

--- a/docs/content/docs/guides/migration.md
+++ b/docs/content/docs/guides/migration.md
@@ -45,6 +45,12 @@ import { TooltipPortal, TooltipRoot, TooltipTrigger } from 'reka-ui' // [!code +
 </script>
 ```
 
+  > **Note**: Codemod for this Change:
+  >
+  > ```bash
+  > npx codemod rekaUI-v2/radix-vue-1-reka-ui-import-update
+  > ```
+
 ## Naming Convention Changes
 
 CSS variable and data attributes names have been updated to use the `reka` prefix instead of `radix`.


### PR DESCRIPTION
To assist with the upgrade from radix-vue to reka-ui, we have added features that utilize codemods to automatically update your code to many of the new updates and patterns. 

These codemods include breaking changes which aren't implemented interally but have to updated across multiple repositories using the framework.

These will run the following codemods from the radix-vue Codemod repository:

- **Remove filter-function props**
- **Rename controlled state to v-model**
- **Remove deprecated step prop**


#### Remove filter-function props 
 Combobox has been refactored and improve to support better custom filtering. 
  - Additional Details
    - Replace searchTerm props of Root to Input's v-model
    - https://go.codemod.com/3lqPTdS
#### Rename controlled state to v-model
   Replace v-model:checked, v-model:pressed with more familiar API for form component.
   - Additional Details
    - Reposition VisuallyHidden - Previously VisuallyHidden were position at the root node, causing style scoped to not be applied.
     - https://go.codemod.com/TkPrj5g
#### Remove deprecated step prop 
    Use prevPage/nextPage props for greater control.
    - Additional Details
      - https://go.codemod.com/w0lCajc











