### PR TITLE
perf(Editable): track pointerdown only in editing mode

### DIFF
--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -1,6 +1,6 @@
-import type { Ref } from 'vue'
+import type { MaybeRefOrGetter, Ref } from 'vue'
 import { isClient } from '@vueuse/shared'
-import { nextTick, ref, watchEffect } from 'vue'
+import { nextTick, ref, toValue, watchEffect } from 'vue'
 import { handleAndDispatchCustomEvent } from '@/shared'
 
 export type PointerDownOutsideEvent = CustomEvent<{
@@ -45,6 +45,7 @@ function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
 export function usePointerDownOutside(
   onPointerDownOutside?: (event: PointerDownOutsideEvent) => void,
   element?: Ref<HTMLElement | undefined>,
+  enabled: MaybeRefOrGetter<boolean> = true,
 ) {
   const ownerDocument: Document
     = element?.value?.ownerDocument ?? globalThis?.document
@@ -53,9 +54,10 @@ export function usePointerDownOutside(
   const handleClickRef = ref(() => {})
 
   watchEffect((cleanupFn) => {
-    if (!isClient)
+    if (!isClient || !toValue(enabled))
       return
     const handlePointerDown = async (event: PointerEvent) => {
+      console.log('pointer down')
       const target = event.target as HTMLElement | undefined
 
       if (!element?.value || !target)

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -133,7 +133,11 @@ export function usePointerDownOutside(
   })
 
   return {
-    onPointerDownCapture: () => (isPointerInsideDOMTree.value = true),
+    onPointerDownCapture: () => {
+      if (!toValue(enabled))
+        return
+      isPointerInsideDOMTree.value = true
+    },
   }
 }
 

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -57,7 +57,6 @@ export function usePointerDownOutside(
     if (!isClient || !toValue(enabled))
       return
     const handlePointerDown = async (event: PointerEvent) => {
-      console.log('pointer down')
       const target = event.target as HTMLElement | undefined
 
       if (!element?.value || !target)

--- a/packages/core/src/Editable/EditableRoot.vue
+++ b/packages/core/src/Editable/EditableRoot.vue
@@ -180,7 +180,7 @@ function handleDismiss() {
   }
 }
 
-const pointerDownOutside = usePointerDownOutside(() => handleDismiss(), currentElement)
+const pointerDownOutside = usePointerDownOutside(() => handleDismiss(), currentElement, isEditing)
 const focusOutside = useFocusOutside(() => handleDismiss(), currentElement)
 const isEmpty = computed(() => modelValue.value === '')
 


### PR DESCRIPTION
Resolves: https://github.com/unovue/reka-ui/issues/1944

The `usePointerDownOutside` event handler can be expensive because it queries the DOM. The `Editable` component only needs to track the pointerdown event while it is in editing mode.