### PR TITLE
fix: Fix select and modal popup errors in wujie micro-frontend project

### DIFF
--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -14,7 +14,7 @@ export const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside'
 export const FOCUS_OUTSIDE = 'dismissableLayer.focusOutside'
 
 function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
-  const targetLayer = targetElement.closest(
+  const targetLayer = targetElement?.closest(
     '[data-dismissable-layer]',
   ) as HTMLElement
 

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -14,9 +14,9 @@ export const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside'
 export const FOCUS_OUTSIDE = 'dismissableLayer.focusOutside'
 
 function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
-  const targetLayer = targetElement?.closest(
+  const targetLayer = targetElement.closest(
     '[data-dismissable-layer]',
-  ) as HTMLElement
+  )
 
   const mainLayer = layerElement.dataset.dismissableLayer === ''
     ? layerElement
@@ -27,10 +27,8 @@ function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
   const nodeList = Array.from(
     layerElement.ownerDocument.querySelectorAll('[data-dismissable-layer]'),
   )
-  if (
-    (targetLayer
-      && mainLayer === targetLayer)
-    || nodeList.indexOf(mainLayer) < nodeList.indexOf(targetLayer)
+
+  if (targetLayer && (mainLayer === targetLayer || nodeList.indexOf(mainLayer) < nodeList.indexOf(targetLayer))
   ) {
     return true
   }
@@ -58,9 +56,9 @@ export function usePointerDownOutside(
     if (!isClient)
       return
     const handlePointerDown = async (event: PointerEvent) => {
-      const target = event.target as HTMLElement
+      const target = event.target as HTMLElement | undefined
 
-      if (!element?.value)
+      if (!element?.value || !target)
         return
 
       if (isLayerExist(element.value, target)) {
@@ -159,7 +157,8 @@ export function useFocusOutside(
 
       await nextTick()
       await nextTick()
-      if (!element.value || isLayerExist(element.value, event.target as HTMLElement))
+      const target = event.target as HTMLElement | undefined
+      if (!element.value || !target || isLayerExist(element.value, target))
         return
 
       if (event.target && !isFocusInsideDOMTree.value) {


### PR DESCRIPTION
In the wujie micro-frontend environment, the following error will be reported when the pop-up layer is pulled down：

`utils.ts:16 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'closest')
    at isLayerExist (utils.ts:16:37)
    at HTMLDocument.handleFocus (utils.ts:160:29)
`    

The above error is because the dom cannot be obtained in the micro-frontend environment, and an additional layer of judgment is required