### PR TITLE
fix(Listbox): check if a dom is still associated with the document

### DIFF
--- a/packages/radix-vue/src/Listbox/ListboxRoot.vue
+++ b/packages/radix-vue/src/Listbox/ListboxRoot.vue
@@ -331,8 +331,9 @@ provideListboxRootContext({
     :dir="dir"
     :data-disabled="disabled ? '' : undefined"
     @pointerleave="onLeave"
-    @focusout="(event: FocusEvent) => {
+    @focusout="async (event: FocusEvent) => {
       const target = (event.relatedTarget || event.target) as HTMLElement | null
+      await nextTick()
       if (highlightedElement && !currentElement.contains(target)) {
         onLeave(event)
       }

--- a/packages/radix-vue/src/Listbox/ListboxRoot.vue
+++ b/packages/radix-vue/src/Listbox/ListboxRoot.vue
@@ -200,7 +200,6 @@ function onLeave(event: Event) {
     previousElement.value = el
   }
 
-  previousElement.value = highlightedElement.value
   highlightedElement.value = null
   emits('leave', event)
 }

--- a/packages/radix-vue/src/Listbox/ListboxRoot.vue
+++ b/packages/radix-vue/src/Listbox/ListboxRoot.vue
@@ -194,6 +194,12 @@ function onKeydownTypeAhead(event: KeyboardEvent) {
 }
 
 function onLeave(event: Event) {
+  const el = highlightedElement.value as Node
+
+  if (el?.isConnected) {
+    previousElement.value = el
+  }
+
   previousElement.value = highlightedElement.value
   highlightedElement.value = null
   emits('leave', event)

--- a/packages/radix-vue/src/Listbox/ListboxRoot.vue
+++ b/packages/radix-vue/src/Listbox/ListboxRoot.vue
@@ -194,9 +194,9 @@ function onKeydownTypeAhead(event: KeyboardEvent) {
 }
 
 function onLeave(event: Event) {
-  const el = highlightedElement.value as Node
+  const el = highlightedElement.value
 
-  if (el?.isConnected) {
+  if ((el as Node)?.isConnected) {
     previousElement.value = el
   }
 


### PR DESCRIPTION
Related to https://github.com/radix-vue/radix-vue/issues/1296, but this is not a fix.

When the `onleave()` event is triggered, the element may no longer exist in the DOM tree. As a result, if you try to use the Tab key to focus on it again, the focus will not move to the next item but will instead select the entire list.