### PR TITLE
fix(RangeCalendar): maximum days with fixed date

### DIFF
--- a/packages/core/src/RangeCalendar/RangeCalendar.test.ts
+++ b/packages/core/src/RangeCalendar/RangeCalendar.test.ts
@@ -726,8 +726,8 @@ describe('handles maximumDays', () => {
     })
 
     const startDay = getByTestId('date-1-15')
-    const maximumDay = getByTestId('date-1-20') // 5 days ahead
-    const beyondMaximumDay = getByTestId('date-1-21') // 6 days ahead
+    const maximumDay = getByTestId('date-1-19') // 5 days ahead
+    const beyondMaximumDay = getByTestId('date-1-20') // 6 days ahead
 
     await user.click(startDay)
     expect(startDay).toHaveAttribute('data-selection-start')
@@ -739,12 +739,12 @@ describe('handles maximumDays', () => {
     expect(beyondMaximumDay).not.toHaveAttribute('data-selected')
 
     // Should be limited to 5 days
-    expect(getByTestId('date-1-20')).not.toHaveAttribute('data-disabled')
+    expect(getByTestId('date-1-19')).not.toHaveAttribute('data-disabled')
 
     await user.click(maximumDay)
 
     // Check that all days within the maximum range are selected
-    for (let day = 15; day <= 20; day++) {
+    for (let day = 15; day < 20; day++) {
       expect(getByTestId(`date-1-${day}`)).toHaveAttribute('data-selected')
     }
   })
@@ -771,10 +771,10 @@ describe('handles maximumDays', () => {
     expect(getByTestId('date-1-14')).toHaveAttribute('aria-disabled', 'true')
 
     // Days within the limit should not be disabled
-    expect(getByTestId('date-1-13')).not.toHaveAttribute('aria-disabled', 'true')
+    expect(getByTestId('date-1-12')).not.toHaveAttribute('aria-disabled', 'true')
 
     // Complete the range selection with a date within the limit
-    await user.click(getByTestId('date-1-13'))
+    await user.click(getByTestId('date-1-12'))
 
     // Distant dates should no longer be disabled
     expect(getByTestId('date-1-20')).not.toHaveAttribute('aria-disabled', 'true')
@@ -784,7 +784,7 @@ describe('handles maximumDays', () => {
     expect(getByTestId('date-1-15')).toHaveAttribute('data-selection-start')
 
     // Days beyond the maximum limit from the new start date should be disabled
-    expect(getByTestId('date-1-19')).toHaveAttribute('aria-disabled', 'true')
-    expect(getByTestId('date-1-18')).not.toHaveAttribute('aria-disabled', 'true')
+    expect(getByTestId('date-1-18')).toHaveAttribute('aria-disabled', 'true')
+    expect(getByTestId('date-1-17')).not.toHaveAttribute('aria-disabled', 'true')
   })
 })


### PR DESCRIPTION
This PR fixes an issue where the `RangeCalendar` wasn't taking into account the `maximumDays` property when a `fixedDate` was set.

cc @Tragio for the initial exploration and bug identification :rocket: