### PR TITLE
refactor(SelectRoot): improve generic types

### DIFF
--- a/packages/core/src/Select/SelectRoot.vue
+++ b/packages/core/src/Select/SelectRoot.vue
@@ -72,11 +72,11 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(defineProps<SelectRootProps>(), {
+const props = withDefaults(defineProps<SelectRootProps<T>>(), {
   modelValue: undefined,
   open: undefined,
 })
-const emits = defineEmits<SelectRootEmits>()
+const emits = defineEmits<SelectRootEmits<T>>()
 
 defineSlots<{
   default: (props: {
@@ -90,6 +90,7 @@ defineSlots<{
 const { required, disabled, multiple, dir: propDir } = toRefs(props)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
+  // @ts-expect-error Missing infer for AcceptableValue
   defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
   passive: (props.modelValue === undefined) as false,
   deep: true,
@@ -156,6 +157,7 @@ provideSelectRootContext({
   modelValue,
   // @ts-expect-error Missing infer for AcceptableValue
   onValueChange: handleValueChange,
+  // @ts-expect-error Missing infer for AcceptableValue
   by: props.by,
   open,
   multiple,


### PR DESCRIPTION
resolves #1901

This PR improves the generic types of `SelectRoot` to enable automatic narrowing of the value type to the current `modelValue` type.

|Before|After|
|:-:|:-:|
|<img width="890" alt="image" src="https://github.com/user-attachments/assets/4ce4b540-6956-4f75-b96f-2250840d306e" />|<img width="764" alt="image" src="https://github.com/user-attachments/assets/a03a7a35-4f44-4422-b89f-edab1b919d39" />|
|<img width="896" alt="image" src="https://github.com/user-attachments/assets/d879c0f3-2107-415d-aab6-6d525045586e" />|<img width="786" alt="image" src="https://github.com/user-attachments/assets/fcd2cab4-b822-4b03-b8f9-43e708e15322" />|