### PR TITLE
fix(ContextMenu): prevent trigger element from being interactive when context menu is opened

### DIFF
--- a/packages/core/src/ContextMenu/ContextMenu.test.ts
+++ b/packages/core/src/ContextMenu/ContextMenu.test.ts
@@ -27,12 +27,12 @@ describe('given default ContextMenu', () => {
       await wrapper.find('span').trigger('click.right')
     })
 
-    it('should pass axe accessibility tests', async () => {
-      expect(await axe(document.body)).toHaveNoViolations()
-    })
-
     it('should render the menu', async () => {
       expect(await findByRole(document.body, 'menu')).toBeTruthy()
+    })
+
+    it('should pass axe accessibility tests', async () => {
+      expect(await axe(document.body)).toHaveNoViolations()
     })
   })
 })

--- a/packages/core/src/ContextMenu/ContextMenuContent.vue
+++ b/packages/core/src/ContextMenu/ContextMenuContent.vue
@@ -42,7 +42,7 @@ const hasInteractedOutside = ref(false)
 
 function handlePointerDownOutside(event: PointerDownOutsideEvent) {
   // Only handle `contextmenu` click events
-  if (event.detail.originalEvent.button !== 2) {
+  if (!rootContext.open.value || event.detail.originalEvent.button !== 2) {
     return
   }
 
@@ -57,6 +57,10 @@ function handlePointerDownOutside(event: PointerDownOutsideEvent) {
 }
 
 function handleContextMenuOutside(event: ContextMenuOutsideEvent) {
+  if (!rootContext.open.value) {
+    return
+  }
+
   const rect = rootContext.triggerElement.value?.getBoundingClientRect()
 
   if (isPointerInRect(event.detail.originalEvent, rect)) {

--- a/packages/core/src/ContextMenu/ContextMenuContent.vue
+++ b/packages/core/src/ContextMenu/ContextMenuContent.vue
@@ -103,11 +103,6 @@ function handleContextMenuOutside(event: ContextMenuOutsideEvent) {
     "
     @interact-outside="
       (event) => {
-        const originalEvent = event.detail.originalEvent as PointerEvent
-        // Prevent closing when right click (button=2) with the trigger element
-        if (originalEvent.button === 2 && event.target === rootContext.triggerElement.value) {
-          event.preventDefault()
-        }
         if (!event.defaultPrevented && !rootContext.modal.value)
           hasInteractedOutside = true;
       }

--- a/packages/core/src/ContextMenu/ContextMenuContent.vue
+++ b/packages/core/src/ContextMenu/ContextMenuContent.vue
@@ -4,7 +4,7 @@ import type {
   MenuContentEmits,
   MenuContentProps,
 } from '@/Menu'
-import { isPointerInRect } from '@/Menu/utils'
+import { isMouseInRect } from '@/Menu/utils'
 import { useForwardExpose, useForwardPropsEmits } from '@/shared'
 
 export type ContextMenuContentEmits = MenuContentEmits
@@ -51,7 +51,7 @@ function handlePointerDownOutside(event: PointerDownOutsideEvent) {
   // If the `contextmenu` click occurs within the trigger element's bounding rect,
   // we prevent the default behavior to avoid closing the menu,
   // because that would cause the flash of closing and opening the menu.
-  if (isPointerInRect(event.detail.originalEvent, rect)) {
+  if (isMouseInRect(event.detail.originalEvent, rect)) {
     event.preventDefault()
   }
 }
@@ -63,7 +63,7 @@ function handleContextMenuOutside(event: ContextMenuOutsideEvent) {
 
   const rect = rootContext.triggerElement.value?.getBoundingClientRect()
 
-  if (isPointerInRect(event.detail.originalEvent, rect)) {
+  if (isMouseInRect(event.detail.originalEvent, rect)) {
     // Prevent the default context menu from appearing
     event.detail.originalEvent.preventDefault()
     // Move the menu to the current pointer position

--- a/packages/core/src/ContextMenu/ContextMenuContent.vue
+++ b/packages/core/src/ContextMenu/ContextMenuContent.vue
@@ -1,8 +1,10 @@
 <script lang="ts">
+import type { ContextMenuOutsideEvent, PointerDownOutsideEvent } from '@/DismissableLayer/utils'
 import type {
   MenuContentEmits,
   MenuContentProps,
 } from '@/Menu'
+import { isPointerInRect } from '@/Menu/utils'
 import { useForwardExpose, useForwardPropsEmits } from '@/shared'
 
 export type ContextMenuContentEmits = MenuContentEmits
@@ -37,6 +39,36 @@ const forwarded = useForwardPropsEmits(props, emits)
 useForwardExpose()
 const rootContext = injectContextMenuRootContext()
 const hasInteractedOutside = ref(false)
+
+function handlePointerDownOutside(event: PointerDownOutsideEvent) {
+  // Only handle `contextmenu` click events
+  if (event.detail.originalEvent.button !== 2) {
+    return
+  }
+
+  const rect = rootContext.triggerElement.value?.getBoundingClientRect()
+
+  // If the `contextmenu` click occurs within the trigger element's bounding rect,
+  // we prevent the default behavior to avoid closing the menu,
+  // because that would cause the flash of closing and opening the menu.
+  if (isPointerInRect(event.detail.originalEvent, rect)) {
+    event.preventDefault()
+  }
+}
+
+function handleContextMenuOutside(event: ContextMenuOutsideEvent) {
+  const rect = rootContext.triggerElement.value?.getBoundingClientRect()
+
+  if (isPointerInRect(event.detail.originalEvent, rect)) {
+    // Prevent the default context menu from appearing
+    event.detail.originalEvent.preventDefault()
+    // Move the menu to the current pointer position
+    rootContext.triggerPoint.value = {
+      x: event.detail.originalEvent.clientX,
+      y: event.detail.originalEvent.clientY,
+    }
+  }
+}
 </script>
 
 <template>
@@ -76,6 +108,8 @@ const hasInteractedOutside = ref(false)
           hasInteractedOutside = true;
       }
     "
+    @pointer-down-outside="handlePointerDownOutside"
+    @context-menu-outside="handleContextMenuOutside"
   >
     <slot />
   </MenuContent>

--- a/packages/core/src/ContextMenu/ContextMenuRoot.vue
+++ b/packages/core/src/ContextMenu/ContextMenuRoot.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
 import type { Ref } from 'vue'
 import type { MenuEmits, MenuProps } from '@/Menu'
+import type { Point } from '@/Menu/utils'
 import type { Direction } from '@/shared/types'
+import { ref, toRefs, watch } from 'vue'
 import { createContext, useDirection, useForwardExpose } from '@/shared'
 
 type ContextMenuRootContext = {
@@ -9,6 +11,7 @@ type ContextMenuRootContext = {
   onOpenChange: (open: boolean) => void
   modal: Ref<boolean>
   dir: Ref<Direction>
+  triggerPoint: Ref<Point>
   triggerElement: Ref<HTMLElement | undefined>
 }
 
@@ -20,7 +23,6 @@ export const [injectContextMenuRootContext, provideContextMenuRootContext]
 </script>
 
 <script setup lang="ts">
-import { ref, toRefs, watch } from 'vue'
 import { MenuRoot } from '@/Menu'
 
 defineOptions({
@@ -37,6 +39,7 @@ const dir = useDirection(propDir)
 
 const open = ref(false)
 const triggerElement = ref<HTMLElement>()
+const triggerPoint = ref<Point>({ x: 0, y: 0 })
 
 provideContextMenuRootContext({
   open,
@@ -45,6 +48,7 @@ provideContextMenuRootContext({
   },
   dir,
   modal,
+  triggerPoint,
   triggerElement,
 })
 

--- a/packages/core/src/ContextMenu/ContextMenuTrigger.vue
+++ b/packages/core/src/ContextMenu/ContextMenuTrigger.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import type { Point } from '@/Menu/utils'
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface ContextMenuTriggerProps extends PrimitiveProps {
@@ -32,17 +31,16 @@ const { disabled } = toRefs(props)
 
 const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectContextMenuRootContext()
-const point = ref<Point>({ x: 0, y: 0 })
 const virtualEl = computed(() => ({
   getBoundingClientRect: () =>
     ({
       width: 0,
       height: 0,
-      left: point.value.x,
-      right: point.value.x,
-      top: point.value.y,
-      bottom: point.value.y,
-      ...point.value,
+      left: rootContext.triggerPoint.value.x,
+      right: rootContext.triggerPoint.value.x,
+      top: rootContext.triggerPoint.value.y,
+      bottom: rootContext.triggerPoint.value.y,
+      ...rootContext.triggerPoint.value,
     } as DOMRect),
 }))
 
@@ -52,7 +50,7 @@ function clearLongPress() {
 }
 
 function handleOpen(event: MouseEvent | PointerEvent) {
-  point.value = { x: event.clientX, y: event.clientY }
+  rootContext.triggerPoint.value = { x: event.clientX, y: event.clientY }
   rootContext.onOpenChange(true)
 }
 

--- a/packages/core/src/ContextMenu/ContextMenuTrigger.vue
+++ b/packages/core/src/ContextMenu/ContextMenuTrigger.vue
@@ -108,7 +108,6 @@ onMounted(() => {
     :data-disabled="disabled ? '' : undefined"
     :style="{
       WebkitTouchCallout: 'none',
-      pointerEvents: 'auto',
     }"
     v-bind="$attrs"
     @contextmenu="handleContextMenu"

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type {
+  ContextMenuOutsideEvent,
   FocusOutsideEvent,
   PointerDownOutsideEvent,
 } from './utils'
@@ -34,6 +35,11 @@ export type DismissableLayerEmits = {
    */
   pointerDownOutside: [event: PointerDownOutsideEvent]
   /**
+   * Event handler called when a `contextmenu` event happens outside of the `DismissableLayer`.
+   * Can be prevented.
+   */
+  contextMenuOutside: [event: ContextMenuOutsideEvent]
+  /**
    * Event handler called when the focus moves outside of the `DismissableLayer`.
    * Can be prevented.
    */
@@ -66,6 +72,7 @@ import {
   Primitive,
 } from '@/Primitive'
 import {
+  useContextMenuOutside,
   useFocusOutside,
   usePointerDownOutside,
 } from './utils'
@@ -100,6 +107,11 @@ const isPointerEventsEnabled = computed(() => {
 
   return index.value >= highestLayerWithOutsidePointerEventsDisabledIndex
 })
+
+const contextMenuOutside = useContextMenuOutside(
+  event => emits('contextMenuOutside', event),
+  layerElement,
+)
 
 const pointerDownOutside = usePointerDownOutside(async (event) => {
   const isPointerDownOnBranch = [...context.branches].some(branch =>
@@ -186,6 +198,7 @@ watchEffect((cleanupFn) => {
     @focus.capture="focusOutside.onFocusCapture"
     @blur.capture="focusOutside.onBlurCapture"
     @pointerdown.capture="pointerDownOutside.onPointerDownCapture"
+    @contextmenu.capture="contextMenuOutside.onContextMenuCapture"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -120,6 +120,7 @@ const contextMenuOutside = useContextMenuOutside(
     emits('contextMenuOutside', event)
   },
   layerElement,
+  true,
 )
 
 const pointerDownOutside = usePointerDownOutside(async (event) => {

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -109,7 +109,16 @@ const isPointerEventsEnabled = computed(() => {
 })
 
 const contextMenuOutside = useContextMenuOutside(
-  event => emits('contextMenuOutside', event),
+  (event) => {
+    const isPointerDownOnBranch = [...context.branches].some(branch =>
+      branch?.contains(event.target as HTMLElement),
+    )
+
+    if (!isPointerEventsEnabled.value || isPointerDownOnBranch)
+      return
+
+    emits('contextMenuOutside', event)
+  },
   layerElement,
 )
 

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -55,7 +55,6 @@ export function useContextMenuOutside(
     = element?.value?.ownerDocument ?? globalThis?.document
 
   const isPointerInsideDOMTree = ref(false)
-  const handleClickRef = ref(() => {})
 
   watchEffect((cleanupFn) => {
     if (!isClient || !toValue(enabled))

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -49,7 +49,7 @@ function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
 export function useContextMenuOutside(
   onContextMenuOutside?: (event: ContextMenuOutsideEvent) => void,
   element?: Ref<HTMLElement | undefined>,
-  enabled: MaybeRefOrGetter<boolean> = true,
+  enabled: MaybeRefOrGetter<boolean> = false,
 ) {
   const ownerDocument: Document
     = element?.value?.ownerDocument ?? globalThis?.document

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -6,11 +6,15 @@ import { handleAndDispatchCustomEvent } from '@/shared'
 export type PointerDownOutsideEvent = CustomEvent<{
   originalEvent: PointerEvent
 }>
+export type ContextMenuOutsideEvent = CustomEvent<{
+  originalEvent: MouseEvent
+}>
 export type FocusOutsideEvent = CustomEvent<{ originalEvent: FocusEvent }>
 
 export const DISMISSABLE_LAYER_NAME = 'DismissableLayer'
 export const CONTEXT_UPDATE = 'dismissableLayer.update'
 export const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside'
+export const CONTEXT_MENU_OUTSIDE = 'dismissableLayer.contextMenuOutside'
 export const FOCUS_OUTSIDE = 'dismissableLayer.focusOutside'
 
 function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
@@ -34,6 +38,78 @@ function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
   }
   else {
     return false
+  }
+}
+
+/**
+ * Listens for `contextmenu` outside a DOM subtree.
+ * to mimic layer dismissing behaviour present in OS.
+ * Returns props to pass to the node we want to check for outside events.
+ */
+export function useContextMenuOutside(
+  onContextMenuOutside?: (event: ContextMenuOutsideEvent) => void,
+  element?: Ref<HTMLElement | undefined>,
+  enabled: MaybeRefOrGetter<boolean> = true,
+) {
+  const ownerDocument: Document
+    = element?.value?.ownerDocument ?? globalThis?.document
+
+  const isPointerInsideDOMTree = ref(false)
+  const handleClickRef = ref(() => {})
+
+  watchEffect((cleanupFn) => {
+    if (!isClient || !toValue(enabled))
+      return
+
+    const handleContextMenu = async (event: MouseEvent) => {
+      const target = event.target as HTMLElement | undefined
+
+      if (!element?.value || !target)
+        return
+
+      if (isLayerExist(element.value, target)) {
+        isPointerInsideDOMTree.value = false
+        return
+      }
+
+      if (event.target && !isPointerInsideDOMTree.value) {
+        handleAndDispatchCustomEvent(
+          CONTEXT_MENU_OUTSIDE,
+          onContextMenuOutside,
+          { originalEvent: event },
+        )
+      }
+      isPointerInsideDOMTree.value = false
+    }
+    /**
+     * if this hook executes in a component that mounts via a `pointerdown` event, the event
+     * would bubble up to the document and trigger a `pointerDownOutside` event. We avoid
+     * this by delaying the event listener registration on the document.
+     * This is how the DOM works, ie:
+     * ```
+     * button.addEventListener('pointerdown', () => {
+     *   console.log('I will log');
+     *   document.addEventListener('pointerdown', () => {
+     *     console.log('I will also log');
+     *   })
+     * });
+     */
+    const timerId = window.setTimeout(() => {
+      ownerDocument.addEventListener('contextmenu', handleContextMenu)
+    }, 0)
+
+    cleanupFn(() => {
+      window.clearTimeout(timerId)
+      ownerDocument.removeEventListener('contextmenu', handleContextMenu)
+    })
+  })
+
+  return {
+    onContextMenuCapture: () => {
+      if (!toValue(enabled))
+        return
+      isPointerInsideDOMTree.value = true
+    },
   }
 }
 

--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -281,6 +281,7 @@ provideMenuContentContext({
       :disable-outside-pointer-events="disableOutsidePointerEvents"
       @escape-key-down="emits('escapeKeyDown', $event)"
       @pointer-down-outside="emits('pointerDownOutside', $event)"
+      @context-menu-outside="emits('contextMenuOutside', $event)"
       @focus-outside="emits('focusOutside', $event)"
       @interact-outside="emits('interactOutside', $event)"
       @dismiss="emits('dismiss')"

--- a/packages/core/src/Menu/MenuRootContentModal.vue
+++ b/packages/core/src/Menu/MenuRootContentModal.vue
@@ -1,20 +1,55 @@
 <script setup lang="ts">
 import type { MenuContentImplEmits, MenuRootContentTypeProps } from './MenuContentImpl.vue'
+import type { PointerDownOutsideEvent } from '@/DismissableLayer'
+import type { ContextMenuOutsideEvent } from '@/DismissableLayer/utils'
+import { injectContextMenuRootContext } from '@/ContextMenu'
 import { useForwardExpose, useForwardPropsEmits, useHideOthers } from '@/shared'
 import MenuContentImpl from './MenuContentImpl.vue'
 import { injectMenuContext } from './MenuRoot.vue'
+import { isPointerInRect } from './utils'
 
 const props = defineProps<MenuRootContentModalProps>()
 const emits = defineEmits<MenuRootContentModalEmits>()
 const forwarded = useForwardPropsEmits(props, emits)
 
 const menuContext = injectMenuContext()
+const menuRootContext = injectContextMenuRootContext()
 
 interface MenuRootContentModalProps extends MenuRootContentTypeProps {}
 type MenuRootContentModalEmits = MenuContentImplEmits
 
 const { forwardRef, currentElement } = useForwardExpose()
 useHideOthers(currentElement)
+
+function handlePointerDownOutside(event: PointerDownOutsideEvent) {
+  // Only handle `contextmenu` click events
+  if (event.detail.originalEvent.button !== 2) {
+    return
+  }
+
+  const rect = menuRootContext.triggerElement.value?.getBoundingClientRect()
+
+  // If the `contextmenu` click occurs within the trigger element's bounding rect,
+  // we prevent the default behavior to avoid closing the menu,
+  // because that would cause the flash of closing and opening the menu.
+  if (isPointerInRect(event.detail.originalEvent, rect)) {
+    event.preventDefault()
+  }
+}
+
+function handleContextMenuOutside(event: ContextMenuOutsideEvent) {
+  const rect = menuRootContext.triggerElement.value?.getBoundingClientRect()
+
+  if (isPointerInRect(event.detail.originalEvent, rect)) {
+    // Prevent the default context menu from appearing
+    event.detail.originalEvent.preventDefault()
+    // Move the menu to the current pointer position
+    menuRootContext.triggerPoint.value = {
+      x: event.detail.originalEvent.clientX,
+      y: event.detail.originalEvent.clientY,
+    }
+  }
+}
 </script>
 
 <template>
@@ -25,6 +60,8 @@ useHideOthers(currentElement)
     :disable-outside-pointer-events="menuContext.open.value"
     :disable-outside-scroll="true"
     @dismiss="menuContext.onOpenChange(false)"
+    @pointer-down-outside="handlePointerDownOutside"
+    @context-menu-outside="handleContextMenuOutside"
     @focus-outside.prevent="emits('focusOutside', $event)"
   >
     <slot />

--- a/packages/core/src/Menu/MenuRootContentModal.vue
+++ b/packages/core/src/Menu/MenuRootContentModal.vue
@@ -1,55 +1,20 @@
 <script setup lang="ts">
 import type { MenuContentImplEmits, MenuRootContentTypeProps } from './MenuContentImpl.vue'
-import type { PointerDownOutsideEvent } from '@/DismissableLayer'
-import type { ContextMenuOutsideEvent } from '@/DismissableLayer/utils'
-import { injectContextMenuRootContext } from '@/ContextMenu'
 import { useForwardExpose, useForwardPropsEmits, useHideOthers } from '@/shared'
 import MenuContentImpl from './MenuContentImpl.vue'
 import { injectMenuContext } from './MenuRoot.vue'
-import { isPointerInRect } from './utils'
 
 const props = defineProps<MenuRootContentModalProps>()
 const emits = defineEmits<MenuRootContentModalEmits>()
 const forwarded = useForwardPropsEmits(props, emits)
 
 const menuContext = injectMenuContext()
-const menuRootContext = injectContextMenuRootContext()
 
 interface MenuRootContentModalProps extends MenuRootContentTypeProps {}
 type MenuRootContentModalEmits = MenuContentImplEmits
 
 const { forwardRef, currentElement } = useForwardExpose()
 useHideOthers(currentElement)
-
-function handlePointerDownOutside(event: PointerDownOutsideEvent) {
-  // Only handle `contextmenu` click events
-  if (event.detail.originalEvent.button !== 2) {
-    return
-  }
-
-  const rect = menuRootContext.triggerElement.value?.getBoundingClientRect()
-
-  // If the `contextmenu` click occurs within the trigger element's bounding rect,
-  // we prevent the default behavior to avoid closing the menu,
-  // because that would cause the flash of closing and opening the menu.
-  if (isPointerInRect(event.detail.originalEvent, rect)) {
-    event.preventDefault()
-  }
-}
-
-function handleContextMenuOutside(event: ContextMenuOutsideEvent) {
-  const rect = menuRootContext.triggerElement.value?.getBoundingClientRect()
-
-  if (isPointerInRect(event.detail.originalEvent, rect)) {
-    // Prevent the default context menu from appearing
-    event.detail.originalEvent.preventDefault()
-    // Move the menu to the current pointer position
-    menuRootContext.triggerPoint.value = {
-      x: event.detail.originalEvent.clientX,
-      y: event.detail.originalEvent.clientY,
-    }
-  }
-}
 </script>
 
 <template>
@@ -60,8 +25,8 @@ function handleContextMenuOutside(event: ContextMenuOutsideEvent) {
     :disable-outside-pointer-events="menuContext.open.value"
     :disable-outside-scroll="true"
     @dismiss="menuContext.onOpenChange(false)"
-    @pointer-down-outside="handlePointerDownOutside"
-    @context-menu-outside="handleContextMenuOutside"
+    @pointer-down-outside="emits('pointerDownOutside', $event)"
+    @context-menu-outside="emits('contextMenuOutside', $event)"
     @focus-outside.prevent="emits('focusOutside', $event)"
   >
     <slot />

--- a/packages/core/src/Menu/utils.ts
+++ b/packages/core/src/Menu/utils.ts
@@ -78,7 +78,7 @@ export function isPointInPolygon(point: Point, polygon: Polygon) {
   return inside
 }
 
-export function isPointerInGraceArea(event: MouseEvent, area?: Polygon) {
+export function isPointerInGraceArea(event: PointerEvent, area?: Polygon) {
   if (!area)
     return false
   const cursorPos = { x: event.clientX, y: event.clientY }
@@ -89,7 +89,7 @@ export function isMouseEvent(event: PointerEvent) {
   return event.pointerType === 'mouse'
 }
 
-export function isPointerInRect(event: MouseEvent, rect?: DOMRect) {
+export function isPointerInRect(event: PointerEvent, rect?: DOMRect) {
   if (!rect) {
     return false
   }

--- a/packages/core/src/Menu/utils.ts
+++ b/packages/core/src/Menu/utils.ts
@@ -78,7 +78,7 @@ export function isPointInPolygon(point: Point, polygon: Polygon) {
   return inside
 }
 
-export function isPointerInGraceArea(event: PointerEvent, area?: Polygon) {
+export function isPointerInGraceArea(event: MouseEvent, area?: Polygon) {
   if (!area)
     return false
   const cursorPos = { x: event.clientX, y: event.clientY }
@@ -87,4 +87,17 @@ export function isPointerInGraceArea(event: PointerEvent, area?: Polygon) {
 
 export function isMouseEvent(event: PointerEvent) {
   return event.pointerType === 'mouse'
+}
+
+export function isPointerInRect(event: MouseEvent, rect?: DOMRect) {
+  if (!rect) {
+    return false
+  }
+
+  return (
+    event.clientX >= rect.left
+    && event.clientX <= rect.right
+    && event.clientY >= rect.top
+    && event.clientY <= rect.bottom
+  )
 }

--- a/packages/core/src/Menu/utils.ts
+++ b/packages/core/src/Menu/utils.ts
@@ -89,7 +89,7 @@ export function isMouseEvent(event: PointerEvent) {
   return event.pointerType === 'mouse'
 }
 
-export function isPointerInRect(event: PointerEvent, rect?: DOMRect) {
+export function isMouseInRect(event: MouseEvent, rect?: DOMRect) {
   if (!rect) {
     return false
   }


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/1923

This PR removes the default `pointer-events: auto` from the `ContextMenuTrigger`.

Not sure why it was added in [635b90e](https://github.com/unovue/reka-ui/commit/635b90e72667a6c462e32336593d1d2689ff23ff#diff-03f37eade715fb89953094d4edd7186a915bd873e9a1408eeb723f45893e3f42R96-R111). If I missed anything, please let me know ❤️