### PR TITLE
feat(Popover): add programmatic close functionality to popover root

### DIFF
--- a/docs/content/docs/components/popover.md
+++ b/docs/content/docs/components/popover.md
@@ -318,6 +318,31 @@ import { PopoverAnchor, PopoverArrow, PopoverClose, PopoverContent, PopoverPorta
 }
 ```
 
+### Close using slot props
+
+Alternatively, you can use the `close` method provided by the `PopoverRoot` slot props to programmatically close the popover.
+
+```vue line=4,8,16-20
+<script setup>
+import { PopoverAnchor, PopoverArrow, PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka-ui'
+</script>
+
+<template>
+  <PopoverRoot v-slot="{ close }">
+    <PopoverTrigger>Open</PopoverTrigger>
+    <PopoverAnchor />
+    <PopoverPortal>
+      <PopoverContent>
+        <button type="submit" @click="close">
+          Submit
+        </button>
+        <PopoverArrow />
+      </PopoverContent>
+    </PopoverPortal>
+  </PopoverRoot>
+</template>
+```
+
 ## Accessibility
 
 Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).

--- a/docs/content/meta/PopoverRoot.md
+++ b/docs/content/meta/PopoverRoot.md
@@ -36,5 +36,10 @@
     'name': 'open',
     'description': '<p>Current open state</p>\n',
     'type': 'boolean'
+  },
+  {
+    'name': 'close',
+    'description': '<p>Close the popover</p>\n',
+    'type': '(): void'
   }
 ]" />

--- a/packages/core/src/Popover/PopoverRoot.vue
+++ b/packages/core/src/Popover/PopoverRoot.vue
@@ -56,6 +56,8 @@ defineSlots<{
   default?: (props: {
     /** Current open state */
     open: typeof open.value
+    /** Close the popover */
+    close: () => void
   }) => any
 }>()
 
@@ -87,6 +89,9 @@ providePopoverRootContext({
 
 <template>
   <PopperRoot>
-    <slot :open="open" />
+    <slot
+      :open="open"
+      :close="() => open = false"
+    />
   </PopperRoot>
 </template>

--- a/packages/core/src/Popover/story/PopoverProgrammaticClose.story.vue
+++ b/packages/core/src/Popover/story/PopoverProgrammaticClose.story.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import {
+  PopoverArrow,
+  PopoverContent,
+  PopoverPortal,
+  PopoverRoot,
+  PopoverTrigger,
+} from '..'
+</script>
+
+<template>
+  <Story
+    title="Popover/ProgrammaticClose"
+    :layout="{ type: 'single', iframe: true }"
+  >
+    <Variant title="default">
+      <div class="relative flex items-center justify-center flex-col">
+        <PopoverRoot v-slot="{ close: closeA }">
+          <PopoverTrigger
+            class="rounded-full w-[35px] h-[35px] inline-flex items-center justify-center text-violet11 bg-white shadow-[0_2px_10px] shadow-blackA7 hover:bg-violet3 focus:shadow-[0_0_0_2px] focus:shadow-black cursor-default outline-none"
+            aria-label="Open popover 1"
+          >
+            <button>
+              <Icon icon="radix-icons:mixer-horizontal" />
+            </button>
+          </PopoverTrigger>
+          <PopoverPortal>
+            <PopoverContent
+              side="bottom"
+              :side-offset="5"
+              class="rounded p-5 w-[260px] bg-white shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] will-change-[transform,opacity] data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade"
+            >
+              First Popover
+              <button
+                aria-label="Close"
+                class="rounded-full h-[25px] w-[25px] inline-flex items-center justify-center text-violet11 absolute top-[5px] right-[5px] hover:bg-violet4 focus:shadow-[0_0_0_2px] focus:shadow-violet7 outline-none cursor-default"
+                @click="closeA"
+              >
+                <Icon icon="radix-icons:cross-2" />
+              </button>
+
+              <PopoverRoot v-slot="{ close: closeB }">
+                <PopoverTrigger
+                  aria-label="Open popover 2"
+                >
+                  Open nested popover
+                </PopoverTrigger>
+                <PopoverPortal>
+                  <PopoverContent
+                    side="top"
+                    align="center"
+                    :side-offset="5"
+                    class="rounded p-5 w-[260px] bg-white shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] will-change-[transform,opacity] data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade"
+                  >
+                    Second popover
+                    <button
+                      aria-label="Close"
+                      class="rounded-full h-[25px] w-[25px] inline-flex items-center justify-center text-violet11 absolute top-[5px] right-[5px] hover:bg-violet4 focus:shadow-[0_0_0_2px] focus:shadow-violet7 outline-none cursor-default"
+                      @click="closeB"
+                    >
+                      <Icon icon="radix-icons:cross-2" />
+                    </button>
+                    <PopoverArrow
+                      :width="20"
+                      :height="10"
+                      :offset="20"
+                      :style="{ fill: 'green' }"
+                    />
+                  </PopoverContent>
+                </PopoverPortal>
+              </PopoverRoot>
+
+              <PopoverArrow style="fill: crimson" />
+            </PopoverContent>
+          </PopoverPortal>
+        </PopoverRoot>
+      </div>
+    </Variant>
+  </Story>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

- I've made this PR to help support a change to NuxtUI (https://github.com/nuxt/ui/pull/4219) as it would reduce the amount of internal state needed.
- A similar change was made for the DialogRoot: https://github.com/unovue/reka-ui/pull/1943

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Implemented programmatic close method for PopoverRoot component. 

#### New Feature:

- Programmatic close method - Popover now exposes a close method through the #default scoped slot, allowing popovers to be closed from within their content without requiring external ref management.

#### Documentation Updates:

- Shows how to eliminate the need for manual v-model:open ref management.

#### Benefits:

- No need to create and manage boolean refs for modal state
- Reduces boilerplate code and cognitive load