### PR TITLE
fix: export constant component types

### DIFF
--- a/packages/core/constant/components.ts
+++ b/packages/core/constant/components.ts
@@ -5,7 +5,7 @@ export const components = {
     'AccordionItem',
     'AccordionRoot',
     'AccordionTrigger',
-  ],
+  ] as const,
 
   alertDialog: [
     'AlertDialogRoot',
@@ -17,17 +17,17 @@ export const components = {
     'AlertDialogTitle',
     'AlertDialogDescription',
     'AlertDialogAction',
-  ],
+  ] as const,
 
   aspectRatio: [
     'AspectRatio',
-  ],
+  ] as const,
 
   avatar: [
     'AvatarRoot',
     'AvatarFallback',
     'AvatarImage',
-  ],
+  ] as const,
 
   calendar: [
     'CalendarRoot',
@@ -42,19 +42,19 @@ export const components = {
     'CalendarGridBody',
     'CalendarGridRow',
     'CalendarCellTrigger',
-  ],
+  ] as const,
 
   checkbox: [
     'CheckboxGroupRoot',
     'CheckboxRoot',
     'CheckboxIndicator',
-  ],
+  ] as const,
 
   collapsible: [
     'CollapsibleRoot',
     'CollapsibleTrigger',
     'CollapsibleContent',
-  ],
+  ] as const,
 
   combobox: [
     'ComboboxRoot',
@@ -73,7 +73,7 @@ export const components = {
     'ComboboxSeparator',
     'ComboboxArrow',
     'ComboboxPortal',
-  ],
+  ] as const,
 
   contextMenu: [
     'ContextMenuRoot',
@@ -92,12 +92,12 @@ export const components = {
     'ContextMenuSub',
     'ContextMenuSubContent',
     'ContextMenuSubTrigger',
-  ],
+  ] as const,
 
   dateField: [
     'DateFieldRoot',
     'DateFieldInput',
-  ],
+  ] as const,
 
   datePicker: [
     'DatePickerRoot',
@@ -120,7 +120,7 @@ export const components = {
     'DatePickerClose',
     'DatePickerTrigger',
     'DatePickerContent',
-  ],
+  ] as const,
 
   dateRangePicker: [
     'DateRangePickerRoot',
@@ -143,12 +143,12 @@ export const components = {
     'DateRangePickerClose',
     'DateRangePickerTrigger',
     'DateRangePickerContent',
-  ],
+  ] as const,
 
   dateRangeField: [
     'DateRangeFieldRoot',
     'DateRangeFieldInput',
-  ],
+  ] as const,
 
   dialog: [
     'DialogRoot',
@@ -159,7 +159,7 @@ export const components = {
     'DialogClose',
     'DialogTitle',
     'DialogDescription',
-  ],
+  ] as const,
 
   dropdownMenu: [
     'DropdownMenuRoot',
@@ -178,7 +178,7 @@ export const components = {
     'DropdownMenuSub',
     'DropdownMenuSubContent',
     'DropdownMenuSubTrigger',
-  ],
+  ] as const,
   editable: [
     'EditableRoot',
     'EditableArea',
@@ -187,7 +187,7 @@ export const components = {
     'EditableSubmitTrigger',
     'EditableCancelTrigger',
     'EditableEditTrigger',
-  ],
+  ] as const,
 
   hoverCard: [
     'HoverCardRoot',
@@ -195,11 +195,11 @@ export const components = {
     'HoverCardPortal',
     'HoverCardContent',
     'HoverCardArrow',
-  ],
+  ] as const,
 
   label: [
     'Label',
-  ],
+  ] as const,
 
   listbox: [
     'ListboxRoot',
@@ -210,7 +210,7 @@ export const components = {
     'ListboxVirtualizer',
     'ListboxGroup',
     'ListboxGroupLabel',
-  ],
+  ] as const,
 
   menubar: [
     'MenubarRoot',
@@ -230,7 +230,7 @@ export const components = {
     'MenubarSubContent',
     'MenubarSubTrigger',
     'MenubarMenu',
-  ],
+  ] as const,
 
   navigationMenu: [
     'NavigationMenuRoot',
@@ -242,14 +242,14 @@ export const components = {
     'NavigationMenuSub',
     'NavigationMenuTrigger',
     'NavigationMenuViewport',
-  ],
+  ] as const,
 
   numberField: [
     'NumberFieldRoot',
     'NumberFieldInput',
     'NumberFieldIncrement',
     'NumberFieldDecrement',
-  ],
+  ] as const,
 
   pagination: [
     'PaginationRoot',
@@ -260,12 +260,12 @@ export const components = {
     'PaginationListItem',
     'PaginationNext',
     'PaginationPrev',
-  ],
+  ] as const,
 
   pinInput: [
     'PinInputRoot',
     'PinInputInput',
-  ],
+  ] as const,
 
   popover: [
     'PopoverRoot',
@@ -275,18 +275,18 @@ export const components = {
     'PopoverArrow',
     'PopoverClose',
     'PopoverAnchor',
-  ],
+  ] as const,
 
   progress: [
     'ProgressRoot',
     'ProgressIndicator',
-  ],
+  ] as const,
 
   radioGroup: [
     'RadioGroupRoot',
     'RadioGroupItem',
     'RadioGroupIndicator',
-  ],
+  ] as const,
 
   rangeCalendar: [
     'RangeCalendarRoot',
@@ -301,7 +301,7 @@ export const components = {
     'RangeCalendarGridBody',
     'RangeCalendarGridRow',
     'RangeCalendarCellTrigger',
-  ],
+  ] as const,
 
   scrollArea: [
     'ScrollAreaRoot',
@@ -309,7 +309,7 @@ export const components = {
     'ScrollAreaScrollbar',
     'ScrollAreaThumb',
     'ScrollAreaCorner',
-  ],
+  ] as const,
 
   select: [
     'SelectRoot',
@@ -328,24 +328,24 @@ export const components = {
     'SelectScrollDownButton',
     'SelectValue',
     'SelectIcon',
-  ],
+  ] as const,
 
   separator: [
     'Separator',
-  ],
+  ] as const,
 
   slider: [
     'SliderRoot',
     'SliderThumb',
     'SliderTrack',
     'SliderRange',
-  ],
+  ] as const,
 
   splitter: [
     'SplitterGroup',
     'SplitterPanel',
     'SplitterResizeHandle',
-  ],
+  ] as const,
 
   stepper: [
     'StepperRoot',
@@ -355,12 +355,12 @@ export const components = {
     'StepperTitle',
     'StepperIndicator',
     'StepperSeparator',
-  ],
+  ] as const,
 
   switch: [
     'SwitchRoot',
     'SwitchThumb',
-  ],
+  ] as const,
 
   tabs: [
     'TabsRoot',
@@ -368,7 +368,7 @@ export const components = {
     'TabsContent',
     'TabsTrigger',
     'TabsIndicator',
-  ],
+  ] as const,
 
   tagsInput: [
     'TagsInputRoot',
@@ -377,12 +377,12 @@ export const components = {
     'TagsInputItemText',
     'TagsInputItemDelete',
     'TagsInputClear',
-  ],
+  ] as const,
 
   timeField: [
     'TimeFieldInput',
     'TimeFieldRoot',
-  ],
+  ] as const,
 
   toast: [
     'ToastProvider',
@@ -393,16 +393,16 @@ export const components = {
     'ToastViewport',
     'ToastTitle',
     'ToastDescription',
-  ],
+  ] as const,
 
   toggle: [
     'Toggle',
-  ],
+  ] as const,
 
   toggleGroup: [
     'ToggleGroupRoot',
     'ToggleGroupItem',
-  ],
+  ] as const,
 
   toolbar: [
     'ToolbarRoot',
@@ -411,7 +411,7 @@ export const components = {
     'ToolbarToggleGroup',
     'ToolbarToggleItem',
     'ToolbarSeparator',
-  ],
+  ] as const,
 
   tooltip: [
     'TooltipRoot',
@@ -420,44 +420,44 @@ export const components = {
     'TooltipArrow',
     'TooltipPortal',
     'TooltipProvider',
-  ],
+  ] as const,
 
   tree: [
     'TreeRoot',
     'TreeItem',
     'TreeVirtualizer',
-  ],
+  ] as const,
 
   viewport: [
     'Viewport',
-  ],
+  ] as const,
 
   // Utility component
   configProvider: [
     'ConfigProvider',
-  ],
+  ] as const,
 
   focusScope: [
     'FocusScope',
-  ],
+  ] as const,
 
   rovingFocus: [
     'RovingFocusGroup',
     'RovingFocusItem',
-  ],
+  ] as const,
 
   presence: [
     'Presence',
-  ],
+  ] as const,
 
   primitive: [
     'Primitive',
     'Slot',
-  ],
+  ] as const,
 
   visuallyHidden: [
     'VisuallyHidden',
-  ],
+  ] as const,
 }
 
 export const utilities = {
@@ -473,5 +473,5 @@ export const utilities = {
     'useDateFormatter',
     'withDefault',
     'createContext',
-  ],
+  ] as const,
 }

