### PR TITLE
fix(Combobox): avoid auto focusing input when `autoFocus: false` (default)

### DIFF
--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -73,7 +73,7 @@ const isInputWithinContent = ref(false)
 onMounted(() => {
   if (rootContext.inputElement.value) {
     isInputWithinContent.value = currentElement.value.contains(rootContext.inputElement.value)
-    if (isInputWithinContent.value) {
+    if (rootContext.isInputAutoFocus.value && isInputWithinContent.value) {
       rootContext.inputElement.value.focus()
     }
   }

--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -92,6 +92,10 @@ watch(rootContext.filterState, () => {
     listboxContext.highlightFirstItem()
   }
 })
+
+watch(() => props.autoFocus, () => {
+  rootContext.isInputAutoFocus.value = props.autoFocus
+}, { immediate: true })
 </script>
 
 <template>

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -16,6 +16,7 @@ type ComboboxRootContext<T> = {
   contentId: string
   inputElement: Ref<HTMLInputElement | undefined>
   onInputElementChange: (el: HTMLInputElement) => void
+  isInputAutoFocus: Ref<boolean>
   triggerElement: Ref<HTMLElement | undefined>
   onTriggerElementChange: (el: HTMLElement) => void
   highlightedElement: Ref<HTMLElement | undefined>
@@ -116,7 +117,9 @@ async function onOpenChange(val: boolean) {
     isUserInputted.value = false
   }
 
-  inputElement.value?.focus()
+  if (isInputAutoFocus.value) {
+    inputElement.value?.focus()
+  }
   setTimeout(() => {
     if (!val && props.resetSearchTermOnBlur)
       resetSearchTerm.trigger()
@@ -127,6 +130,7 @@ const resetSearchTerm = createEventHook()
 const isUserInputted = ref(false)
 const isVirtual = ref(false)
 const inputElement = ref<HTMLInputElement>()
+const isInputAutoFocus = ref(false)
 const triggerElement = ref<HTMLElement>()
 
 const highlightedElement = computed(() => primitiveElement.value?.highlightedElement ?? undefined)
@@ -209,6 +213,7 @@ provideComboboxRootContext({
   isVirtual,
   inputElement,
   highlightedElement,
+  isInputAutoFocus,
   onInputElementChange: val => inputElement.value = val,
   triggerElement,
   onTriggerElementChange: val => triggerElement.value = val,


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2034

This is mainly a draft PR to demonstrate how it would affect users who rely on the implicit behavior. ❤️

Before:

Auto-focus the input when the `Combobox` is opened, ignoring the `autoFocus` prop on `ComboboxInput`.

After:

Only auto-focus the input when the `Combobox` is opened when the `autoFocus:true` prop is set on `ComboboxInput`.