### PR TITLE
feat(splitter): expose collapse expand, and resize on SplitterPannel slot

### DIFF
--- a/packages/core/src/Splitter/SplitterPanel.vue
+++ b/packages/core/src/Splitter/SplitterPanel.vue
@@ -74,6 +74,12 @@ defineSlots<{
     isCollapsed: typeof isCollapsed.value
     /** Is the panel expanded */
     isExpanded: typeof isExpanded.value
+    /** If panel is `collapsible`, collapse it fully. */
+    collapse: typeof collapse
+    /** If panel is currently collapsed, expand it to its most recent size. */
+    expand: typeof expand
+    /** Resize panel to the specified percentage (1 - 100). */
+    resize: typeof resize
   }) => any
 }>()
 
@@ -134,23 +140,29 @@ const style = computed(() => getPanelStyle(panelDataRef.value, props.defaultSize
 const isCollapsed = computed(() => isPanelCollapsed(panelDataRef.value))
 const isExpanded = computed(() => !isCollapsed.value)
 
+function collapse() {
+  collapsePanel(panelDataRef.value)
+}
+
+function expand() {
+  expandPanel(panelDataRef.value)
+}
+
+function resize(size: number) {
+  resizePanel(panelDataRef.value, size)
+}
+
 defineExpose({
   /** If panel is `collapsible`, collapse it fully. */
-  collapse: () => {
-    collapsePanel(panelDataRef.value)
-  },
+  collapse,
   /** If panel is currently collapsed, expand it to its most recent size. */
-  expand: () => {
-    expandPanel(panelDataRef.value)
-  },
+  expand,
   /** Gets the current size of the panel as a percentage (1 - 100). */
   getSize() {
     return getPanelSize(panelDataRef.value)
   },
   /** Resize panel to the specified percentage (1 - 100). */
-  resize: (size: number) => {
-    resizePanel(panelDataRef.value, size)
-  },
+  resize,
   /** Returns `true` if the panel is currently collapsed */
   isCollapsed,
   /** Returns `true` if the panel is currently not collapsed */
@@ -174,6 +186,9 @@ defineExpose({
     <slot
       :is-collapsed="isCollapsed"
       :is-expanded="isExpanded"
+      :expand="expand"
+      :collapse="collapse"
+      :resize="resize"
     />
   </Primitive>
 </template>


### PR DESCRIPTION
Instead of needing create a ref to call expand like this:

```vue
<script setup lang="ts">
const panelRef= useTemplateRef('panelRef')
</script>

<template>
...
     <splitter-panel v-slot="{ isCollapsed }" ref="panelRef" :min-size="25" :collapsed-size="5" collapsible>
           <button v-if="isCollapsed"  @click="googleImagePanelRef?.expand()">Expand</div>
...
</template>
```
Could be refactored into this:

```vue
<script setup lang="ts">
...
</script>

<template>
...
     <splitter-panel v-slot="{ isCollapsed , expand}" :min-size="25" :collapsed-size="5" collapsible>
           <button v-if="isCollapsed"  @click="expand()">Expand</div>
...
</template>
```
