### PR TITLE
Expose virtualizer and virtualized items

### DIFF
--- a/packages/radix-vue/src/Listbox/ListboxVirtualizer.vue
+++ b/packages/radix-vue/src/Listbox/ListboxVirtualizer.vue
@@ -21,12 +21,15 @@ import { getNextMatch } from '@/shared/useTypeahead'
 import { useParentElement } from '@vueuse/core'
 import { useCollection } from '@/Collection'
 import type { AcceptableValue } from '@/shared/types'
+import type { Virtualizer, VirtualItem } from '@tanstack/vue-virtual'
 
 const props = defineProps<ListboxVirtualizerProps<T>>()
 
 defineSlots<{
   default: (props: {
-    option: T
+    option: T;
+    virtualizer: Virtualizer<Element | Window, Element>;
+    virtualItem: VirtualItem
   }) => any
 }>()
 
@@ -71,6 +74,8 @@ const virtualizedItems = computed(() => virtualizer.value.getVirtualItems().map(
     item,
     is: cloneVNode(slots.default!({
       option: props.options[item.index],
+      virtualizer: virtualizer.value,
+      virtualItem: item
     })![0], {
       'key': `${item.key}`,
       'data-index': item.index,

--- a/packages/radix-vue/src/Listbox/ListboxVirtualizer.vue
+++ b/packages/radix-vue/src/Listbox/ListboxVirtualizer.vue
@@ -10,7 +10,7 @@ export interface ListboxVirtualizerProps<T extends AcceptableValue = AcceptableV
 </script>
 
 <script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
-import { useVirtualizer } from '@tanstack/vue-virtual'
+import { type VirtualItem, type Virtualizer, useVirtualizer } from '@tanstack/vue-virtual'
 import { type Ref, cloneVNode, computed, useSlots } from 'vue'
 import { injectListboxRootContext } from './ListboxRoot.vue'
 import { compare, queryCheckedElement } from './utils'
@@ -21,15 +21,14 @@ import { getNextMatch } from '@/shared/useTypeahead'
 import { useParentElement } from '@vueuse/core'
 import { useCollection } from '@/Collection'
 import type { AcceptableValue } from '@/shared/types'
-import type { Virtualizer, VirtualItem } from '@tanstack/vue-virtual'
 
 const props = defineProps<ListboxVirtualizerProps<T>>()
 
 defineSlots<{
   default: (props: {
-    option: T;
-    virtualizer: Virtualizer<Element | Window, Element>;
-    virtualItem: VirtualItem
+    option: T
+    virtualizer: Virtualizer<Element | Window, Element>
+    virtualItem: VirtualItem<Element>
   }) => any
 }>()
 
@@ -75,7 +74,7 @@ const virtualizedItems = computed(() => virtualizer.value.getVirtualItems().map(
     is: cloneVNode(slots.default!({
       option: props.options[item.index],
       virtualizer: virtualizer.value,
-      virtualItem: item
+      virtualItem: item,
     })![0], {
       'key': `${item.key}`,
       'data-index': item.index,

--- a/packages/radix-vue/src/Tree/TreeVirtualizer.vue
+++ b/packages/radix-vue/src/Tree/TreeVirtualizer.vue
@@ -8,8 +8,7 @@ export interface TreeVirtualizerProps {
 </script>
 
 <script setup lang="ts">
-import { useVirtualizer } from '@tanstack/vue-virtual'
-import type { Virtualizer, VirtualItem } from '@tanstack/vue-virtual'
+import { type VirtualItem, type Virtualizer, useVirtualizer } from '@tanstack/vue-virtual'
 import { type Ref, cloneVNode, computed, nextTick, useSlots } from 'vue'
 import { type FlattenedItem, injectTreeRootContext } from './TreeRoot.vue'
 import { refAutoReset, useParentElement } from '@vueuse/core'
@@ -21,9 +20,9 @@ const props = defineProps<TreeVirtualizerProps>()
 
 defineSlots<{
   default: (props: {
-    item: FlattenedItem<Record<string, any>>;
-    virtualizer: Virtualizer<Element | Window, Element>;
-    virtualItem: VirtualItem;
+    item: FlattenedItem<Record<string, any>>
+    virtualizer: Virtualizer<Element | Window, Element>
+    virtualItem: VirtualItem<Element>
   }) => any
 }>()
 
@@ -88,7 +87,7 @@ const virtualizedItems = computed(() => virtualizer.value.getVirtualItems().map(
     is: cloneVNode(slots.default!({
       item: rootContext.expandedItems.value[item.index],
       virtualizer: virtualizer.value,
-      virtualItem: item
+      virtualItem: item,
     })![0], {
       'data-index': item.index,
       'style': {

--- a/packages/radix-vue/src/Tree/TreeVirtualizer.vue
+++ b/packages/radix-vue/src/Tree/TreeVirtualizer.vue
@@ -9,6 +9,7 @@ export interface TreeVirtualizerProps {
 
 <script setup lang="ts">
 import { useVirtualizer } from '@tanstack/vue-virtual'
+import type { Virtualizer, VirtualItem } from '@tanstack/vue-virtual'
 import { type Ref, cloneVNode, computed, nextTick, useSlots } from 'vue'
 import { type FlattenedItem, injectTreeRootContext } from './TreeRoot.vue'
 import { refAutoReset, useParentElement } from '@vueuse/core'
@@ -20,7 +21,9 @@ const props = defineProps<TreeVirtualizerProps>()
 
 defineSlots<{
   default: (props: {
-    item: FlattenedItem<Record<string, any>>
+    item: FlattenedItem<Record<string, any>>;
+    virtualizer: Virtualizer<Element | Window, Element>;
+    virtualItem: VirtualItem;
   }) => any
 }>()
 
@@ -84,6 +87,8 @@ const virtualizedItems = computed(() => virtualizer.value.getVirtualItems().map(
     item,
     is: cloneVNode(slots.default!({
       item: rootContext.expandedItems.value[item.index],
+      virtualizer: virtualizer.value,
+      virtualItem: item
     })![0], {
       'data-index': item.index,
       'style': {


### PR DESCRIPTION
Expose the virtualizer to the default slot of ListboxVirtualizer and TreeVirtualizer.

This allows the height of the virtualized element to be dynamically calculated if necessary or styled.
```vue
<template>
 <ListboxVirtualizer
    v-slot="{ option, virtualizer, virtualItem }"
    ... ...
  >
    <ListboxItem
      :class="virtualItem.index % 2 === 0 && 'bg-accent/50'"
      @vue:mounted="(node: VNode) => virtualizer.measureElement(node.el as Element)"
      ... ...
    >
        <div>... ... ...</div>
    </ListboxItem>
  </ListboxVirtualizer>
</template>
```
resolve #1266 