### PR TITLE
fix(Tooltip): prevent closing `Tooltip` on `pointerDown` when `disableClosingTrigger`

### DIFF
--- a/packages/core/src/Tooltip/TooltipTrigger.vue
+++ b/packages/core/src/Tooltip/TooltipTrigger.vue
@@ -57,7 +57,7 @@ function handlePointerUp() {
 }
 
 function handlePointerDown() {
-  if (rootContext.open) {
+  if (rootContext.open && !rootContext.disableClosingTrigger.value) {
     rootContext.onClose()
   }
   isPointerDown.value = true


### PR DESCRIPTION
resolves #1899