### PR TITLE
Fix `ESModulesLinkingError` in `useId.js` for Old Version Vue Compatibility

### DIFF
--- a/packages/core/src/shared/useId.ts
+++ b/packages/core/src/shared/useId.ts
@@ -18,8 +18,8 @@ export function useId(deterministicId?: string | null | undefined, prefix = 'rek
 
   const configProviderContext = injectConfigProviderContext({ useId: undefined })
 
-  if (vue.useId) {
-    return `${prefix}-${vue.useId()}`
+  if (Object.hasOwn(vue, 'useId')) {
+    return `${prefix}-${vue['useId']?.()}`
   }
   else if (configProviderContext.useId) {
     return `${prefix}-${configProviderContext.useId()}`


### PR DESCRIPTION
# What Problem Does This Solve?

When using `reka-ui@2.2.1` with Vue 3.3.13 in a project, an `ESModulesLinkingError` occurs during the build process. The error is caused by the `useId.js` module attempting to access `vue.useId`, which is not exported by Vue 3.3.13. The error messages are as follows:


```
ERROR in ../../../node_modules/.pnpm/reka-ui@2.2.1_typescript@5.3.3_vue@3.3.13/node_modules/reka-ui/dist/shared/useId.js 
  × ESModulesLinkingError: export 'useId' (imported as 'vue') was not found in 'vue' (possible exports: BaseTransition, BaseTransitionPropsValidators, Comment, EffectScope, Fragment, KeepAlive, ReactiveEffect, Static, Suspense, Teleport, Text, Transition, TransitionGroup, VueElement, assertNumber, callWithAsyncErrorHandling, callWithErrorHandling, camelize, capitalize, cloneVNode, compatUtils, compile, computed, createApp, createBlock, createCommentVNode, createElementBlock, createElementVNode, createHydrationRenderer, createPropsRestProxy, createRenderer, createSSRApp, createSlots, createStaticVNode, createTextVNode, createVNode, customRef, defineAsyncComponent, defineComponent, defineCustomElement, defineEmits, defineExpose, defineModel, defineOptions, defineProps, defineSSRCustomElement, defineSlots, devtools, effect, effectScope, getCurrentInstance, getCurrentScope, getTransitionRawChildren, guardReactiveProps, h, handleError, hasInjectionContext, hydrate, initCustomFormatter, initDirectivesForSSR, inject, isMemoSame, isProxy, isReactive, isReadonly, isRef, isRuntimeOnly, isShallow, isVNode, markRaw, mergeDefaults, mergeModels, mergeProps, nextTick, normalizeClass, normalizeProps, normalizeStyle, onActivated, onBeforeMount, onBeforeUnmount, onBeforeUpdate, onDeactivated, onErrorCaptured, onMounted, onRenderTracked, onRenderTriggered, onScopeDispose, onServerPrefetch, onUnmounted, onUpdated, openBlock, popScopeId, provide, proxyRefs, pushScopeId, queuePostFlushCb, reactive, readonly, ref, registerRuntimeCompiler, render, renderList, renderSlot, resolveComponent, resolveDirective, resolveDynamicComponent, resolveFilter, resolveTransitionHooks, setBlockTracking, setDevtoolsHook, setTransitionHooks, shallowReactive, shallowReadonly, shallowRef, ssrContextKey, ssrUtils, stop, toDisplayString, toHandlerKey, toHandlers, toRaw, toRef, toRefs, toValue, transformVNodeArgs, triggerRef, unref, useAttrs, useCssModule, useCssVars, useModel, useSSRContext, useSlots, useTransitionState, vModelCheckbox, vModelDynamic, vModelRadio, vModelSelect, vModelText, vShow, version, warn, watch, watchEffect, watchPostEffect, watchSyncEffect, withAsyncContext, withCtx, withDefaults, withDirectives, withKeys, withMemo, withModifiers, withScopeId)
    ╭─[9:6]
  7 │     return deterministicId;
  8 │   const configProviderContext = injectConfigProviderContext({ useId: void 0 });
  9 │   if (vue.useId) {
    ·       ─────────
 10 │     return `${prefix}-${vue.useId()}`;
 11 │   } else if (configProviderContext.useId) {
    ╰────
ERROR in ../../../node_modules/.pnpm/reka-ui@2.2.1_typescript@5.3.3_vue@3.3.13/node_modules/reka-ui/dist/shared/useId.js 
  × ESModulesLinkingError: export 'useId' (imported as 'vue') was not found in 'vue' (possible exports: BaseTransition, BaseTransitionPropsValidators, Comment, EffectScope, Fragment, KeepAlive, ReactiveEffect, Static, Suspense, Teleport, Text, Transition, TransitionGroup, VueElement, assertNumber, callWithAsyncErrorHandling, callWithErrorHandling, camelize, capitalize, cloneVNode, compatUtils, compile, computed, createApp, createBlock, createCommentVNode, createElementBlock, createElementVNode, createHydrationRenderer, createPropsRestProxy, createRenderer, createSSRApp, createSlots, createStaticVNode, createTextVNode, createVNode, customRef, defineAsyncComponent, defineComponent, defineCustomElement, defineEmits, defineExpose, defineModel, defineOptions, defineProps, defineSSRCustomElement, defineSlots, devtools, effect, effectScope, getCurrentInstance, getCurrentScope, getTransitionRawChildren, guardReactiveProps, h, handleError, hasInjectionContext, hydrate, initCustomFormatter, initDirectivesForSSR, inject, isMemoSame, isProxy, isReactive, isReadonly, isRef, isRuntimeOnly, isShallow, isVNode, markRaw, mergeDefaults, mergeModels, mergeProps, nextTick, normalizeClass, normalizeProps, normalizeStyle, onActivated, onBeforeMount, onBeforeUnmount, onBeforeUpdate, onDeactivated, onErrorCaptured, onMounted, onRenderTracked, onRenderTriggered, onScopeDispose, onServerPrefetch, onUnmounted, onUpdated, openBlock, popScopeId, provide, proxyRefs, pushScopeId, queuePostFlushCb, reactive, readonly, ref, registerRuntimeCompiler, render, renderList, renderSlot, resolveComponent, resolveDirective, resolveDynamicComponent, resolveFilter, resolveTransitionHooks, setBlockTracking, setDevtoolsHook, setTransitionHooks, shallowReactive, shallowReadonly, shallowRef, ssrContextKey, ssrUtils, stop, toDisplayString, toHandlerKey, toHandlers, toRaw, toRef, toRefs, toValue, transformVNodeArgs, triggerRef, unref, useAttrs, useCssModule, useCssVars, useModel, useSSRContext, useSlots, useTransitionState, vModelCheckbox, vModelDynamic, vModelRadio, vModelSelect, vModelText, vShow, version, warn, watch, watchEffect, watchPostEffect, watchSyncEffect, withAsyncContext, withCtx, withDefaults, withDirectives, withKeys, withMemo, withModifiers, withScopeId)
    ╭─[10:24]
  8 │   const configProviderContext = injectConfigProviderContext({ useId: void 0 });
  9 │   if (vue.useId) {
 10 │     return `${prefix}-${vue.useId()}`;
    ·                         ─────────
 11 │   } else if (configProviderContext.useId) {
 12 │     return `${prefix}-${configProviderContext.useId()}`;
    ╰────
```

The issue arises because `vue.useId` is not available in Vue 3.3.13 (and possibly other versions prior to Vue 3.4, where `useId` may have been introduced). This causes the build to fail during static module analysis, even though the code includes fallback logic for `configProviderContext.useId` and a counter-based ID generator.







