### PR TITLE
Stepper: replace onMousedown by onClick for consistency

### DIFF
--- a/packages/radix-vue/src/Stepper/StepperTrigger.vue
+++ b/packages/radix-vue/src/Stepper/StepperTrigger.vue
@@ -88,7 +88,7 @@ onUnmounted(() => {
     :tabindex="itemContext.isFocusable.value ? 0 : -1"
     :aria-describedby="itemContext.descriptionId"
     :aria-labelledby="itemContext.titleId"
-    @mouseclick="handleMouseDown"
+    @click="handleMouseDown"
     @keydown.enter.space.left.right.up.down="handleKeyDown"
   >
     <slot />


### PR DESCRIPTION
Using `mousedown` event can lead to some edge cases.

In our app, changing step changes the modal content, thus its height, and a mouseup event would then be fired outside the modal: so changing step was actually closing the modal... it was hard to find why!

Also, this would be better for accessibility because I think using `enter` actually trigger the `click` event natively.

I can't think of any reason why using `mousedown` would be better, but I might be wrong!

Related: https://github.com/unovue/radix-vue/discussions/1330