### PR TITLE
fix(Combobox): stop event propagation on enter

### DIFF
--- a/packages/radix-vue/src/Combobox/Combobox.test.ts
+++ b/packages/radix-vue/src/Combobox/Combobox.test.ts
@@ -296,6 +296,17 @@ describe('given combobox in a form', async () => {
 
   const valueBox = wrapper.find('input')
 
+  let enterEventBubbledToForm = false
+
+  beforeEach(() => {
+    enterEventBubbledToForm = false
+    wrapper.find('form').element.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        enterEventBubbledToForm = true
+      }
+    })
+  })
+
   it('should have hidden input field', async () => {
     expect(wrapper.find('[type="hidden"]').exists()).toBe(true)
   })
@@ -340,8 +351,8 @@ describe('given combobox in a form', async () => {
       expect((valueBox.element).value).toBe('Banana')
     })
 
-    it('should not trigger form submit', () => {
-      expect(handleSubmit).not.toHaveBeenCalled()
+    it('should bubble up the Enter keydown event to the form', () => {
+      expect(enterEventBubbledToForm).toBe(false)
     })
   })
 })

--- a/packages/radix-vue/src/Combobox/Combobox.test.ts
+++ b/packages/radix-vue/src/Combobox/Combobox.test.ts
@@ -294,6 +294,8 @@ describe('given combobox in a form', async () => {
     props: { handleSubmit },
   })
 
+  const valueBox = wrapper.find('input')
+
   it('should have hidden input field', async () => {
     expect(wrapper.find('[type="hidden"]').exists()).toBe(true)
   })
@@ -325,6 +327,21 @@ describe('given combobox in a form', async () => {
     it('should trigger submit once', () => {
       expect(handleSubmit).toHaveBeenCalledTimes(2)
       expect(handleSubmit.mock.results[1].value).toStrictEqual({ test: 'Pineapple' })
+    })
+  })
+
+  describe('after selecting an option via keyboard', () => {
+    beforeEach(async () => {
+      await valueBox.setValue('B')
+      await valueBox.trigger('keydown', { key: 'Enter' })
+    })
+
+    it('should show value correctly', () => {
+      expect((valueBox.element).value).toBe('Banana')
+    })
+
+    it('should not trigger form submit', () => {
+      expect(handleSubmit).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -24,7 +24,7 @@ type ComboboxRootContext<T> = {
   inputElement: Ref<HTMLInputElement | undefined>
   onInputElementChange: (el: HTMLInputElement) => void
   onInputNavigation: (dir: 'up' | 'down' | 'home' | 'end') => void
-  onInputEnter: () => void
+  onInputEnter: (event: InputEvent) => void
   selectedValue: Ref<T | undefined>
   selectedElement: ComputedRef<HTMLElement | undefined>
   onSelectedValueChange: (val: T) => void
@@ -278,9 +278,13 @@ provideComboboxRootContext({
 
     nextTick(() => inputElement.value?.focus({ preventScroll: true }))
   },
-  onInputEnter: async () => {
-    if (filteredOptions.value.length && selectedValue.value && selectedElement.value instanceof Element)
+  onInputEnter: async (event) => {
+    if (filteredOptions.value.length && selectedValue.value && selectedElement.value instanceof Element) {
+      event.preventDefault()
+      event.stopPropagation()
+
       selectedElement.value?.click()
+    }
   },
   selectedValue,
   onSelectedValueChange: val => selectedValue.value = val as T,


### PR DESCRIPTION
This PR is my attempt of fixing the bug described in #1278 

~~Important: [the test case here is a false-positive](https://github.com/radix-vue/radix-vue/compare/main...ragulka:1278-bug-stop-enter-event-propagation-in-combobox?expand=1#diff-336ad141037fb1bc99cda0417410f50e54953fbce0363fe53d5164094230a814R343-R345): when I remove the `event.stopPropagation()` line, it still passes. I'm not surer why - I don't have too much experience with vitest and if event bubbling actually happens in the test environment?~~

Since we're not using a real browser, the enter event bubbling up to form is not causing a form submit in tests. So, instead of testing for the handleSubmit not to be called, I updated the test to check if the enter event bubbled up to the form.

With this change, removing the `event.stopPropagation()` call will cause the test to fail.