### PR TITLE
fix(FocusScope): mounting components during init breaks autofocus

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -1,6 +1,6 @@
 import { type RenderResult, render, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { defineComponent, onMounted, ref } from 'vue'
 import { FocusScope } from '.'
 import userEvent from '@testing-library/user-event'
 
@@ -17,6 +17,21 @@ const TestField = ({
       <span>{{ label }}</span>
       <input type="text" :name="label.toLowerCase()" v-bind="$attrs" />
     </label>
+  `,
+})
+
+// Stripped-down version of Teleport.vue and onMounted from @vueuse/core
+const Delay = ({
+  setup() {
+    const isMounted = ref(false)
+    onMounted(() => isMounted.value = true)
+    return {
+      isMounted,
+    }
+  },
+  template: `
+    <div v-if="isMounted">
+    </div>
   `,
 })
 
@@ -130,6 +145,42 @@ describe('focusScope', () => {
       await userEvent.tab({ shift: true })
       await userEvent.tab()
       waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
+    })
+  })
+
+  describe('given a FocusScope with inner DOM mutations during onMounted', () => {
+    let rendered: RenderResult
+    let innerInputField: HTMLInputElement
+    let outerButton: HTMLButtonElement
+
+    beforeEach(() => {
+      rendered = render(defineComponent({
+        setup() {
+          const isVisible = ref(false)
+          return {
+            isVisible,
+          }
+        },
+        components: { TestField, FocusScope, Delay },
+        template: `<div>
+          <button @click="isVisible = !isVisible">some outer button</button>
+          <FocusScope v-if="isVisible" asChild loop trapped>
+            <form>
+              <TestField label=${INNER_NAME_INPUT_LABEL} />
+              <Delay></Delay>
+            </form>
+          </FocusScope>
+        </div>`,
+      }))
+      outerButton = rendered.getByRole('button') as HTMLButtonElement
+    })
+
+    it('should focus the first element when activated', async () => {
+      // DOM mutations during initialization shouldn't reset the focus to the container.
+      await userEvent.click(outerButton)
+
+      innerInputField = rendered.getByLabelText(INNER_NAME_INPUT_LABEL) as HTMLInputElement
+      expect(document.activeElement).toBe(innerInputField)
     })
   })
 })


### PR DESCRIPTION
Hello,

it is an old issue of mine and I finally got a working test case and a fix for it.


### 🔗 Linked issue

Fixes #680 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This change moves the MutationObserver to the second watchEffect, after the call of nextTick.
So that the MutationObserver doesn't try to fix the focus when a delayed component gets mounted during nextTick. 

I added a test case to the pull request.
 
 
Simple reproduction of the error on a live page (I used Chrome on Windows):
- Opening https://reka-ui.com/docs/components/dialog
- Click on "Edit Profile" 
- The first element gets focused
- Close the Dialog
- Click on "Edit Profile" again
- The first element won't get focused

This PR should fix this and the first element gets always focused.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.



