### PR TITLE
fix(UseDateField): allow the maximun day to be `31` when no month

### DIFF
--- a/packages/core/src/DateField/DateField.test.ts
+++ b/packages/core/src/DateField/DateField.test.ts
@@ -223,8 +223,12 @@ describe('dateField', async () => {
   it('allow the maximum day to be 31 when no month field', async () => {
     const { user, day } = setup({
       dateFieldProps: {
-        // Explicitly set the placeholder to avoid using current local time as placeholder
-        placeholder: new CalendarDate(2025, 5, 30),
+        /**
+         * Explicitly set the placeholder to avoid using current local time as placeholder.
+         * And use a month (here is April, 30 days) with less than 31 days to ensure the day can be 31
+         * when user input day segment first.
+         */
+        placeholder: new CalendarDate(2025, 4, 30),
       },
     })
 

--- a/packages/core/src/DateField/DateField.test.ts
+++ b/packages/core/src/DateField/DateField.test.ts
@@ -1,12 +1,12 @@
 import type { DateFields, DateValue, TimeFields } from '@internationalized/date'
 
 import type { DateFieldRootProps } from './DateFieldRoot.vue'
-import { useTestKbd } from '@/shared'
 import { CalendarDate, CalendarDateTime, now, parseAbsoluteToLocal, toZoned } from '@internationalized/date'
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { useTestKbd } from '@/shared'
 import DateField from './story/_DateField.vue'
 
 const calendarDate = new CalendarDate(1980, 1, 20)
@@ -218,6 +218,20 @@ describe('dateField', async () => {
     await user.click(second)
     await user.keyboard(kbd.ARROW_DOWN)
     expect(second).toHaveTextContent(cycle('second'))
+  })
+
+  it('allow the maximum day to be 31 when no month field', async () => {
+    const { user, day } = setup({
+      dateFieldProps: {
+        // Explicitly set the placeholder to avoid using current local time as placeholder
+        placeholder: new CalendarDate(2025, 5, 30),
+      },
+    })
+
+    await user.click(day)
+    await user.keyboard(kbd.ARROW_UP)
+    await user.keyboard(kbd.ARROW_UP)
+    expect(day).toHaveTextContent('31')
   })
 
   it('navigates segments using the arrow keys', async () => {

--- a/packages/core/src/shared/date/parser.ts
+++ b/packages/core/src/shared/date/parser.ts
@@ -1,7 +1,7 @@
-import type { Formatter } from '@/shared'
-import type { DateSegmentPart, Granularity, HourCycle, SegmentContentObj, SegmentPart, SegmentValueObj, TimeSegmentPart } from '@/shared/date'
 import type { DateFields, DateValue } from '@internationalized/date'
 import type { Ref } from 'vue'
+import type { Formatter } from '@/shared'
+import type { DateSegmentPart, Granularity, HourCycle, SegmentContentObj, SegmentPart, SegmentValueObj, TimeSegmentPart } from '@/shared/date'
 import { isZonedDateTime, toDate } from '@/date'
 import { DATE_SEGMENT_PARTS, EDITABLE_SEGMENT_PARTS, getOptsByGranularity, getPlaceholder, isDateSegmentPart, isSegmentPart, TIME_SEGMENT_PARTS } from '@/shared/date'
 
@@ -103,13 +103,20 @@ function createContentObj(props: CreateContentObjProps) {
     if ('hour' in segmentValues) {
       const value = segmentValues[part]
       if (value !== null) {
-        /**
-         * Edge case for when the month field is filled and the day field snaps to the maximum value of the value of the placeholder month
-         */
-        if (part === 'day' && segmentValues.month !== null) {
-          return formatter.part(props.dateRef.set({ [part as keyof DateFields]: value, month: segmentValues.month }), part, {
-            hourCycle: props.hourCycle === 24 ? 'h23' : undefined,
-          })
+        if (part === 'day') {
+          return formatter.part(props.dateRef.set({
+            [part as keyof DateFields]: value,
+            /**
+             * Edge case for the day field:
+             *
+             * 1. If the month is filled,
+             *   we need to ensure that the day snaps to the maximum value of that month.
+             * 2. If the month is not filled,
+             *   we default to the month with the maximum number of days (here just using January, 31 days),
+             *   so that user can input any possible day.
+             */
+            month: segmentValues.month ?? 1,
+          }), part, { hourCycle: props.hourCycle === 24 ? 'h23' : undefined })
         }
         return formatter.part(props.dateRef.set({ [part]: value }), part, {
           hourCycle: props.hourCycle === 24 ? 'h23' : undefined,
@@ -123,11 +130,13 @@ function createContentObj(props: CreateContentObjProps) {
       if (isDateSegmentPart(part)) {
         const value = segmentValues[part]
         if (value !== null) {
-          if (part === 'day' && segmentValues.month !== null)
-          /**
-           * As described above, same function
-           */
-            return formatter.part(props.dateRef.set({ [part]: value, month: segmentValues.month }), part)
+          if (part === 'day') {
+            return formatter.part(props.dateRef.set({
+              [part]: value,
+              // Same logic as above for the day field
+              month: segmentValues.month ?? 1,
+            }), part)
+          }
 
           return formatter.part(props.dateRef.set({ [part]: value }), part)
         }

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -1,10 +1,10 @@
-import type { Formatter } from '@/shared'
 import type { CalendarDateTime, CycleTimeOptions, DateFields, DateValue, TimeFields } from '@internationalized/date'
 import type { Ref } from 'vue'
 import type { AnyExceptLiteral, HourCycle, SegmentPart, SegmentValueObj } from './types'
+import type { Formatter } from '@/shared'
+import { computed } from 'vue'
 import { getDaysInMonth, toDate } from '@/date'
 import { useKbd } from '@/shared'
-import { computed } from 'vue'
 import { isAcceptableSegmentKey, isNumberString, isSegmentNavigationKey } from './segment'
 
 type MinuteSecondIncrementProps = {
@@ -322,8 +322,21 @@ export function useDateField(props: UseDateFieldProps) {
     }
 
     const cycleArgs: [keyof DateFields, number] = [part as keyof DateFields, sign]
-    if (part === 'day' && props.segmentValues.value.month !== null)
-      return dateRef.set({ [part as keyof DateValue]: prevValue, month: props.segmentValues.value.month }).cycle(...cycleArgs)[part as keyof Omit<DateFields, 'era'>]
+    if (part === 'day') {
+      return dateRef.set({
+        [part as keyof DateValue]: prevValue,
+        /**
+         * Edge case for the day field:
+         *
+         * 1. If the month is filled,
+         *   we need to ensure that the day snaps to the maximum value of that month.
+         * 2. If the month is not filled,
+         *   we default to the month with the maximum number of days (here just using January, 31 days),
+         *   so that user can input any possible day.
+         */
+        month: props.segmentValues.value.month ?? 1,
+      }).cycle(...cycleArgs)[part as keyof Omit<DateFields, 'era'>]
+    }
 
     return dateRef.set({ [part as keyof DateValue]: prevValue }).cycle(...cycleArgs)[part as keyof Omit<DateFields, 'era'>]
   }
@@ -618,7 +631,9 @@ export function useDateField(props: UseDateFieldProps) {
 
       const daysInMonth = segmentMonthValue
         ? getDaysInMonth(props.placeholder.value.set({ month: segmentMonthValue }))
-        : getDaysInMonth(props.placeholder.value)
+        // if the month is not set, we default to the maximum number of days in a month
+        // so that user can input any possible day
+        : 31
 
       const { value, moveToNext } = updateDayOrMonth(daysInMonth, num, prevValue)
 


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/1828

This PR allows users to input `31` in the day field when no month is inputted.

Otherwise, the maximum number for the day field will be limited to the user's current local month. That is to say, if the current month is April (maximum day is 30), the user can't input `31` without first inputting the month. That's not user-friendly; we should enable users to input any day they want (`1-31`), and then snap the day to the actual available range when the month is inputted.