### PR TITLE
feat(NumberField): support `invertWheelChange` to invert the wheel change behavior

### DIFF
--- a/docs/content/meta/NumberFieldRoot.md
+++ b/docs/content/meta/NumberFieldRoot.md
@@ -45,6 +45,12 @@
     'required': false
   },
   {
+    'name': 'invertWheelChange',
+    'description': '<p>When <code>true</code>, inverts the direction of the wheel change.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
     'name': 'locale',
     'description': '<p>The locale to use for formatting dates</p>\n',
     'type': 'string',

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -129,6 +129,23 @@ describe('numberField', () => {
       await fireEvent.wheel(input, {
         deltaY: 100, // Positive value for scrolling down
       })
+      expect(input.value).toBe('11')
+      await fireEvent.wheel(input, {
+        deltaY: -100, // Negative value for scrolling up
+      })
+      expect(input.value).toBe('10')
+    })
+
+    it('should invert update value when `invertWheelChange` is `true`', async () => {
+      const { input } = setup({
+        defaultValue: 10,
+        invertWheelChange: true,
+      })
+      input.focus()
+      expect(input.value).toBe('10')
+      await fireEvent.wheel(input, {
+        deltaY: 100, // Positive value for scrolling down
+      })
       expect(input.value).toBe('9')
       await fireEvent.wheel(input, {
         deltaY: -100, // Negative value for scrolling up

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -1,11 +1,11 @@
 import type { NumberFieldRootProps } from './NumberFieldRoot.vue'
-import { useKbd } from '@/shared'
-import { handleSubmit } from '@/test'
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { useKbd } from '@/shared'
+import { handleSubmit } from '@/test'
 import NumberField from './story/_NumberField.vue'
 
 function setup(props?: NumberFieldRootProps) {
@@ -129,7 +129,11 @@ describe('numberField', () => {
       await fireEvent.wheel(input, {
         deltaY: 100, // Positive value for scrolling down
       })
-      expect(input.value).toBe('11')
+      expect(input.value).toBe('9')
+      await fireEvent.wheel(input, {
+        deltaY: -100, // Negative value for scrolling up
+      })
+      expect(input.value).toBe('10')
     })
 
     it('should not update value when `disableWheelChange` is `true`', async () => {

--- a/packages/core/src/NumberField/NumberFieldInput.vue
+++ b/packages/core/src/NumberField/NumberFieldInput.vue
@@ -35,9 +35,9 @@ function handleWheelEvent(event: WheelEvent) {
 
   event.preventDefault()
   if (event.deltaY > 0)
-    rootContext.handleDecrease()
+    rootContext.invertWheelChange.value ? rootContext.handleDecrease() : rootContext.handleIncrease()
   else if (event.deltaY < 0)
-    rootContext.handleIncrease()
+    rootContext.invertWheelChange.value ? rootContext.handleIncrease() : rootContext.handleDecrease()
 }
 
 onMounted(() => {

--- a/packages/core/src/NumberField/NumberFieldInput.vue
+++ b/packages/core/src/NumberField/NumberFieldInput.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { getActiveElement } from '@/shared'
 import { onMounted, ref, watch } from 'vue'
+import { getActiveElement } from '@/shared'
 import { injectNumberFieldRootContext } from './NumberFieldRoot.vue'
 
 export interface NumberFieldInputProps extends PrimitiveProps {
@@ -35,9 +35,9 @@ function handleWheelEvent(event: WheelEvent) {
 
   event.preventDefault()
   if (event.deltaY > 0)
-    rootContext.handleIncrease()
-  else if (event.deltaY < 0)
     rootContext.handleDecrease()
+  else if (event.deltaY < 0)
+    rootContext.handleIncrease()
 }
 
 onMounted(() => {

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
+import type { HTMLAttributes, Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
 import type { FormFieldProps } from '@/shared/types'
-import type { HTMLAttributes, Ref } from 'vue'
-import { clamp, createContext, snapValueToStep, useFormControl, useLocale } from '@/shared'
 import { useVModel } from '@vueuse/core'
 import { computed, ref, toRefs } from 'vue'
+import { clamp, createContext, snapValueToStep, useFormControl, useLocale } from '@/shared'
 
 export interface NumberFieldRootProps extends PrimitiveProps, FormFieldProps {
   defaultValue?: number
@@ -25,6 +25,8 @@ export interface NumberFieldRootProps extends PrimitiveProps, FormFieldProps {
   disabled?: boolean
   /** When `true`, prevents the value from changing on wheel scroll. */
   disableWheelChange?: boolean
+  /** When `true`, inverts the direction of the wheel change. */
+  invertWheelChange?: boolean
   /** Id of the element */
   id?: string
 }
@@ -46,6 +48,7 @@ interface NumberFieldRootContext {
   applyInputValue: (val: string) => void
   disabled: Ref<boolean>
   disableWheelChange: Ref<boolean>
+  invertWheelChange: Ref<boolean>
   max: Ref<number | undefined>
   min: Ref<number | undefined>
   isDecreaseDisabled: Ref<boolean>
@@ -72,7 +75,7 @@ const props = withDefaults(defineProps<NumberFieldRootProps>(), {
   stepSnapping: true,
 })
 const emits = defineEmits<NumberFieldRootEmits>()
-const { disabled, disableWheelChange, min, max, step, stepSnapping, formatOptions, id, locale: propLocale } = toRefs(props)
+const { disabled, disableWheelChange, invertWheelChange, min, max, step, stepSnapping, formatOptions, id, locale: propLocale } = toRefs(props)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue,
@@ -191,6 +194,7 @@ provideNumberFieldRootContext({
   applyInputValue,
   disabled,
   disableWheelChange,
+  invertWheelChange,
   max,
   min,
   isDecreaseDisabled,


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/1934

~~This PR "corrects" the wheel change behavior:~~

||~~Before~~|~~After~~|
|:-|:-:|:-:|
|~~Scroll down (`deltaY > 0`)~~|~~increase~~|~~decrease~~|
|~~Scroll up (`deltaY < 0`)~~|~~decrease~~|~~increase~~|

~~This is more intuitive, other UI libraries also do this, e.g., [Material UI - TextField](https://mui.com/material-ui/react-text-field/#form-props) and [Ant Design - InputNumber](https://ant.design/components/input-number)|~~

This PR adds support for `invertWheelChange` to invert the wheel change behavior.