### PR TITLE
Use "off" instead of "false" to disable ComboboxInput autocomplete

### DIFF
--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -105,7 +105,7 @@ watch(rootContext.filterState, () => {
     :aria-controls="rootContext.contentId"
     aria-autocomplete="list"
     role="combobox"
-    autocomplete="false"
+    autocomplete="off"
     @input="handleInput"
     @keydown.down.up.prevent="handleKeyDown"
   >


### PR DESCRIPTION
"false" does not have an effect on inputs, whereas "off" does.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#off