### PR TITLE
refactor(useBodyScrollLock): hoist `--scrollbar-width` CSS var to html root

### DIFF
--- a/packages/core/src/ConfigProvider/ConfigProvider.test.ts
+++ b/packages/core/src/ConfigProvider/ConfigProvider.test.ts
@@ -43,7 +43,7 @@ describe('given a default ConfigProvider', async () => {
     expect(document.body.style.paddingRight).toBe('10px')
     expect(document.body.style.marginRight).toBe('0px')
     expect(document.body.style.overflow).toBe('hidden')
-    expect(document.body.style.getPropertyValue('--scrollbar-width')).toBe('10px')
+    expect(document.documentElement.style.getPropertyValue('--scrollbar-width')).toBe('10px')
   })
 })
 

--- a/packages/core/src/shared/useBodyScrollLock.ts
+++ b/packages/core/src/shared/useBodyScrollLock.ts
@@ -30,7 +30,7 @@ const useBodyLockStackCount = createSharedComposable(() => {
     document.body.style.paddingRight = ''
     document.body.style.marginRight = ''
     document.body.style.pointerEvents = ''
-    document.body.style.removeProperty('--scrollbar-width')
+    document.documentElement.style.removeProperty('--scrollbar-width')
     document.body.style.overflow = initialOverflow.value ?? ''
     isIOS && stopTouchMoveListener?.()
 
@@ -65,7 +65,7 @@ const useBodyLockStackCount = createSharedComposable(() => {
     if (verticalScrollbarWidth > 0) {
       document.body.style.paddingRight = typeof config.padding === 'number' ? `${config.padding}px` : String(config.padding)
       document.body.style.marginRight = typeof config.margin === 'number' ? `${config.margin}px` : String(config.margin)
-      document.body.style.setProperty('--scrollbar-width', `${verticalScrollbarWidth}px`)
+      document.documentElement.style.setProperty('--scrollbar-width', `${verticalScrollbarWidth}px`)
       document.body.style.overflow = 'hidden'
     }
 


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/1874

This PR hoists the `--scrollbar-width` CSS variable from the `body` to the `html` element to allow for more usage in user scenarios, for example, the `:root` selector often used in tailwindcss. ❤️