### PR TITLE
feat(Combobox): add `max` prop to limit the count of selected options

### DIFF
--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -57,6 +57,13 @@
     'required': false
   },
   {
+    'name': 'max',
+    'description': '<p>Maximum number of options that can be selected.\nOnly applies when <code>multiple</code> is <code>true</code>.\nWhen <code>0</code>, there is no limit.</p>\n',
+    'type': 'number',
+    'required': false,
+    'default': '0'
+  },
+  {
     'name': 'modelValue',
     'description': '<p>The controlled value of the listbox. Can be binded with with <code>v-model</code>.</p>\n',
     'type': 'AcceptableValue | AcceptableValue[]',
@@ -107,6 +114,11 @@
     'name': 'highlight',
     'description': '<p>Event handler when highlighted element changes.</p>\n',
     'type': '[payload: { ref: HTMLElement; value: AcceptableValue; }]'
+  },
+  {
+    'name': 'invalid',
+    'description': '<p>Event handler called when the value is invalid</p>\n',
+    'type': '[payload: AcceptableValue]'
   },
   {
     'name': 'update:modelValue',

--- a/docs/content/meta/ListboxRoot.md
+++ b/docs/content/meta/ListboxRoot.md
@@ -45,6 +45,13 @@
     'required': false
   },
   {
+    'name': 'max',
+    'description': '<p>Maximum number of options that can be selected.\nOnly applies when <code>multiple</code> is <code>true</code>.\nWhen <code>0</code>, there is no limit.</p>\n',
+    'type': 'number',
+    'required': false,
+    'default': '0'
+  },
+  {
     'name': 'modelValue',
     'description': '<p>The controlled value of the listbox. Can be binded with with <code>v-model</code>.</p>\n',
     'type': 'AcceptableValue | AcceptableValue[]',
@@ -94,6 +101,11 @@
     'name': 'highlight',
     'description': '<p>Event handler when highlighted element changes.</p>\n',
     'type': '[payload: { ref: HTMLElement; value: AcceptableValue; }]'
+  },
+  {
+    'name': 'invalid',
+    'description': '<p>Event handler called when the value is invalid</p>\n',
+    'type': '[payload: AcceptableValue]'
   },
   {
     'name': 'leave',

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -1,13 +1,14 @@
 <script lang="ts">
+import type { Ref } from 'vue'
 import type { ListboxRootProps } from '@/Listbox'
 import type { AcceptableValue, GenericComponentInstance } from '@/shared/types'
-import type { Ref } from 'vue'
 import { usePrimitiveElement } from '@/Primitive'
 import { createContext, useDirection, useFilter } from '@/shared'
 
 type ComboboxRootContext<T> = {
   modelValue: Ref<T | Array<T>>
   multiple: Ref<boolean>
+  max: Ref<number>
   disabled: Ref<boolean>
   open: Ref<boolean>
   onOpenChange: (value: boolean) => void
@@ -41,6 +42,8 @@ export type ComboboxRootEmits<T = AcceptableValue> = {
   'highlight': [payload: { ref: HTMLElement, value: T } | undefined]
   /** Event handler called when the open state of the combobox changes. */
   'update:open': [value: boolean]
+  /** Event handler called when the value is invalid */
+  'invalid': [payload: T]
 }
 
 export interface ComboboxRootProps<T = AcceptableValue> extends Omit<ListboxRootProps<T>, 'orientation' | 'selectionBehavior'> {
@@ -67,12 +70,13 @@ export interface ComboboxRootProps<T = AcceptableValue> extends Omit<ListboxRoot
 
 <script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
 import type { EventHookOn } from '@vueuse/core'
-import { ListboxRoot } from '@/Listbox'
-import { PopperRoot } from '@/Popper'
 import { createEventHook, useVModel } from '@vueuse/core'
 import { computed, getCurrentInstance, nextTick, onMounted, reactive, ref, toRefs, watch } from 'vue'
+import { ListboxRoot } from '@/Listbox'
+import { PopperRoot } from '@/Popper'
 
 const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
+  max: 0,
   open: undefined,
   resetSearchTermOnBlur: true,
   resetSearchTermOnSelect: true,
@@ -89,7 +93,7 @@ defineSlots<{
 }>()
 
 const { primitiveElement, currentElement: parentElement } = usePrimitiveElement<GenericComponentInstance<typeof ListboxRoot>>()
-const { multiple, disabled, ignoreFilter, resetSearchTermOnSelect, dir: propDir } = toRefs(props)
+const { multiple, max, disabled, ignoreFilter, resetSearchTermOnSelect, dir: propDir } = toRefs(props)
 
 const dir = useDirection(propDir)
 
@@ -213,6 +217,7 @@ defineExpose({
 provideComboboxRootContext({
   modelValue,
   multiple,
+  max,
   disabled,
   open,
   onOpenChange,
@@ -247,11 +252,13 @@ provideComboboxRootContext({
       :as-child="asChild"
       :dir="dir"
       :multiple="multiple"
+      :max="max"
       :name="name"
       :required="required"
       :disabled="disabled"
       :highlight-on-hover="true"
       :by="props.by as any"
+      @invalid="emits('invalid', $event as T)"
       @highlight="emits('highlight', $event as any)"
     >
       <slot

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -10,6 +10,7 @@ type ListboxRootContext<T> = {
   modelValue: Ref<T | Array<T> | undefined>
   onValueChange: (val: T) => void
   multiple: Ref<boolean>
+  max: Ref<number>
   orientation: Ref<DataOrientation>
   dir: Ref<Direction>
   disabled: Ref<boolean>
@@ -46,6 +47,14 @@ export interface ListboxRootProps<T = AcceptableValue> extends PrimitiveProps, F
   defaultValue?: T | Array<T>
   /** Whether multiple options can be selected or not. */
   multiple?: boolean
+  /**
+   * Maximum number of options that can be selected.
+   * Only applies when `multiple` is `true`.
+   * When `0`, there is no limit.
+   *
+   * @defaultValue 0
+   */
+  max?: number
   /** The orientation of the listbox. <br>Mainly so arrow navigation is done accordingly (left & right vs. up & down) */
   orientation?: DataOrientation
   /** The reading direction of the listbox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
@@ -72,19 +81,22 @@ export type ListboxRootEmits<T = AcceptableValue> = {
   'entryFocus': [event: CustomEvent]
   /** Event handler called when the mouse leave the container */
   'leave': [event: Event]
+  /** Event handler called when the value is invalid */
+  'invalid': [payload: T]
 }
 </script>
 
 <script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
 import type { EventHook } from '@vueuse/core'
 import type { Ref } from 'vue'
-import { useCollection } from '@/Collection'
-import { VisuallyHiddenInput } from '@/VisuallyHidden'
 import { createEventHook, useVModel } from '@vueuse/core'
 import { nextTick, ref, toRefs, watch } from 'vue'
+import { useCollection } from '@/Collection'
+import { VisuallyHiddenInput } from '@/VisuallyHidden'
 import { compare } from './utils'
 
 const props = withDefaults(defineProps<ListboxRootProps>(), {
+  max: 0,
   selectionBehavior: 'toggle',
   orientation: 'vertical',
 })
@@ -97,7 +109,7 @@ defineSlots<{
   }) => any
 }>()
 
-const { multiple, highlightOnHover, orientation, disabled, selectionBehavior, dir: propDir } = toRefs(props)
+const { multiple, max, highlightOnHover, orientation, disabled, selectionBehavior, dir: propDir } = toRefs(props)
 const { getItems } = useCollection<{ value: T }>({ isProvider: true })
 const { handleTypeaheadSearch } = useTypeahead()
 const { primitiveElement, currentElement } = usePrimitiveElement()
@@ -121,7 +133,16 @@ function onValueChange(val: T) {
     const modelArray = Array.isArray(modelValue.value) ? [...modelValue.value] : []
     const index = modelArray.findIndex(i => compare(i, val, props.by))
     if (props.selectionBehavior === 'toggle') {
-      index === -1 ? modelArray.push(val) : modelArray.splice(index, 1)
+      if (index === -1) {
+        if (max.value && modelArray.length >= max.value) {
+          emits('invalid', val)
+          return
+        }
+        modelArray.push(val)
+      }
+      else {
+        modelArray.splice(index, 1)
+      }
       modelValue.value = modelArray
     }
     else {


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/1919

This PR adds a `max` prop to the `Combobox`/`Listbox` component to support limiting the number of selected options when `multiple: true`. It also adds a corresponding `@invalid` event when the count limit is exceeded during selection, aligning with the behavior of `TagsInput`.