### PR TITLE
fix(combobox): disable the options even without pointer-events: none

### DIFF
--- a/packages/core/src/Combobox/ComboboxItem.vue
+++ b/packages/core/src/Combobox/ComboboxItem.vue
@@ -80,7 +80,7 @@ onUnmounted(() => {
     v-bind="props"
     :id="id"
     ref="primitiveElement"
-    :disabled="rootContext.disabled || disabled"
+    :disabled="rootContext.disabled.value || disabled"
     @select="(event) => {
       emits('select', event as any)
       if (event.defaultPrevented)

--- a/packages/core/src/Combobox/ComboboxItem.vue
+++ b/packages/core/src/Combobox/ComboboxItem.vue
@@ -80,12 +80,13 @@ onUnmounted(() => {
     v-bind="props"
     :id="id"
     ref="primitiveElement"
+    :disabled="rootContext.disabled || disabled"
     @select="(event) => {
       emits('select', event as any)
       if (event.defaultPrevented)
         return
 
-      if (!rootContext.multiple.value) {
+      if (!rootContext.multiple.value && !disabled) {
         event.preventDefault()
         rootContext.onOpenChange(false)
         rootContext.modelValue.value = props.value

--- a/packages/core/src/Combobox/ComboboxItem.vue
+++ b/packages/core/src/Combobox/ComboboxItem.vue
@@ -86,7 +86,7 @@ onUnmounted(() => {
       if (event.defaultPrevented)
         return
 
-      if (!rootContext.multiple.value && !disabled) {
+      if (!rootContext.multiple.value && !disabled && !rootContext.disabled.value) {
         event.preventDefault()
         rootContext.onOpenChange(false)
         rootContext.modelValue.value = props.value


### PR DESCRIPTION
Fix https://github.com/unovue/reka-ui/issues/1825

I changed 2 things here:
1. `ComboboxItem` now checks the root context for the disabled prop as I think the component should be truly not interactable while the disabled prop is set on `ComboboxRoot` (could be wrong)
2. `ComboboxItem` does not change the `rootContext.modelValue` while either the root or the item itself is disabled