### PR TITLE
fix(Splitter): fix getParent()

### DIFF
--- a/packages/radix-vue/src/Splitter/utils/stackingOrder.ts
+++ b/packages/radix-vue/src/Splitter/utils/stackingOrder.ts
@@ -140,5 +140,5 @@ function getAncestors(node: HTMLElement) {
 /** @param {HTMLElement} node */
 function getParent(node: HTMLElement) {
   // @ts-expect-error host should exist
-  return node.parentNode?.host || node.parentNode
+  return (node.parentNode instanceof DocumentFragment && node.parentNode?.host) || node.parentNode
 }


### PR DESCRIPTION
Fixes https://github.com/radix-vue/radix-vue/issues/1305.

`a` and `area` element can have `host` property.