### PR TITLE
chore(docs): correct grammar

### DIFF
--- a/docs/content/docs/guides/inject-context.md
+++ b/docs/content/docs/guides/inject-context.md
@@ -1,13 +1,13 @@
 ---
 title: Inject Context
-description: Utilize `injectContext` to enhances component composition in Reka UI, enabling powerful and flexible UI development.
+description: Utilize `injectContext` to enhance component composition in Reka UI, enabling powerful and flexible UI development.
 ---
 
 # Inject Context
 
 <Description>
 
-Utilize `injectContext` to enhances component composition in Reka UI, enabling powerful and flexible UI development.
+Utilize `injectContext` to enhance component composition in Reka UI, enabling powerful and flexible UI development.
 
 </Description>
 


### PR DESCRIPTION
This is a tiny patch that correct the grammar for the inject context page in documentation.