### PR TITLE
Pass "disabled" prop as expected from ComboboxInput

### DIFF
--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -101,6 +101,7 @@ watch(rootContext.filterState, () => {
     :as="as"
     :as-child="asChild"
     :auto-focus="autoFocus"
+    :disabled="disabled"
     :aria-expanded="rootContext.open.value"
     :aria-controls="rootContext.contentId"
     aria-autocomplete="list"


### PR DESCRIPTION
The ComboboxInput component currently just swallows a `disabled` prop without passing it on to the ListboxFilter. This fixes that.