### PR TITLE
fix(RangeCalendar): fixed selected and highlighted when `allowNonContiguousRanges`

### DIFF
--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -79,6 +79,7 @@ const isHighlightEnd = computed(() => rootContext.isHighlightedEnd(props.day))
 const isHighlighted = computed(() => rootContext.highlightedRange.value
   ? isBetweenInclusive(props.day, rootContext.highlightedRange.value.start, rootContext.highlightedRange.value.end)
   : false)
+const allowNonContiguousRanges = computed(() => rootContext.allowNonContiguousRanges.value)
 
 const isDateToday = computed(() => {
   return isToday(props.day, getLocalTimeZone())
@@ -279,14 +280,14 @@ function handleArrowKey(e: KeyboardEvent) {
     role="button"
     :aria-label="labelText"
     data-reka-calendar-cell-trigger
-    :aria-selected="isSelectedDate && !isUnavailable ? true : undefined"
+    :aria-selected="isSelectedDate && (allowNonContiguousRanges || !isUnavailable) ? true : undefined"
     :aria-disabled="isDisabled || isUnavailable ? true : undefined"
-    :data-highlighted="isHighlighted && !isUnavailable ? '' : undefined"
+    :data-highlighted="isHighlighted && (allowNonContiguousRanges || !isUnavailable) ? '' : undefined"
     :data-selection-start="isSelectionStart ? true : undefined"
     :data-selection-end="isSelectionEnd ? true : undefined"
     :data-highlighted-start="isHighlightStart ? true : undefined"
     :data-highlighted-end="isHighlightEnd ? true : undefined"
-    :data-selected="isSelectedDate && !isUnavailable ? true : undefined"
+    :data-selected="isSelectedDate && (allowNonContiguousRanges || !isUnavailable) ? true : undefined"
     :data-outside-visible-view="isOutsideVisibleView ? '' : undefined"
     :data-value="day.toString()"
     :data-disabled="isDisabled ? '' : undefined"
@@ -308,7 +309,7 @@ function handleArrowKey(e: KeyboardEvent) {
       :outside-view="isOutsideView"
       :outside-visible-view="isOutsideVisibleView"
       :unavailable="isUnavailable"
-      :highlighted="isHighlighted && !isUnavailable"
+      :highlighted="isHighlighted && (allowNonContiguousRanges || !isUnavailable)"
       :highlighted-start="isHighlightStart"
       :highlighted-end="isHighlightEnd"
       :selection-start="isSelectionStart"

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -40,6 +40,7 @@ type RangeCalendarRootContext = {
   isDateUnavailable?: Matcher
   isDateHighlightable?: Matcher
   isOutsideVisibleView: (date: DateValue) => boolean
+  allowNonContiguousRanges: Ref<boolean>
   highlightedRange: Ref<{ start: DateValue, end: DateValue } | null>
   focusedValue: Ref<DateValue | undefined>
   lastPressedDateValue: Ref<DateValue | undefined>
@@ -359,6 +360,7 @@ provideRangeCalendarRootContext({
   headingValue,
   isInvalid,
   isDateDisabled,
+  allowNonContiguousRanges,
   highlightedRange,
   focusedValue,
   lastPressedDateValue,


### PR DESCRIPTION
Hi there 👋

Currently, the range calendar does not highlight unavailable days, which works perfectly as expected. However, when `allowNonContiguousRanges` is enabled, it is possible to select a date range that includes unavailable days, and those days are not highlighted or shown as selected.

**Use case example:**
Consider a car rental website where pickup and return can happen on specific days, even if those days fall within a larger range of unavailable dates, those days are indeed selected, you just can't select them as pickup or return.

![CleanShot 2025-05-21 at 16 19 59](https://github.com/user-attachments/assets/bffece7a-367e-4e33-ab47-d89e740d173c)

This change supports that scenario by showing those "unavailable" days as highlighted and selected inside a range.

Please let me know if the implementation needs to be refactored or adjusted to better align with your coding standards or conventions.

Thank you for the wonderful work 🚀 