### PR TITLE
feat: useHideOthers support v-show

### DIFF
--- a/packages/core/src/shared/useElementVisible.ts
+++ b/packages/core/src/shared/useElementVisible.ts
@@ -1,0 +1,26 @@
+import type { MaybeComputedElementRef } from '@vueuse/core'
+import { tryOnMounted, unrefElement, useMutationObserver } from '@vueuse/core'
+import { shallowRef } from 'vue'
+
+export function useElementVisible(
+  target: MaybeComputedElementRef,
+) {
+  const visible = shallowRef(false)
+  useMutationObserver(target, update, { attributeFilter: ['style', 'class'] })
+
+  tryOnMounted(() => {
+    update()
+  })
+
+  function update() {
+    const el = unrefElement(target)
+    if (!el)
+      return
+
+    visible.value = window.getComputedStyle(el).display !== 'none'
+  }
+
+  return {
+    visible,
+  }
+}

--- a/packages/core/src/shared/useHideOthers.ts
+++ b/packages/core/src/shared/useHideOthers.ts
@@ -1,7 +1,8 @@
 import type { MaybeElementRef } from '@vueuse/core'
 import { unrefElement } from '@vueuse/core'
 import { hideOthers } from 'aria-hidden'
-import { onUnmounted, watch } from 'vue'
+import { onUnmounted, unref, watch } from 'vue'
+import { useElementVisible } from './useElementVisible'
 
 /**
  * The `useHideOthers` function is a TypeScript function that takes a target element reference and
@@ -11,8 +12,10 @@ import { onUnmounted, watch } from 'vue'
  * to hide other elements when it is clicked or focused.
  */
 export function useHideOthers(target: MaybeElementRef) {
+  const { visible } = useElementVisible(target)
+
   let undo: ReturnType<typeof hideOthers>
-  watch(() => unrefElement(target), (el) => {
+  watch(() => unref(visible) && unrefElement(target), (el) => {
     // disable hideOthers on test mode
     if (import.meta.env.MODE === 'test')
       return


### PR DESCRIPTION
Resolved: https://github.com/unovue/reka-ui/issues/539

As comment from https://github.com/unovue/reka-ui/issues/688#issuecomment-1951951927 it works, but the aria-hidden still at other elements when user close dialog.

I think that problem is `useHideOthers` not support for v-show, so I just make `useElementVisible` and apply in `useHideOthers`.