--- a/packages/core/constant/components.ts
+++ b/packages/core/constant/components.ts
@@ -475,3 +475,5 @@ export const utilities = {
     'createContext',
   ] as const,
 }
+
+export type Components = typeof components

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -23,6 +23,7 @@
   },
   "include": [
     "env.d.ts",
+    "constant/*",
     "src/**/*",
     "src/**/*.ts",
     "src/**/*.tsx",

--- a/packages/plugins/src/nuxt/index.ts
+++ b/packages/plugins/src/nuxt/index.ts
@@ -1,10 +1,11 @@
 import type { } from '@nuxt/schema' // workaround for TS bug with "phantom" deps
 
+import type { Components } from 'reka-ui/constant'
 import { addComponent, defineNuxtModule } from '@nuxt/kit'
 import { components as allComponents } from 'reka-ui/constant'
 
 export interface ModuleOptions {
-  components: Partial<Record<keyof typeof allComponents, boolean>> | boolean
+  components: Partial<Record<keyof Components, boolean>> | boolean
   prefix: string
 }
 
@@ -20,26 +21,22 @@ export default defineNuxtModule<ModuleOptions>({
     prefix: '',
     components: true,
   },
-  setup(options) {
-    function getComponents() {
-      if (typeof options.components === 'object') {
-        return Object.entries(allComponents)
-          .filter(([name]) => (options.components as Record<string, boolean>)[name])
-          .flatMap(([_, components]) => components)
-      }
-
-      if (options.components)
-        return Object.values(allComponents).flat()
-
-      return []
+  setup({ prefix, components }) {
+    if (components === false) {
+      return
     }
 
-    for (const component of getComponents()) {
-      addComponent({
-        name: `${options.prefix}${component}`,
-        export: component,
-        filePath: 'reka-ui',
-      })
+    let groupName: keyof Components
+    for (groupName in allComponents) {
+      if (components === true || components[groupName]) {
+        for (const component of allComponents[groupName]) {
+          addComponent({
+            name: `${prefix}${component}`,
+            export: component,
+            filePath: 'reka-ui',
+          })
+        }
+      }
     }
   },
 })

--- a/packages/plugins/src/resolver/index.ts
+++ b/packages/plugins/src/resolver/index.ts
@@ -1,3 +1,4 @@
+import type { Components } from 'reka-ui/constant'
 import type { ComponentResolver } from 'unplugin-vue-components'
 import { components } from 'reka-ui/constant'
 
@@ -18,10 +19,14 @@ export default function (options: ResolverOptions = {}): ComponentResolver {
     resolve: (name: string) => {
       if (name.toLowerCase().startsWith(prefix.toLowerCase())) {
         const componentName = name.substring(prefix.length)
-        if (Object.values(components).flat().includes(componentName)) {
-          return {
-            name: componentName,
-            from: 'reka-ui',
+        let groupName: keyof Components
+        for (groupName in components) {
+          const groupComponents: readonly string[] = components[groupName]
+          if (groupComponents.includes(componentName)) {
+            return {
+              name: componentName,
+              from: 'reka-ui',
+            }
           }
         }
       }


### PR DESCRIPTION
The builds provide a `reka-ui/constant` export but at the moment those give an error in TS because `dist/constant.d.ts` only has an empty export.

This was caused due to the `constant/` folder being outside the `src/` folder which was the only folder being included in the TS build config.

The `as const`'s are ensuring that the TS exports do not fallback to `string[]`

--edit--

Due to build error also simplified the nuxt module and remove the `flat()` and function  usage. Flat causes a new array to be created which just isn't needed if we use a for loop as in this pr.

With these changes it's also possible to support a per component configuration. Currently you can only add all components in a group, but extending `ModuleOptions.components` with the following type would allow users to toggle individual components. Let me know if you want me to add that.
```typescript
// Toggle components by group
type ComponentGroupConfig = {
  [K in keyof Components]?: boolean
}

// Toggle components invidually (still nested per group)
type ComponentConfig = {
  [K in keyof Components]?: {
    [K2 in Components[K][number]]: boolean
  }
}

export interface ModuleOptions {
  components: ComponentConfig | ComponentGroupConfig | boolean
  prefix: string
}
```

--edit--
The two config types can be combined for even more flexiblity ofc
```typescript
type ComponentConfig = {
  [K in keyof Components]?: boolean | {
    [K2 in Components[K][number]]: boolean
  }
}

export interface ModuleOptions {
  components: ComponentConfig | boolean
  prefix: string
}
```