### PR TITLE
feat(CalendarRoot): Add maxDate and minDate at props availability

### DIFF
--- a/docs/content/meta/CalendarRoot.md
+++ b/docs/content/meta/CalendarRoot.md
@@ -35,5 +35,15 @@
     'name': 'modelValue',
     'description': '<p>The current date of the calendar</p>\n',
     'type': 'CalendarDate | CalendarDateTime | ZonedDateTime'
+  },
+  {
+    'name': 'maxDate',
+    'description': '<p>The maximum selected date of the calendar</p>\n',
+    'type': 'CalendarDate | CalendarDateTime | ZonedDateTime | undefined'
+  },
+  {
+    'name': 'minDate',
+    'description': '<p>The minimum selected date of the calendar</p>\n',
+    'type': 'CalendarDate | CalendarDateTime | ZonedDateTime | undefined'
   }
 ]" />


### PR DESCRIPTION
I just use the beta version of CalendarRoot and find is there any option to pass minDate and maxDate into that, it's available but not defined at the documentation section.