### PR TITLE
docs: fix missing event types

### DIFF
--- a/docs/content/meta/AvatarFallback.md
+++ b/docs/content/meta/AvatarFallback.md
@@ -18,7 +18,6 @@
     'name': 'delayMs',
     'description': '<p>Useful for delaying rendering so it only appears for those with slower connections.</p>\n',
     'type': 'number',
-    'required': false,
-    'default': '0'
+    'required': false
   }
 ]" />

--- a/docs/content/meta/AvatarImage.md
+++ b/docs/content/meta/AvatarImage.md
@@ -15,6 +15,12 @@
     'required': false
   },
   {
+    'name': 'crossOrigin',
+    'description': '',
+    'type': '\'\' | \'anonymous\' | \'use-credentials\'',
+    'required': false
+  },
+  {
     'name': 'referrerPolicy',
     'description': '',
     'type': '\'\' | \'no-referrer\' | \'no-referrer-when-downgrade\' | \'origin\' | \'origin-when-cross-origin\' | \'same-origin\' | \'strict-origin\' | \'strict-origin-when-cross-origin\' | \'unsafe-url\'',

--- a/docs/content/meta/EditableRoot.md
+++ b/docs/content/meta/EditableRoot.md
@@ -150,17 +150,17 @@
   {
     'name': 'submit',
     'description': '<p>Function to submit the value of the editable</p>\n',
-    'type': ''
+    'type': '(): void'
   },
   {
     'name': 'cancel',
     'description': '<p>Function to cancel the value of the editable</p>\n',
-    'type': ''
+    'type': '(): void'
   },
   {
     'name': 'edit',
     'description': '<p>Function to set the editable in edit mode</p>\n',
-    'type': ''
+    'type': '(): void'
   }
 ]" />
 

--- a/docs/content/meta/ScrollAreaRoot.md
+++ b/docs/content/meta/ScrollAreaRoot.md
@@ -30,7 +30,7 @@
   {
     'name': 'type',
     'description': '<p>Describes the nature of scrollbar visibility, similar to how the scrollbar preferences in MacOS control visibility of native scrollbars.</p>\n<p><code>auto</code> - means that scrollbars are visible when content is overflowing on the corresponding orientation. &lt;br&gt;\n<code>always</code> - means that scrollbars are always visible regardless of whether the content is overflowing.&lt;br&gt;\n<code>scroll</code> - means that scrollbars are visible when the user is scrolling along its corresponding orientation.&lt;br&gt;\n<code>hover</code> - when the user is scrolling along its corresponding orientation and when the user is hovering over the scroll area.</p>\n',
-    'type': '\'scroll\' | \'always\' | \'auto\' | \'hover\'',
+    'type': '\'scroll\' | \'always\' | \'hover\' | \'auto\'',
     'required': false,
     'default': '\'hover\''
   }

--- a/docs/content/meta/StepperItem.md
+++ b/docs/content/meta/StepperItem.md
@@ -40,6 +40,6 @@
   {
     'name': 'state',
     'description': '<p>The current state of the stepper item</p>\n',
-    'type': '\'active\' | \'inactive\' | \'completed\''
+    'type': '\'active\' | \'completed\' | \'inactive\''
   }
 ]" />

--- a/docs/content/meta/StepperRoot.md
+++ b/docs/content/meta/StepperRoot.md
@@ -91,16 +91,16 @@
   {
     'name': 'goToStep',
     'description': '<p>Go to a specific step</p>\n',
-    'type': ''
+    'type': '(step: number): void'
   },
   {
     'name': 'nextStep',
     'description': '<p>Go to the next step</p>\n',
-    'type': ''
+    'type': '(): void'
   },
   {
     'name': 'prevStep',
     'description': '<p>Go to the previous step</p>\n',
-    'type': ''
+    'type': '(): void'
   }
 ]" />

--- a/docs/content/meta/TreeItem.md
+++ b/docs/content/meta/TreeItem.md
@@ -60,11 +60,11 @@
   {
     'name': 'handleToggle',
     'description': '',
-    'type': ''
+    'type': '(): void'
   },
   {
     'name': 'handleSelect',
     'description': '',
-    'type': ''
+    'type': '(): void'
   }
 ]" />

--- a/docs/content/meta/TreeRoot.md
+++ b/docs/content/meta/TreeRoot.md
@@ -54,7 +54,7 @@
   {
     'name': 'getKey',
     'description': '<p>This function is passed the index of each item and should return a unique key for that item</p>\n',
-    'type': '(val: Record<string, any>) => string',
+    'type': '(val: Record<string, any>): string',
     'required': true
   },
   {

--- a/docs/content/meta/VisuallyHidden.md
+++ b/docs/content/meta/VisuallyHidden.md
@@ -17,7 +17,7 @@
   {
     'name': 'feature',
     'description': '',
-    'type': '\'fully-hidden\' | \'focusable\'',
+    'type': '\'focusable\' | \'fully-hidden\'',
     'required': false,
     'default': '\'focusable\''
   }

--- a/docs/scripts/autogen.ts
+++ b/docs/scripts/autogen.ts
@@ -93,7 +93,7 @@ function parseTypeFromSchema(schema: PropertyMetaSchema): string {
     else
       return schema.type
   }
-  else if (typeof schema === 'object' && schema.kind === 'object') {
+  else if (typeof schema === 'object' && (schema.kind === 'object' || schema.kind === 'event')) {
     return schema.type
   }
   else if (typeof schema === 'string') {


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/1910

(Regarding the diff, only `docs/scripts/autogen.ts` is changed manually, other changed markdowns are auto-generated by `docs:gen`)