### PR TITLE
feat: add copy paste function to date field input

### DIFF
--- a/packages/core/src/DateField/DateFieldInput.vue
+++ b/packages/core/src/DateField/DateFieldInput.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 import type { SegmentPart } from '@/shared/date'
+import { computed, ref } from 'vue'
 import { Primitive } from '@/Primitive'
 import { useDateField } from '@/shared/date/useDateField'
-import { computed, ref } from 'vue'
 import { injectDateFieldRootContext } from './DateFieldRoot.vue'
 
 export interface DateFieldInputProps extends PrimitiveProps {
@@ -23,6 +23,8 @@ const lastKeyZero = ref(false)
 const {
   handleSegmentClick,
   handleSegmentKeydown,
+  handleSegmentCopy,
+  handleSegmentPaste,
   attributes,
 } = useDateField({
   hasLeftFocus,
@@ -56,6 +58,8 @@ const isInvalid = computed(() => rootContext.isInvalid.value)
     :data-invalid="isInvalid ? '' : undefined"
     :aria-invalid="isInvalid ? true : undefined"
     v-on="part !== 'literal' ? {
+      copy: handleSegmentCopy,
+      paste: handleSegmentPaste,
       mousedown: handleSegmentClick,
       keydown: handleSegmentKeydown,
       focusout: () => { hasLeftFocus = true },

--- a/packages/core/src/DateRangeField/DateRangeFieldInput.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldInput.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
+import type { DateRangeType } from './DateRangeFieldRoot.vue'
 import type { PrimitiveProps } from '@/Primitive'
 import type { SegmentPart } from '@/shared/date'
-import type { DateRangeType } from './DateRangeFieldRoot.vue'
+import { computed, ref } from 'vue'
 import { Primitive } from '@/Primitive'
 import { useDateField } from '@/shared/date/useDateField'
-import { computed, ref } from 'vue'
 import { injectDateRangeFieldRootContext } from './DateRangeFieldRoot.vue'
 
 export interface DateRangeFieldInputProps extends PrimitiveProps {
@@ -26,6 +26,8 @@ const lastKeyZero = ref(false)
 const {
   handleSegmentClick,
   handleSegmentKeydown,
+  handleSegmentCopy,
+  handleSegmentPaste,
   attributes,
 } = useDateField({
   hasLeftFocus,
@@ -60,6 +62,8 @@ const isInvalid = computed(() => rootContext.isInvalid.value)
     :data-invalid="isInvalid ? '' : undefined"
     :aria-invalid="isInvalid ? true : undefined"
     v-on="part !== 'literal' ? {
+      copy: handleSegmentCopy,
+      paste: handleSegmentPaste,
       mousedown: handleSegmentClick,
       keydown: handleSegmentKeydown,
       focusout: () => { hasLeftFocus = true },

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -1,10 +1,12 @@
-import type { Formatter } from '@/shared'
-import type { CalendarDateTime, CycleTimeOptions, DateFields, DateValue, TimeFields } from '@internationalized/date'
+import type { CycleTimeOptions, DateFields, DateValue, TimeFields } from '@internationalized/date'
 import type { Ref } from 'vue'
 import type { AnyExceptLiteral, HourCycle, SegmentPart, SegmentValueObj } from './types'
+import type { Formatter } from '@/shared'
+import { CalendarDate, CalendarDateTime, parseAbsoluteToLocal, parseDate, parseDateTime } from '@internationalized/date'
+import { computed } from 'vue'
 import { getDaysInMonth, toDate } from '@/date'
 import { useKbd } from '@/shared'
-import { computed } from 'vue'
+import { isCopy, isCut, isPaste } from '../macro'
 import { isAcceptableSegmentKey, isNumberString, isSegmentNavigationKey } from './segment'
 
 type MinuteSecondIncrementProps = {
@@ -342,11 +344,11 @@ export function useDateField(props: UseDateFieldProps) {
     }
 
     if (prev === null) {
-    /**
-     * If the user types a 0 as the first number, we want
-     * to keep track of that so that when they type the next
-     * number, we can move to the next segment.
-     */
+      /**
+       * If the user types a 0 as the first number, we want
+       * to keep track of that so that when they type the next
+       * number, we can move to the next segment.
+       */
 
       if (num === 0) {
         props.lastKeyZero.value = true
@@ -360,7 +362,7 @@ export function useDateField(props: UseDateFieldProps) {
        */
 
       if (props.lastKeyZero.value || num > maxStart) {
-      // move to next
+        // move to next
         moveToNext = true
       }
       props.lastKeyZero.value = false
@@ -388,13 +390,13 @@ export function useDateField(props: UseDateFieldProps) {
      */
 
     if (digits === 2 || total > max) {
-    /**
-     * As we're doing elsewhere, we're checking if the number is greater
-     * than the max start digit (0-3 in most months), and if so, we're
-     * going to move to the next segment.
-     */
+      /**
+       * As we're doing elsewhere, we're checking if the number is greater
+       * than the max start digit (0-3 in most months), and if so, we're
+       * going to move to the next segment.
+       */
       if (num > maxStart || total > max) {
-      // move to next
+        // move to next
         moveToNext = true
       }
       return { value: num, moveToNext }
@@ -420,11 +422,11 @@ export function useDateField(props: UseDateFieldProps) {
     }
 
     if (prev === null) {
-    /**
-     * If the user types a 0 as the first number, we want
-     * to keep track of that so that when they type the next
-     * number, we can move to the next segment.
-     */
+      /**
+       * If the user types a 0 as the first number, we want
+       * to keep track of that so that when they type the next
+       * number, we can move to the next segment.
+       */
 
       if (num === 0) {
         props.lastKeyZero.value = true
@@ -438,7 +440,7 @@ export function useDateField(props: UseDateFieldProps) {
        */
 
       if (props.lastKeyZero.value || num > maxStart) {
-      // move to next
+        // move to next
         moveToNext = true
       }
       props.lastKeyZero.value = false
@@ -467,13 +469,13 @@ export function useDateField(props: UseDateFieldProps) {
      */
 
     if (digits === 2 || total > max) {
-    /**
-     * As we're doing elsewhere, we're checking if the number is greater
-     * than the max start digit (0-3 in most months), and if so, we're
-     * going to move to the next segment.
-     */
+      /**
+       * As we're doing elsewhere, we're checking if the number is greater
+       * than the max start digit (0-3 in most months), and if so, we're
+       * going to move to the next segment.
+       */
       if (num > maxStart) {
-      // move to next
+        // move to next
         moveToNext = true
       }
       return { value: num, moveToNext }
@@ -500,11 +502,11 @@ export function useDateField(props: UseDateFieldProps) {
     }
 
     if (prev === null) {
-    /**
-     * If the user types a 0 as the first number, we want
-     * to keep track of that so that when they type the next
-     * number, we can move to the next segment.
-     */
+      /**
+       * If the user types a 0 as the first number, we want
+       * to keep track of that so that when they type the next
+       * number, we can move to the next segment.
+       */
 
       if (num === 0) {
         props.lastKeyZero.value = true
@@ -518,7 +520,7 @@ export function useDateField(props: UseDateFieldProps) {
        */
 
       if (props.lastKeyZero.value || num > maxStart) {
-      // move to next
+        // move to next
         moveToNext = true
       }
       props.lastKeyZero.value = false
@@ -547,13 +549,13 @@ export function useDateField(props: UseDateFieldProps) {
      */
 
     if (digits === 2 || total > max) {
-    /**
-     * As we're doing elsewhere, we're checking if the number is greater
-     * than the max start digit (0-3 in most months), and if so, we're
-     * going to move to the next segment.
-     */
+      /**
+       * As we're doing elsewhere, we're checking if the number is greater
+       * than the max start digit (0-3 in most months), and if so, we're
+       * going to move to the next segment.
+       */
       if (num > maxStart) {
-      // move to next
+        // move to next
         moveToNext = true
       }
       return { value: num, moveToNext }
@@ -820,7 +822,8 @@ export function useDateField(props: UseDateFieldProps) {
   function handleSegmentKeydown(e: KeyboardEvent) {
     const disabled = props.disabled.value
     const readonly = props.readonly.value
-    if (e.key !== kbd.TAB)
+
+    if (e.key !== kbd.TAB && !isCut(e) && !isCopy(e) && !isPaste(e))
       e.preventDefault()
 
     if (disabled || readonly)
@@ -833,7 +836,7 @@ export function useDateField(props: UseDateFieldProps) {
       minute: handleMinuteSegmentKeydown,
       second: handleSecondSegmentKeydown,
       dayPeriod: handleDayPeriodSegmentKeydown,
-      timeZoneName: () => {},
+      timeZoneName: () => { },
     } as const
 
     segmentKeydownHandlers[props.part as keyof typeof segmentKeydownHandlers](e)
@@ -854,9 +857,82 @@ export function useDateField(props: UseDateFieldProps) {
     }
   }
 
+  function handleSegmentCopy(event: ClipboardEvent) {
+    event.preventDefault()
+
+    if (!props.modelValue.value)
+      return
+
+    const formattedValue = props.formatter.toParts(props.modelValue.value).map(part => part.value).join('')
+    event.clipboardData?.setData('text/plain', formattedValue)
+  }
+
+  function handleSegmentPaste(event: ClipboardEvent) {
+    event.preventDefault()
+
+    const dateString = event.clipboardData?.getData('text/plain').trim() || ''
+    if (!dateString)
+      return
+
+    /**
+     * Assume the date string is in ISO format, and try to parse it.
+     */
+    try {
+      const dateValue = parseDate(dateString)
+      props.modelValue.value = dateValue
+      return
+    }
+    catch { }
+
+    try {
+      const dateValue = parseDateTime(dateString)
+      props.modelValue.value = dateValue
+      return
+    }
+    catch { }
+
+    try {
+      const dateValue = parseAbsoluteToLocal(dateString)
+      props.modelValue.value = dateValue
+      return
+    }
+    catch { }
+
+    /**
+     * Fallback to native Date parsing to handle locale specific formats.
+     */
+    const date = new Date(dateString)
+    if (isNaN(date.getTime()))
+      return
+
+    const includesTime = /\d{1,2}:\d{2}:\d{2}/.test(dateString)
+
+    if (includesTime) {
+      const dateValue = new CalendarDateTime(
+        date.getFullYear(),
+        date.getMonth() + 1,
+        date.getDate(),
+        date.getHours(),
+        date.getMinutes(),
+        date.getSeconds(),
+      )
+      props.modelValue.value = dateValue
+    }
+    else {
+      const dateValue = new CalendarDate(
+        date.getFullYear(),
+        date.getMonth() + 1,
+        date.getDate(),
+      )
+      props.modelValue.value = dateValue
+    }
+  }
+
   return {
     handleSegmentClick,
+    handleSegmentCopy,
     handleSegmentKeydown,
+    handleSegmentPaste,
     attributes,
   }
 }

--- a/packages/core/src/shared/macro.ts
+++ b/packages/core/src/shared/macro.ts
@@ -1,0 +1,11 @@
+export function isCut(event: KeyboardEvent) {
+  return (event.key === 'x' || event.key === 'X') && (event.ctrlKey || event.metaKey)
+}
+
+export function isCopy(event: KeyboardEvent) {
+  return (event.key === 'c' || event.key === 'C') && (event.ctrlKey || event.metaKey)
+}
+
+export function isPaste(event: KeyboardEvent) {
+  return (event.key === 'v' || event.key === 'V') && (event.ctrlKey || event.metaKey)
+}


### PR DESCRIPTION
Implements #1897.

A few things I'm unsure about...

**Copying the locale string to clipboard**. I used the date field's formatter to get the string from the DateValue because I assumed users are expecting to copy the value they see on the screen.

**Copy, paste and cut macros.** Not sure how reliable these are for every device out there but they seem pretty common. Happy to implement an alternative way to bail out of the preventDefault if someone can suggest one.

**Locale datetime strings with timezone information.** The parsing functions from `@internationalized/date` only handle ISO formats but my guess is that users will want to paste date strings from elsewhere that are in their locale format so I added a fallback to parsing the date using the native Date object. It works pretty well for strings like "May 28 2025" and "28/5/2025" but there's a dozen ways people might provide time zone information.