### PR TITLE
fix(TagsInput): korean IME duplicate tags with nextTick in onCompositionEnd

### DIFF
--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -227,7 +227,7 @@ function onCompositionStart() {
   isComposing.value = true
 }
 function onCompositionEnd() {
-  requestAnimationFrame(() => {
+  nextTick(() => {
     isComposing.value = false
   })
 }

--- a/packages/core/src/TagsInput/TagsInputInput.vue
+++ b/packages/core/src/TagsInput/TagsInputInput.vue
@@ -51,7 +51,7 @@ function onCompositionStart() {
   isComposing.value = true
 }
 function onCompositionEnd() {
-  requestAnimationFrame(() => {
+  nextTick(() => {
     isComposing.value = false
   })
 }


### PR DESCRIPTION
Replaced `requestAnimationFrame` in `onCompositionEnd` with Vue's `nextTick` to safely delay setting `isComposing.value = false` until after DOM updates and event queues are processed.


resolve #2024 