### PR TITLE
fix(Combobox): search term not reactive to prop changes

### DIFF
--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -85,6 +85,15 @@ watch(rootContext.modelValue, async () => {
   if (!rootContext.isUserInputted.value && rootContext.resetSearchTermOnSelect.value)
     resetSearchTerm()
 }, { immediate: true, deep: true })
+
+watch(
+  () => props.modelValue,
+  () => {
+    if (props.modelValue !== undefined) {
+      rootContext.filterState.search = props.modelValue
+    }
+  },
+)
 </script>
 
 <template>


### PR DESCRIPTION
If the `ComboboxInput` `modelValue` prop was changed, then the `filterState.search` was not updated, so the previously filtered results were still shown in the combobox content.

With this change, we explicitly update the `filterState.search` whenever the `modelValue` is updated.

To test this, I added this snippet to the `ComboboxBasic.story.vue`, and added `v-model="searchTerm"` prop to the `ComboboxInput` component:

```ts
const searchTerm = ref('')
setTimeout(() => {
  searchTerm.value = 'ba'
  setTimeout(() => {
    searchTerm.value = ''
  }, 1000)
}, 2000)
```

and can see that the list is not filtered whenever the search term is changed:


https://github.com/user-attachments/assets/6058317d-7ba1-4525-b065-3d3abdd8eacb

However, after applying this fix, the list is filtered as expected:

https://github.com/user-attachments/assets/48c84fd4-518e-4272-bd21-9d9f0f9273f1