### PR TITLE
fix(PinInput): provide better autocomplete for `type` field

### DIFF
--- a/packages/core/src/PinInput/PinInputInput.vue
+++ b/packages/core/src/PinInput/PinInputInput.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { PinInputValue } from './PinInputRoot.vue'
+import type { PinInputContextValue } from './PinInputRoot.vue'
 import type { PrimitiveProps } from '@/Primitive'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { getActiveElement, useArrowNavigation } from '@/shared'
@@ -115,7 +115,7 @@ function handlePaste(event: ClipboardEvent) {
 }
 
 function handleMultipleCharacter(values: string) {
-  const tempModelValue = [...context.currentModelValue.value] as PinInputValue<typeof context.type.value>
+  const tempModelValue = [...context.currentModelValue.value] as typeof context.currentModelValue.value
   const initialIndex = values.length >= inputElements.value.length ? 0 : props.index
   const lastIndex = Math.min(initialIndex + values.length, inputElements.value.length)
   for (let i = initialIndex; i < lastIndex; i++) {
@@ -131,7 +131,7 @@ function handleMultipleCharacter(values: string) {
   inputElements.value[lastIndex]?.focus()
 }
 
-function removeTrailingEmptyStrings(input: PinInputValue<typeof context.type.value>) {
+function removeTrailingEmptyStrings(input: PinInputContextValue<typeof context.type.value>) {
   let i = input.length - 1
 
   while (i >= 0 && input[i] === '') {
@@ -143,7 +143,7 @@ function removeTrailingEmptyStrings(input: PinInputValue<typeof context.type.val
 }
 
 function updateModelValueAt(index: number, value: string) {
-  const tempModelValue = [...context.currentModelValue.value] as PinInputValue<typeof context.type.value>
+  const tempModelValue = [...context.currentModelValue.value] as typeof context.currentModelValue.value
 
   if (context.isNumericMode.value) {
     const num = +value

--- a/packages/core/src/PinInput/PinInputRoot.vue
+++ b/packages/core/src/PinInput/PinInputRoot.vue
@@ -9,7 +9,16 @@ import VisuallyHiddenInput from '@/VisuallyHidden/VisuallyHiddenInput.vue'
 export type PinInputType = 'text' | 'number'
 
 // Using this type to avoid mixed arrays (string | number)[].
-export type PinInputValue<Type extends PinInputType = 'text'> = Type extends 'number' ? number[] : string[]
+// The value type can be number[] only when the type is explicitly set to 'number'
+export type PinInputValue<Type extends PinInputType> = 'number' extends Type ? number[] : string[]
+
+// provide the mixed arrays because the `type` is dynamic in the context
+export type PinInputContextValue<Type extends PinInputType = 'text'> =
+  Type extends 'number'
+    ? Type extends 'string'
+      ? string[] | number[]
+      : number[]
+    : string[]
 
 export type PinInputRootEmits<Type extends PinInputType = 'text'> = {
   'update:modelValue': [value: PinInputValue<Type>]
@@ -38,8 +47,8 @@ export interface PinInputRootProps<Type extends PinInputType = 'text'> extends P
 }
 
 export interface PinInputRootContext<Type extends PinInputType = 'text'> {
-  modelValue: Ref<PinInputValue<Type>>
-  currentModelValue: ComputedRef<PinInputValue<Type>>
+  modelValue: Ref<PinInputContextValue<Type>>
+  currentModelValue: ComputedRef<PinInputContextValue<Type>>
   mask: Ref<boolean>
   otp: Ref<boolean>
   placeholder: Ref<string>
@@ -56,7 +65,7 @@ export const [injectPinInputRootContext, providePinInputRootContext]
   = createContext<PinInputRootContext<PinInputType>>('PinInputRoot')
 </script>
 
-<script setup lang="ts" generic="Type extends PinInputType = 'text'">
+<script setup lang="ts" generic="Type extends PinInputType">
 import { useVModel } from '@vueuse/core'
 import { Primitive } from '@/Primitive'
 

--- a/packages/core/src/PinInput/PinInputRoot.vue
+++ b/packages/core/src/PinInput/PinInputRoot.vue
@@ -10,7 +10,7 @@ export type PinInputType = 'text' | 'number'
 
 // Using this type to avoid mixed arrays (string | number)[].
 // The value type can be number[] only when the type is explicitly set to 'number'
-export type PinInputValue<Type extends PinInputType> = 'number' extends Type ? number[] : string[]
+export type PinInputValue<Type extends PinInputType> = [Type] extends ['number'] ? number[] : string[]
 
 // provide the mixed arrays because the `type` is dynamic in the context
 export type PinInputContextValue<Type extends PinInputType = 'text'> =


### PR DESCRIPTION
Related https://github.com/nuxt/ui/pull/4346

[As my comment said](https://github.com/nuxt/ui/pull/4346#issuecomment-3032770524), user can only get `'text'` when they are adding the `type` field:

```vue
<UPinInput type="" />
<!--             ^ cursor here, only get 'text' -->
```

This PR fixed the issue by postponing the application of default value, and make `number` also appear in the autocomplete hint. It also makes the type of context more robust.