### PR TITLE
fix: root node for RovingFocusItem when shadowRoot

### DIFF
--- a/packages/radix-vue/src/RovingFocus/RovingFocusItem.vue
+++ b/packages/radix-vue/src/RovingFocus/RovingFocusItem.vue
@@ -10,7 +10,7 @@ export interface RovingFocusItemProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
 import { injectRovingFocusGroupContext } from './RovingFocusGroup.vue'
 import { Primitive } from '@/Primitive'
 import { focusFirst, getFocusIntent, wrapArray } from './utils'
@@ -30,6 +30,9 @@ const isCurrentTabStop = computed(
 )
 
 const { getItems } = useCollection()
+
+const elRef = ref()
+const rootNode = computed<Document | ShadowRoot>(() => elRef.value?.$el.getRootNode())
 
 onMounted(() => {
   if (props.focusable)
@@ -76,7 +79,7 @@ function handleKeydown(event: KeyboardEvent) {
         : candidateNodes.slice(currentIndex + 1)
     }
 
-    nextTick(() => focusFirst(candidateNodes))
+    nextTick(() => focusFirst(candidateNodes, false, rootNode.value))
   }
 }
 </script>
@@ -84,6 +87,7 @@ function handleKeydown(event: KeyboardEvent) {
 <template>
   <CollectionItem>
     <Primitive
+      ref="elRef"
       :tabindex="isCurrentTabStop ? 0 : -1"
       :data-orientation="context.orientation.value"
       :data-active="active"

--- a/packages/radix-vue/src/RovingFocus/RovingFocusItem.vue
+++ b/packages/radix-vue/src/RovingFocus/RovingFocusItem.vue
@@ -10,9 +10,9 @@ export interface RovingFocusItemProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { injectRovingFocusGroupContext } from './RovingFocusGroup.vue'
-import { Primitive } from '@/Primitive'
+import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { focusFirst, getFocusIntent, wrapArray } from './utils'
 import { useId } from '@/shared'
 import { CollectionItem, useCollection } from '@/Collection'
@@ -31,8 +31,8 @@ const isCurrentTabStop = computed(
 
 const { getItems } = useCollection()
 
-const elRef = ref()
-const rootNode = computed<Document | ShadowRoot>(() => elRef.value?.$el.getRootNode())
+const { primitiveElement, currentElement } = usePrimitiveElement()
+const rootNode = computed(() => currentElement.value?.getRootNode() as Document | ShadowRoot)
 
 onMounted(() => {
   if (props.focusable)
@@ -87,7 +87,7 @@ function handleKeydown(event: KeyboardEvent) {
 <template>
   <CollectionItem>
     <Primitive
-      ref="elRef"
+      ref="primitiveElement"
       :tabindex="isCurrentTabStop ? 0 : -1"
       :data-orientation="context.orientation.value"
       :data-active="active"

--- a/packages/radix-vue/src/RovingFocus/utils.ts
+++ b/packages/radix-vue/src/RovingFocus/utils.ts
@@ -40,8 +40,8 @@ export function getFocusIntent(
   return MAP_KEY_TO_FOCUS_INTENT[key]
 }
 
-export function focusFirst(candidates: HTMLElement[], preventScroll = false) {
-  const PREVIOUSLY_FOCUSED_ELEMENT = document.activeElement
+export function focusFirst(candidates: HTMLElement[], preventScroll = false, rootNode?: Document | ShadowRoot) {
+  const PREVIOUSLY_FOCUSED_ELEMENT = rootNode?.activeElement ?? document.activeElement
   for (const candidate of candidates) {
     // if focus is already where we want to go, we don't want to keep going through the candidates
     if (candidate === PREVIOUSLY_FOCUSED_ELEMENT)


### PR DESCRIPTION
This PR fixes RovingFocusItem getting the rootNode when using radix-vue in a shadow dom.

Fixes: https://github.com/radix-vue/radix-vue/issues/1003 

Thanks @sunnylost for the detailed fix 