### PR TITLE
fix(Progress): omit `aria-valuetext`/`aria-label` for determinate state

### DIFF
--- a/docs/content/meta/ProgressRoot.md
+++ b/docs/content/meta/ProgressRoot.md
@@ -17,7 +17,7 @@
   {
     'name': 'getValueLabel',
     'description': '<p>A function to get the accessible label text representing the current value in a human-readable format.</p>\n<p>If not provided, the value label will be read as the numeric value as a percentage of the max value.</p>\n',
-    'type': '((value: number, max: number) => string)',
+    'type': '((value: number | null | undefined, max: number) => string | undefined)',
     'required': false,
     'default': '`${Math.round((value / max) * DEFAULT_MAX)}%`'
   },
@@ -61,6 +61,6 @@
   {
     'name': 'getValueLabel',
     'description': '<p>A function to get the accessible label text representing the current value in a human-readable format.</p>\n<p>If not provided, the value label will be read as the numeric value as a percentage of the max value.</p>\n',
-    'type': '(value: number, max: number) => string'
+    'type': '(value: number | null | undefined, max: number) => string | undefined'
   }
 ]" />

--- a/packages/core/src/Progress/ProgressRoot.vue
+++ b/packages/core/src/Progress/ProgressRoot.vue
@@ -20,7 +20,7 @@ export interface ProgressRootProps extends PrimitiveProps {
    *
    *  If not provided, the value label will be read as the numeric value as a percentage of the max value.
    */
-  getValueLabel?: (value: number, max: number) => string
+  getValueLabel?: (value: number | null | undefined, max: number) => string | undefined
 }
 
 const DEFAULT_MAX = 100
@@ -75,8 +75,8 @@ import { computed, nextTick, watch } from 'vue'
 
 const props = withDefaults(defineProps<ProgressRootProps>(), {
   max: DEFAULT_MAX,
-  getValueLabel: (value: number, max: number) =>
-    `${Math.round((value / max) * DEFAULT_MAX)}%`,
+  getValueLabel: (value: number | null | undefined, max: number) =>
+    isNumber(value) ? `${Math.round((value / max) * DEFAULT_MAX)}%` : undefined,
 })
 
 const emit = defineEmits<ProgressRootEmits>()
@@ -143,8 +143,8 @@ provideProgressRootContext({
     :aria-valuemax="max"
     :aria-valuemin="0"
     :aria-valuenow="isNumber(modelValue) ? modelValue : undefined"
-    :aria-valuetext="getValueLabel(modelValue!, max)"
-    :aria-label="getValueLabel(modelValue!, max)"
+    :aria-valuetext="getValueLabel(modelValue, max)"
+    :aria-label="getValueLabel(modelValue, max)"
     role="progressbar"
     :data-state="progressState"
     :data-value="modelValue ?? undefined"


### PR DESCRIPTION
resolves #1871

This PR omit `aria-valuetext`/`aria-label` for determinate state (`modelValue` is `null` or `undefined`); otherwise these will be displayed as `NaN`.