### PR TITLE
docs(Combobox): Update highlighted lines in "Binding objects as values" section

### DIFF
--- a/docs/content/docs/components/combobox.md
+++ b/docs/content/docs/components/combobox.md
@@ -279,7 +279,7 @@ Unlike native HTML form controls which only allow you to provide strings as valu
 
 Make sure to set the `displayValue` prop to set the input value on item selection.
 
-```vue line=12,17,26
+```vue line=12,17,23
 <script setup lang="ts">
 import { ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot } from 'reka-ui'
 import { ref } from 'vue'


### PR DESCRIPTION
I almost missed updating the `value` prop because it isn't highlighted in the code snippet. 

![CleanShot 2025-05-09 at 10 58 35](https://github.com/user-attachments/assets/7160946d-5ab9-4caf-9dee-e2f2367f22d7)

I'm guessing it should probably be highlighting that line, instead of the one with the person's name?