### PR TITLE
fix(CollapsibleRoot): ensure open does not trigger when disabled

### DIFF
--- a/packages/core/src/Collapsible/CollapsibleRoot.vue
+++ b/packages/core/src/Collapsible/CollapsibleRoot.vue
@@ -64,6 +64,9 @@ provideCollapsibleRootContext({
   open,
   unmountOnHide,
   onOpenToggle: () => {
+    if (disabled.value)
+      return
+
     open.value = !open.value
   },
 })


### PR DESCRIPTION
The Collapsible `disabled` prop expects the trigger to be disabled to prevent toggle but when the trigger is a link for example, we need to check in `onOpenToggle`.