### PR TITLE
feat: add ColorSwatch components

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -158,6 +158,16 @@ export default defineConfig({
             ],
           },
           {
+            text: 'Color',
+            items: [
+              { text: 'Color Swatch', link: '/docs/components/color-swatch' },
+              {
+                text: 'Color Swatch Picker',
+                link: '/docs/components/color-swatch-picker',
+              },
+            ],
+          },
+          {
             text: 'Dates',
             items: [
               {

--- a/docs/components/demo/ColorSwatch/css/index.vue
+++ b/docs/components/demo/ColorSwatch/css/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { ColorSwatch } from 'reka-ui'
+import './styles.css'
+</script>
+
+<template>
+  <ColorSwatch
+    color="#16a372"
+    class="swatch"
+  />
+</template>

--- a/docs/components/demo/ColorSwatch/css/index.vue
+++ b/docs/components/demo/ColorSwatch/css/index.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
+import { green } from '@radix-ui/colors'
 import { ColorSwatch } from 'reka-ui'
 import './styles.css'
 </script>
 
 <template>
   <ColorSwatch
-    color="#16a372"
+    :color="green.green9"
     class="swatch"
   />
 </template>

--- a/docs/components/demo/ColorSwatch/css/styles.css
+++ b/docs/components/demo/ColorSwatch/css/styles.css
@@ -1,0 +1,11 @@
+.swatch {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+    flex-shrink: 0;
+}
+
+.dark .swatch {
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}

--- a/docs/components/demo/ColorSwatch/tailwind/index.vue
+++ b/docs/components/demo/ColorSwatch/tailwind/index.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { ColorSwatch } from 'reka-ui'
+</script>
+
+<template>
+  <ColorSwatch
+    color="#16a372"
+    class="size-8 shrink-0 bg-[--reka-color-swatch-color] rounded ring-1 ring-inset ring-black/15 dark:ring-white/15"
+  />
+</template>

--- a/docs/components/demo/ColorSwatch/tailwind/index.vue
+++ b/docs/components/demo/ColorSwatch/tailwind/index.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import { green } from '@radix-ui/colors'
 import { ColorSwatch } from 'reka-ui'
 </script>
 
 <template>
   <ColorSwatch
-    color="#16a372"
+    :color="green.green9"
     class="size-8 shrink-0 bg-[--reka-color-swatch-color] rounded ring-1 ring-inset ring-black/15 dark:ring-white/15"
   />
 </template>

--- a/docs/components/demo/ColorSwatch/tailwind/tailwind.config.js
+++ b/docs/components/demo/ColorSwatch/tailwind/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./**/*.vue'],
+  theme: {},
+  plugins: [],
+}

--- a/docs/components/demo/ColorSwatchPicker/css/index.vue
+++ b/docs/components/demo/ColorSwatchPicker/css/index.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ColorSwatchPickerItem, ColorSwatchPickerItemIndicator, ColorSwatchPickerItemSwatch, ColorSwatchPickerRoot } from 'reka-ui'
+import './styles.css'
+
+const colors = [
+  '#84CC16',
+  '#F59E0B',
+  '#0D6EFD',
+  '#EC4899',
+  '#F43F5E',
+]
+</script>
+
+<template>
+  <ColorSwatchPickerRoot class="root">
+    <ColorSwatchPickerItem
+      v-for="color in colors"
+      :key="color"
+      :value="color"
+      class="item"
+    >
+      <ColorSwatchPickerItemSwatch
+        class="swatch"
+      />
+      <ColorSwatchPickerItemIndicator class="indicator">
+        <Icon icon="radix-icons:check" />
+      </ColorSwatchPickerItemIndicator>
+    </ColorSwatchPickerItem>
+  </ColorSwatchPickerRoot>
+</template>

--- a/docs/components/demo/ColorSwatchPicker/css/index.vue
+++ b/docs/components/demo/ColorSwatchPicker/css/index.vue
@@ -1,14 +1,25 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
+import {
+  blue,
+  green,
+  orange,
+  pink,
+  red,
+  violet,
+  yellow,
+} from '@radix-ui/colors'
 import { ColorSwatchPickerItem, ColorSwatchPickerItemIndicator, ColorSwatchPickerItemSwatch, ColorSwatchPickerRoot } from 'reka-ui'
 import './styles.css'
 
 const colors = [
-  '#84CC16',
-  '#F59E0B',
-  '#0D6EFD',
-  '#EC4899',
-  '#F43F5E',
+  red.red9,
+  pink.pink9,
+  violet.violet9,
+  blue.blue9,
+  green.green9,
+  orange.orange9,
+  yellow.yellow9,
 ]
 </script>
 

--- a/docs/components/demo/ColorSwatchPicker/css/styles.css
+++ b/docs/components/demo/ColorSwatchPicker/css/styles.css
@@ -1,0 +1,32 @@
+.root {
+    display: flex;
+    gap: 8px;
+}
+
+.item {
+    position: relative;
+}
+
+.swatch {
+    height: 32px;
+    width: 32px;
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+    flex-shrink: 0;
+    cursor: pointer;
+}
+
+.dark .swatch {
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.indicator {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    color: white;
+}
+
+.swatch[data-color-contrast='dark'] ~ .indicator {
+    color: black;
+}

--- a/docs/components/demo/ColorSwatchPicker/tailwind/index.vue
+++ b/docs/components/demo/ColorSwatchPicker/tailwind/index.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ColorSwatchPickerItem, ColorSwatchPickerItemIndicator, ColorSwatchPickerItemSwatch, ColorSwatchPickerRoot } from 'reka-ui'
+
+const colors = [
+  '#84CC16',
+  '#F59E0B',
+  '#0D6EFD',
+  '#EC4899',
+  '#F43F5E',
+]
+</script>
+
+<template>
+  <ColorSwatchPickerRoot class="flex gap-2">
+    <ColorSwatchPickerItem
+      v-for="color in colors"
+      :key="color"
+      :value="color"
+      class="relative"
+    >
+      <ColorSwatchPickerItemSwatch
+        class="size-8 rounded ring-1 ring-inset ring-black/15 dark:ring-white/15 bg-[--reka-color-swatch-color] peer"
+      />
+      <ColorSwatchPickerItemIndicator class="text-white peer-data-[color-contrast=dark]:text-black absolute right-1 bottom-1">
+        <Icon icon="radix-icons:check" />
+      </ColorSwatchPickerItemIndicator>
+    </ColorSwatchPickerItem>
+  </ColorSwatchPickerRoot>
+</template>

--- a/docs/components/demo/ColorSwatchPicker/tailwind/index.vue
+++ b/docs/components/demo/ColorSwatchPicker/tailwind/index.vue
@@ -1,13 +1,24 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
+import {
+  blue,
+  green,
+  orange,
+  pink,
+  red,
+  violet,
+  yellow,
+} from '@radix-ui/colors'
 import { ColorSwatchPickerItem, ColorSwatchPickerItemIndicator, ColorSwatchPickerItemSwatch, ColorSwatchPickerRoot } from 'reka-ui'
 
 const colors = [
-  '#84CC16',
-  '#F59E0B',
-  '#0D6EFD',
-  '#EC4899',
-  '#F43F5E',
+  red.red9,
+  pink.pink9,
+  violet.violet9,
+  blue.blue9,
+  green.green9,
+  orange.orange9,
+  yellow.yellow9,
 ]
 </script>
 

--- a/docs/components/demo/ColorSwatchPicker/tailwind/index.vue
+++ b/docs/components/demo/ColorSwatchPicker/tailwind/index.vue
@@ -3,8 +3,8 @@ import { Icon } from '@iconify/vue'
 import {
   blue,
   green,
+  indigo,
   orange,
-  pink,
   red,
   violet,
   yellow,
@@ -13,12 +13,12 @@ import { ColorSwatchPickerItem, ColorSwatchPickerItemIndicator, ColorSwatchPicke
 
 const colors = [
   red.red9,
-  pink.pink9,
-  violet.violet9,
-  blue.blue9,
-  green.green9,
   orange.orange9,
   yellow.yellow9,
+  green.green9,
+  blue.blue9,
+  indigo.indigo9,
+  violet.violet9,
 ]
 </script>
 

--- a/docs/components/demo/ColorSwatchPicker/tailwind/tailwind.config.js
+++ b/docs/components/demo/ColorSwatchPicker/tailwind/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./**/*.vue'],
+  theme: {},
+  plugins: [],
+}

--- a/docs/content/docs/components/color-swatch-picker.md
+++ b/docs/content/docs/components/color-swatch-picker.md
@@ -48,15 +48,15 @@ import {
 <template>
   <ColorSwatchPickerRoot>
     <ColorSwatchPickerItem value="#ff0000">
-      <ColorSwatchPickerSwatch />
+      <ColorSwatchPickerItemSwatch />
       <ColorSwatchPickerItemIndicator />
     </ColorSwatchPickerItem>
     <ColorSwatchPickerItem value="#00ff00">
-      <ColorSwatchPickerSwatch />
+      <ColorSwatchPickerItemSwatch />
       <ColorSwatchPickerItemIndicator />
     </ColorSwatchPickerItem>
     <ColorSwatchPickerItem value="#0000ff">
-      <ColorSwatchPickerSwatch />
+      <ColorSwatchPickerItemSwatch />
       <ColorSwatchPickerItemIndicator />
     </ColorSwatchPickerItem>
   </ColorSwatchPickerRoot>

--- a/docs/content/docs/components/color-swatch-picker.md
+++ b/docs/content/docs/components/color-swatch-picker.md
@@ -1,0 +1,90 @@
+---
+
+title: Color Swatch Picker
+description: A component that allows users to select from a set of predefined colors, often used for themes or branding.
+name: color-swatch-picker
+---
+
+# Color Swatch Picker
+
+<Description>
+A component that allows users to select from a set of predefined colors, often used for themes or branding.
+</Description>
+
+<ComponentPreview name="ColorSwatchPicker" />
+
+## Features
+
+<Highlights
+  :features="[
+    'Can be controlled or uncontrolled.',
+    'Focus is fully managed.',
+    'Full keyboard navigation.',
+    'Supports Right to Left direction.',
+    'Different selection behavior.',
+  ]"
+/>
+
+## Installation
+
+Install the component from your command line.
+
+<InstallationTabs value="reka-ui" />
+
+## Anatomy
+
+Import all parts and piece them together.
+
+```vue
+<script setup>
+import {
+  ColorSwatchPickerItem,
+  ColorSwatchPickerItemIndicator,
+  ColorSwatchPickerRoot,
+  ColorSwatchPickerSwatch
+} from 'reka-ui'
+</script>
+
+<template>
+  <ColorSwatchPickerRoot>
+    <ColorSwatchPickerItem value="#ff0000">
+      <ColorSwatchPickerSwatch />
+      <ColorSwatchPickerItemIndicator />
+    </ColorSwatchPickerItem>
+    <ColorSwatchPickerItem value="#00ff00">
+      <ColorSwatchPickerSwatch />
+      <ColorSwatchPickerItemIndicator />
+    </ColorSwatchPickerItem>
+    <ColorSwatchPickerItem value="#0000ff">
+      <ColorSwatchPickerSwatch />
+      <ColorSwatchPickerItemIndicator />
+    </ColorSwatchPickerItem>
+  </ColorSwatchPickerRoot>
+</template>
+```
+
+## API Reference
+
+### ColorSwatchPickerRoot
+
+The main component that displays a color swatch picker.
+
+<!-- @include: @/meta/ColorSwatchPickerRoot.md -->
+
+### ColorSwatchPickerItem
+
+The item that represents a selectable color swatch.
+
+<!-- @include: @/meta/ColorSwatchPickerItem.md -->
+
+### ColorSwatchPickerItemSwatch
+
+The component that displays the color swatch within an item.
+
+<!-- @include: @/meta/ColorSwatchPickerItemSwatch.md -->
+
+### ColorSwatchPickerItemIndicator
+
+The component that indicates the selected color swatch within an item.
+
+<!-- @include: @/meta/ColorSwatchPickerItemIndicator.md -->

--- a/docs/content/docs/components/color-swatch-picker.md
+++ b/docs/content/docs/components/color-swatch-picker.md
@@ -40,8 +40,8 @@ Import all parts and piece them together.
 import {
   ColorSwatchPickerItem,
   ColorSwatchPickerItemIndicator,
+  ColorSwatchPickerItemSwatch,
   ColorSwatchPickerRoot,
-  ColorSwatchPickerSwatch
 } from 'reka-ui'
 </script>
 

--- a/docs/content/docs/components/color-swatch.md
+++ b/docs/content/docs/components/color-swatch.md
@@ -17,13 +17,9 @@ Displays a color swatch, which can be used to represent colors in a UI.
 
 <Highlights
   :features="[
-    // 'Full keyboard navigation',
-    // 'Can be controlled or uncontrolled',
-    // 'Focus is fully managed',
-    // 'Localization support',
-    // 'Highly composable'
-    'Accessible by default',
     'Supports custom colors',
+    'Provides an accessible label for screen readers',
+    'Provides a color contrast for better visibility',
   ]"
 />
 

--- a/docs/content/docs/components/color-swatch.md
+++ b/docs/content/docs/components/color-swatch.md
@@ -1,0 +1,58 @@
+---
+
+title: Color Swatch
+description: A predefined color block that allows users to quickly select commonly used or brand-specific colors.
+name: color-swatch
+---
+
+# Color Swatch
+
+<Description>
+Displays a color swatch, which can be used to represent colors in a UI.
+</Description>
+
+<ComponentPreview name="ColorSwatch" />
+
+## Features
+
+<Highlights
+  :features="[
+    // 'Full keyboard navigation',
+    // 'Can be controlled or uncontrolled',
+    // 'Focus is fully managed',
+    // 'Localization support',
+    // 'Highly composable'
+    'Accessible by default',
+    'Supports custom colors',
+  ]"
+/>
+
+## Installation
+
+Install the component from your command line.
+
+<InstallationTabs value="reka-ui" />
+
+## Anatomy
+
+Import all parts and piece them together.
+
+```vue
+<script setup>
+import {
+  ColorSwatch,
+} from 'reka-ui'
+</script>
+
+<template>
+  <ColorSwatch color="#ff0000" />
+</template>
+```
+
+## API Reference
+
+### ColorSwatch
+
+The main component that displays a color swatch.
+
+<!-- @include: @/meta/ColorSwatch.md -->

--- a/docs/content/meta/ColorSwatch.md
+++ b/docs/content/meta/ColorSwatch.md
@@ -1,0 +1,25 @@
+<!-- This file was automatic generated. Do not edit it manually -->
+
+<PropsTable :data="[
+  {
+    'name': 'color',
+    'description': '',
+    'type': 'string',
+    'required': false,
+    'default': '\'\''
+  },
+  {
+    'name': 'label',
+    'description': '',
+    'type': 'string',
+    'required': false
+  }
+]" />
+
+<SlotsTable :data="[
+  {
+    'name': 'color',
+    'description': '',
+    'type': 'string'
+  }
+]" />

--- a/docs/content/meta/ColorSwatch.md
+++ b/docs/content/meta/ColorSwatch.md
@@ -16,14 +16,14 @@
   },
   {
     'name': 'color',
-    'description': '',
+    'description': '<p>The color to display in the swatch as a hex string.\nExample: <code>#16a372</code> or <code>#ff5733</code>.</p>\n',
     'type': 'string',
     'required': false,
     'default': '\'\''
   },
   {
     'name': 'label',
-    'description': '',
+    'description': '<p>Optional accessible label for the color. If omitted, the color name will be derived from the color value.</p>\n',
     'type': 'string',
     'required': false
   }

--- a/docs/content/meta/ColorSwatchPickerItem.md
+++ b/docs/content/meta/ColorSwatchPickerItem.md
@@ -22,7 +22,7 @@
   },
   {
     'name': 'value',
-    'description': '<p>The value given as data when submitted with a <code>name</code>.</p>\n',
+    'description': '<p>The color to display in the swatch as a hex string.\nExample: <code>#16a372</code> or <code>#ff5733</code>.</p>\n',
     'type': 'string',
     'required': true
   }

--- a/docs/content/meta/ColorSwatchPickerItem.md
+++ b/docs/content/meta/ColorSwatchPickerItem.md
@@ -1,0 +1,37 @@
+<!-- This file was automatic generated. Do not edit it manually -->
+
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'disabled',
+    'description': '<p>When <code>true</code>, prevents the user from interacting with the item.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'value',
+    'description': '<p>The value given as data when submitted with a <code>name</code>.</p>\n',
+    'type': 'string',
+    'required': true
+  }
+]" />
+
+<EmitsTable :data="[
+  {
+    'name': 'select',
+    'description': '<p>Event handler called when the selecting item. &lt;br&gt; It can be prevented by calling <code>event.preventDefault</code>.</p>\n',
+    'type': '[event: SelectEvent<AcceptableValue>]'
+  }
+]" />

--- a/docs/content/meta/ColorSwatchPickerItemIndicator.md
+++ b/docs/content/meta/ColorSwatchPickerItemIndicator.md
@@ -1,0 +1,17 @@
+<!-- This file was automatic generated. Do not edit it manually -->
+
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />

--- a/docs/content/meta/ColorSwatchPickerItemSwatch.md
+++ b/docs/content/meta/ColorSwatchPickerItemSwatch.md
@@ -16,7 +16,7 @@
   },
   {
     'name': 'label',
-    'description': '',
+    'description': '<p>Optional accessible label for the color. If omitted, the color name will be derived from the color value.</p>\n',
     'type': 'string',
     'required': false
   }

--- a/docs/content/meta/ColorSwatchPickerItemSwatch.md
+++ b/docs/content/meta/ColorSwatchPickerItemSwatch.md
@@ -15,24 +15,9 @@
     'required': false
   },
   {
-    'name': 'color',
-    'description': '',
-    'type': 'string',
-    'required': false,
-    'default': '\'\''
-  },
-  {
     'name': 'label',
     'description': '',
     'type': 'string',
     'required': false
-  }
-]" />
-
-<SlotsTable :data="[
-  {
-    'name': 'color',
-    'description': '',
-    'type': 'string'
   }
 ]" />

--- a/docs/content/meta/ColorSwatchPickerRoot.md
+++ b/docs/content/meta/ColorSwatchPickerRoot.md
@@ -1,0 +1,112 @@
+<!-- This file was automatic generated. Do not edit it manually -->
+
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'defaultValue',
+    'description': '<p>The value of the listbox when initially rendered. Use when you do not need to control the state of the Listbox</p>\n',
+    'type': 'string | string[]',
+    'required': false,
+    'default': '\'\''
+  },
+  {
+    'name': 'dir',
+    'description': '<p>The reading direction of the listbox when applicable. &lt;br&gt; If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
+    'type': '\'ltr\' | \'rtl\'',
+    'required': false,
+    'default': '\'ltr\''
+  },
+  {
+    'name': 'disabled',
+    'description': '<p>When <code>true</code>, prevents the user from interacting with listbox</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'false'
+  },
+  {
+    'name': 'highlightOnHover',
+    'description': '<p>When <code>true</code>, hover over item will trigger highlight</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'modelValue',
+    'description': '<p>The controlled value of the listbox. Can be binded with with <code>v-model</code>.</p>\n',
+    'type': 'string | string[]',
+    'required': false
+  },
+  {
+    'name': 'multiple',
+    'description': '<p>Whether multiple options can be selected or not.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'name',
+    'description': '<p>The name of the field. Submitted with its owning form as part of a name/value pair.</p>\n',
+    'type': 'string',
+    'required': false
+  },
+  {
+    'name': 'orientation',
+    'description': '<p>The orientation of the listbox. &lt;br&gt;Mainly so arrow navigation is done accordingly (left &amp; right vs. up &amp; down)</p>\n',
+    'type': '\'vertical\' | \'horizontal\'',
+    'required': false,
+    'default': '\'horizontal\''
+  },
+  {
+    'name': 'required',
+    'description': '<p>When <code>true</code>, indicates that the user must set the value before the owning form can be submitted.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'selectionBehavior',
+    'description': '<p>How multiple selection should behave in the collection.</p>\n',
+    'type': '\'toggle\' | \'replace\'',
+    'required': false
+  }
+]" />
+
+<EmitsTable :data="[
+  {
+    'name': 'entryFocus',
+    'description': '<p>Event handler called when container is being focused. Can be prevented.</p>\n',
+    'type': '[event: CustomEvent<any>]'
+  },
+  {
+    'name': 'highlight',
+    'description': '<p>Event handler when highlighted element changes.</p>\n',
+    'type': '[payload: { ref: HTMLElement; value: AcceptableValue; }]'
+  },
+  {
+    'name': 'leave',
+    'description': '<p>Event handler called when the mouse leave the container</p>\n',
+    'type': '[event: Event]'
+  },
+  {
+    'name': 'update:modelValue',
+    'description': '<p>Event handler called when the value changes.</p>\n',
+    'type': '[value: AcceptableValue]'
+  }
+]" />
+
+<SlotsTable :data="[
+  {
+    'name': 'modelValue',
+    'description': '',
+    'type': 'string | string[] | undefined'
+  }
+]" />

--- a/packages/core/constant/components.ts
+++ b/packages/core/constant/components.ts
@@ -56,6 +56,17 @@ export const components = {
     'CollapsibleContent',
   ] as const,
 
+  colorSwatch: [
+    'ColorSwatch',
+  ] as const,
+
+  colorSwatchPicker: [
+    'ColorSwatchPickerRoot',
+    'ColorSwatchPickerItem',
+    'ColorSwatchPickerItemSwatch',
+    'ColorSwatchPickerItemIndicator',
+  ] as const,
+
   combobox: [
     'ComboboxRoot',
     'ComboboxInput',

--- a/packages/core/src/ColorSwatch/ColorSwatch.test.ts
+++ b/packages/core/src/ColorSwatch/ColorSwatch.test.ts
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import ColorSwatch from './ColorSwatch.vue'
+
+const TEST_COLOR = '#123abc'
+
+describe('colorSwatch.vue', () => {
+  it('applies the correct style variable for color', () => {
+    const { getByRole } = render(ColorSwatch, { props: { color: TEST_COLOR } })
+    const swatch = getByRole('img')
+    expect(swatch.style.getPropertyValue('--reka-color-swatch-color')).toBe(TEST_COLOR)
+  })
+
+  it('sets the correct aria-label', () => {
+    const { getByRole } = render(ColorSwatch, { props: { color: TEST_COLOR } })
+    const swatch = getByRole('img')
+    expect(swatch.hasAttribute('aria-label')).toBe(true)
+  })
+
+  it('sets aria-roledescription to "color swatch"', () => {
+    const { getByRole } = render(ColorSwatch, { props: { color: TEST_COLOR } })
+    const swatch = getByRole('img')
+    expect(swatch.getAttribute('aria-roledescription')).toBe('color swatch')
+  })
+})

--- a/packages/core/src/ColorSwatch/ColorSwatch.test.ts
+++ b/packages/core/src/ColorSwatch/ColorSwatch.test.ts
@@ -1,25 +1,16 @@
-import { render } from '@testing-library/vue'
+import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import ColorSwatch from './ColorSwatch.vue'
+import { axe } from 'vitest-axe'
+import ColorSwatch from './story/_ColorSwatch.vue'
 
-const TEST_COLOR = '#123abc'
-
-describe('colorSwatch.vue', () => {
-  it('applies the correct style variable for color', () => {
-    const { getByRole } = render(ColorSwatch, { props: { color: TEST_COLOR } })
-    const swatch = getByRole('img')
-    expect(swatch.style.getPropertyValue('--reka-color-swatch-color')).toBe(TEST_COLOR)
+describe('given a default ColorSwatch', () => {
+  it('should pass axe accessibility tests', async () => {
+    const wrapper = mount(ColorSwatch, { attachTo: document.body })
+    expect(await axe(wrapper.element)).toHaveNoViolations()
   })
 
-  it('sets the correct aria-label', () => {
-    const { getByRole } = render(ColorSwatch, { props: { color: TEST_COLOR } })
-    const swatch = getByRole('img')
-    expect(swatch.hasAttribute('aria-label')).toBe(true)
-  })
-
-  it('sets aria-roledescription to "color swatch"', () => {
-    const { getByRole } = render(ColorSwatch, { props: { color: TEST_COLOR } })
-    const swatch = getByRole('img')
-    expect(swatch.getAttribute('aria-roledescription')).toBe('color swatch')
+  it('should render ColorSwatch', () => {
+    const wrapper = mount(ColorSwatch)
+    expect(wrapper.element).toBeTruthy()
   })
 })

--- a/packages/core/src/ColorSwatch/ColorSwatch.vue
+++ b/packages/core/src/ColorSwatch/ColorSwatch.vue
@@ -2,7 +2,14 @@
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface ColorSwatchProps extends PrimitiveProps {
+  /**
+   * The color to display in the swatch as a hex string.
+   * Example: `#16a372` or `#ff5733`.
+   */
   color?: string
+  /**
+   * Optional accessible label for the color. If omitted, the color name will be derived from the color value.
+   */
   label?: string
 }
 </script>

--- a/packages/core/src/ColorSwatch/ColorSwatch.vue
+++ b/packages/core/src/ColorSwatch/ColorSwatch.vue
@@ -1,0 +1,61 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/Primitive'
+
+export interface ColorSwatchProps extends PrimitiveProps {
+  color?: string
+  label?: string
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { getColorContrast, getColorName } from '@/color'
+import { Primitive } from '@/Primitive'
+
+const props = withDefaults(defineProps<ColorSwatchProps>(), { as: 'div', color: '' })
+
+const label = computed(() => {
+  if (props.label)
+    return props.label
+
+  try {
+    return `${getColorName(props.color)}`
+  }
+  catch {
+    if (import.meta.env.DEV) {
+      console.warn(`WARNING: Unable to resolve color "${props.color}" to a name. 
+           Please check that the color provided is a valid hex color or provide a label.`)
+    }
+    return undefined
+  }
+})
+
+const colorContrast = computed(() => {
+  try {
+    return getColorContrast(props.color)
+  }
+  catch {
+    if (import.meta.env.DEV) {
+      console.warn(`WARNING: Unable to resolve contrast color for "${props.color}". 
+           Please check that the color provided is a valid hex color.`)
+    }
+    return undefined
+  }
+})
+</script>
+
+<template>
+  <Primitive
+    role="img"
+    :aria-label="label"
+    aria-roledescription="color swatch"
+    :as-child="asChild"
+    :as="as"
+    :data-color-contrast="colorContrast"
+    :style="{
+      '--reka-color-swatch-color': color,
+    }"
+  >
+    <slot :color="color" />
+  </Primitive>
+</template>

--- a/packages/core/src/ColorSwatch/index.ts
+++ b/packages/core/src/ColorSwatch/index.ts
@@ -1,0 +1,4 @@
+export {
+  default as ColorSwatch,
+  type ColorSwatchProps,
+} from './ColorSwatch.vue'

--- a/packages/core/src/ColorSwatch/story/_ColorSwatch.vue
+++ b/packages/core/src/ColorSwatch/story/_ColorSwatch.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import type { ColorSwatchProps } from '..'
+import { ColorSwatch } from '..'
+
+const props = defineProps<ColorSwatchProps>()
+
+const color = '#E5484D'
+</script>
+
+<template>
+  <ColorSwatch
+    v-bind="props"
+    :color="color"
+    class="w-8 h-8 rounded ring-1 ring-inset ring-black/15 dark:ring-white/15"
+  /> />
+</template>

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPicker.test.ts
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPicker.test.ts
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import ColorSwatchPickerItem from './ColorSwatchPickerItem.vue'
+import ColorSwatchPickerRoot from './ColorSwatchPickerRoot.vue'
+
+const TEST_COLOR = '#ff00aa'
+
+describe('colorSwatchPickerRoot.vue', () => {
+  it('renders with the correct model value', () => {
+    const { getByRole } = render(ColorSwatchPickerRoot, {
+      props: { modelValue: TEST_COLOR },
+      slots: {
+        default: `<div data-testid="slot-content"></div>`,
+      },
+    })
+    expect(getByRole('listbox')).toBeInTheDocument()
+  })
+})
+
+describe('colorSwatchPickerItem.vue', () => {
+  it('applies the correct style variable for color', () => {
+    const { getByRole } = render(ColorSwatchPickerItem, {
+      props: { value: TEST_COLOR },
+      slots: { default: 'item' },
+    })
+    const item = getByRole('option')
+    expect(item.style.getPropertyValue('--reka-color-swatch-picker-item-color')).toBe(TEST_COLOR)
+  })
+})

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPicker.test.ts
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPicker.test.ts
@@ -1,29 +1,29 @@
-import { render } from '@testing-library/vue'
-import { describe, expect, it } from 'vitest'
-import ColorSwatchPickerItem from './ColorSwatchPickerItem.vue'
-import ColorSwatchPickerRoot from './ColorSwatchPickerRoot.vue'
+import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+import ColorSwatchPicker from './story/_ColorSwatchPicker.vue'
 
-const TEST_COLOR = '#ff00aa'
+describe('given default ColorSwatchPicker', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ColorSwatchPicker>>
+  let content: DOMWrapper<Element>
+  let items: DOMWrapper<Element>[]
 
-describe('colorSwatchPickerRoot.vue', () => {
-  it('renders with the correct model value', () => {
-    const { getByRole } = render(ColorSwatchPickerRoot, {
-      props: { modelValue: TEST_COLOR },
-      slots: {
-        default: `<div data-testid="slot-content"></div>`,
-      },
-    })
-    expect(getByRole('listbox')).toBeInTheDocument()
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(ColorSwatchPicker, { attachTo: document.body })
+    content = wrapper.find('[role=listbox]')
+    items = wrapper.findAll('[role=option]')
   })
-})
 
-describe('colorSwatchPickerItem.vue', () => {
-  it('applies the correct style variable for color', () => {
-    const { getByRole } = render(ColorSwatchPickerItem, {
-      props: { value: TEST_COLOR },
-      slots: { default: 'item' },
-    })
-    const item = getByRole('option')
-    expect(item.style.getPropertyValue('--reka-color-swatch-picker-item-color')).toBe(TEST_COLOR)
+  it('should render the component', () => {
+    expect(wrapper.exists()).toBe(true)
+    expect(content.exists()).toBe(true)
+    expect(items.length).toBeGreaterThan(0)
+  })
+
+  it('should have no accessibility violations', async () => {
+    const results = await axe(wrapper.element)
+    expect(results).toHaveNoViolations()
   })
 })

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItem.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItem.vue
@@ -4,6 +4,10 @@ import type { ListboxItemEmits, ListboxItemProps } from '@/Listbox'
 import { createContext, useForwardPropsEmits } from '@/shared'
 
 export interface ColorSwatchPickerItemProps extends ListboxItemProps {
+/**
+ * The color to display in the swatch as a hex string.
+ * Example: `#16a372` or `#ff5733`.
+ */
   value: string
 }
 

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItem.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItem.vue
@@ -1,0 +1,44 @@
+<script lang="ts">
+import type { Ref } from 'vue'
+import type { ListboxItemEmits, ListboxItemProps } from '@/Listbox'
+import { createContext, useForwardPropsEmits } from '@/shared'
+
+export interface ColorSwatchPickerItemProps extends ListboxItemProps {
+  value: string
+}
+
+export type ColorSwatchPickerItemEmits = ListboxItemEmits
+
+export interface ColorSwatchPickerItemContext {
+  color: Ref<string>
+}
+
+export const [injectColorSwatchPickerItemContext, provideColorSwatchPickerItemContext]
+  = createContext<ColorSwatchPickerItemContext>('ColorSwatchPickerItem', 'ColorSwatchPickerItemContext')
+</script>
+
+<script setup lang="ts">
+import { toRefs } from 'vue'
+import { ListboxItem } from '@/Listbox'
+
+const props = defineProps<ColorSwatchPickerItemProps>()
+
+const emits = defineEmits<ColorSwatchPickerItemEmits>()
+
+const { value } = toRefs(props)
+
+const forwarded = useForwardPropsEmits(props, emits)
+
+provideColorSwatchPickerItemContext({
+  color: value,
+})
+</script>
+
+<template>
+  <ListboxItem
+    v-bind="forwarded"
+    :style="{ '--reka-color-swatch-picker-item-color': value }"
+  >
+    <slot />
+  </ListboxItem>
+</template>

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemIndicator.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemIndicator.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+import type { ListboxItemIndicatorProps } from '@/Listbox'
+
+export interface ColorSwatchPickerItemIndicatorProps extends ListboxItemIndicatorProps { }
+</script>
+
+<script setup lang="ts">
+import { ListboxItemIndicator } from '@/Listbox'
+
+const props = defineProps<ColorSwatchPickerItemIndicatorProps>()
+</script>
+
+<template>
+  <ListboxItemIndicator v-bind="props">
+    <slot />
+  </ListboxItemIndicator>
+</template>

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemSwatch.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemSwatch.vue
@@ -1,0 +1,21 @@
+<script lang="ts">
+import type { ColorSwatchProps } from '@/ColorSwatch/ColorSwatch.vue'
+
+export interface ColorSwatchPickerItemSwatchProps extends Omit<ColorSwatchProps, 'color'> { }
+</script>
+
+<script setup lang="ts">
+import { ColorSwatch } from '@/ColorSwatch'
+import { injectColorSwatchPickerItemContext } from './ColorSwatchPickerItem.vue'
+
+const props = defineProps<ColorSwatchPickerItemSwatchProps>()
+
+const colorSwatchPickerItemContext = injectColorSwatchPickerItemContext()
+</script>
+
+<template>
+  <ColorSwatch
+    v-bind="props"
+    :color="colorSwatchPickerItemContext.color.value"
+  />
+</template>

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
@@ -40,6 +40,7 @@ const forwarded = useForwardPropsEmits(props, emits)
     as-child
   >
     <ListboxContent
+      aria-label="color swatch options"
       :as-child="asChild"
       :as="as"
     >

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
@@ -1,0 +1,49 @@
+<script lang="ts">
+import type { ListboxRootEmits, ListboxRootProps } from '@/Listbox'
+import { useVModel } from '@vueuse/core'
+import { useForwardPropsEmits } from '@/shared'
+
+export interface ColorSwatchPickerRootProps extends Omit<ListboxRootProps, 'by'> {
+  defaultValue?: string | string[]
+  modelValue?: string | string[]
+}
+
+export type ColorSwatchPickerRootEmits = ListboxRootEmits
+</script>
+
+<script setup lang="ts">
+import { ListboxContent, ListboxRoot } from '@/Listbox'
+
+const props = withDefaults(defineProps<ColorSwatchPickerRootProps>(), {
+  as: 'div',
+  defaultValue: '',
+  dir: 'ltr',
+  disabled: false,
+  loop: false,
+  orientation: 'horizontal',
+})
+
+const emits = defineEmits<ColorSwatchPickerRootEmits>()
+
+const modelValue = useVModel(props, 'modelValue', emits, {
+  defaultValue: props.defaultValue,
+  passive: (props.modelValue === undefined) as false,
+})
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <ListboxRoot
+    v-bind="forwarded"
+    v-model="modelValue"
+    as-child
+  >
+    <ListboxContent
+      :as-child="asChild"
+      :as="as"
+    >
+      <slot :model-value="modelValue" />
+    </ListboxContent>
+  </ListboxRoot>
+</template>

--- a/packages/core/src/ColorSwatchPicker/index.ts
+++ b/packages/core/src/ColorSwatchPicker/index.ts
@@ -1,0 +1,17 @@
+export {
+  default as ColorSwatchPickerItem,
+  type ColorSwatchPickerItemProps,
+} from './ColorSwatchPickerItem.vue'
+export {
+  default as ColorSwatchPickerItemIndicator,
+  type ColorSwatchPickerItemIndicatorProps,
+} from './ColorSwatchPickerItemIndicator.vue'
+export {
+  default as ColorSwatchPickerItemSwatch,
+  type ColorSwatchPickerItemSwatchProps,
+} from './ColorSwatchPickerItemSwatch.vue'
+export {
+  default as ColorSwatchPickerRoot,
+  type ColorSwatchPickerRootEmits,
+  type ColorSwatchPickerRootProps,
+} from './ColorSwatchPickerRoot.vue'

--- a/packages/core/src/ColorSwatchPicker/story/_ColorSwatchPicker.vue
+++ b/packages/core/src/ColorSwatchPicker/story/_ColorSwatchPicker.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { ColorSwatchPickerRootEmits, ColorSwatchPickerRootProps } from '..'
+import { useForwardPropsEmits } from '@/shared'
+import { ColorSwatchPickerItem, ColorSwatchPickerItemIndicator, ColorSwatchPickerItemSwatch, ColorSwatchPickerRoot } from '..'
+
+const props = defineProps<ColorSwatchPickerRootProps>()
+
+const emits = defineEmits<ColorSwatchPickerRootEmits>()
+
+const colors = [
+  '#E5484D',
+  '#D6409F',
+  '#8E4EC6',
+  '#0090FF',
+  '#30A46C',
+  '#F76B15',
+  '#FFE629',
+]
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <ColorSwatchPickerRoot v-bind="forwarded">
+    <ColorSwatchPickerItem
+      v-for="color in colors"
+      :key="color"
+      :value="color"
+      class="relative"
+    >
+      <ColorSwatchPickerItemSwatch
+        class="w-8 h-8 rounded cursor-pointer ring-1 ring-inset ring-black/15 dark:ring-white/15 peer"
+      />
+      <ColorSwatchPickerItemIndicator class="absolute bottom-1 right-1 size-1 rounded-full bg-white peer-data-[color-contrast=dark]:bg-black" />
+    </ColorSwatchPickerItem>
+  </ColorSwatchPickerRoot>
+</template>

--- a/packages/core/src/color/index.ts
+++ b/packages/core/src/color/index.ts
@@ -1,0 +1,1 @@
+export * from './utils'

--- a/packages/core/src/color/utils.ts
+++ b/packages/core/src/color/utils.ts
@@ -1,0 +1,132 @@
+/**
+ * Converts a hex color string to HSL (Hue, Saturation, Lightness).
+ * @param hex Hex color string (e.g., "#ff5733")
+ * @returns An object containing hue, saturation, and lightness values.
+ */
+export function hexToHSL(hex: string): { h: number, s: number, l: number } {
+  // Remove the hash at the start if it's there
+  hex = hex.replace(/^#/, '')
+
+  // Parse the r, g, b values from the hex string
+  const bigint = parseInt(hex, 16)
+  let r = (bigint >> 16) & 255
+  let g = (bigint >> 8) & 255
+  let b = bigint & 255
+
+  // Convert to HSL
+  r /= 255
+  g /= 255
+  b /= 255
+
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h: number
+  let s: number
+  let l: number = (max + min) / 2
+
+  if (max === min) {
+    h = s = 0 // achromatic
+  }
+  else {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    if (max === r) {
+      h = (g - b) / d + (g < b ? 6 : 0)
+    }
+    else if (max === g) {
+      h = (b - r) / d + 2
+    }
+    else {
+      h = (r - g) / d + 4
+    }
+    h /= 6
+    h *= 360
+    s *= 100
+    l *= 100
+  }
+
+  return { h, s, l }
+}
+
+/**
+ * Converts a hex color string to a human-readable color name.
+ * @param hex Hex color string (e.g., "#ff5733")
+ * @returns A human-readable color name based on the hue, saturation, and lightness.
+ */
+export function getColorName(hex: string) {
+  // Convert RGB to HSL
+  const { h, s, l } = hexToHSL(hex)
+
+  // Handle achromatic colors (low saturation)
+  if (s < 0.1) {
+    if (l < 0.1)
+      return 'black'
+    if (l > 0.95)
+      return 'white'
+    if (l < 0.2)
+      return 'very dark gray'
+    if (l < 0.35)
+      return 'dark gray'
+    if (l < 0.65)
+      return 'gray'
+    if (l < 0.8)
+      return 'light gray'
+    return 'very light gray'
+  }
+
+  // Determine base color by hue
+  let baseName
+  if (h < 15 || h >= 345)
+    baseName = 'red'
+  else if (h < 45)
+    baseName = 'orange'
+  else if (h < 75)
+    baseName = 'yellow'
+  else if (h < 105)
+    baseName = 'yellow-green'
+  else if (h < 135)
+    baseName = 'green'
+  else if (h < 165)
+    baseName = 'green-cyan'
+  else if (h < 195)
+    baseName = 'cyan'
+  else if (h < 225)
+    baseName = 'blue'
+  else if (h < 255)
+    baseName = 'blue-violet'
+  else if (h < 285)
+    baseName = 'violet'
+  else if (h < 315)
+    baseName = 'magenta'
+  else baseName = 'red-magenta'
+
+  // Add descriptors based on saturation and lightness
+  const descriptors = []
+  if (s > 0.8)
+    descriptors.push('vibrant')
+  else if (s < 0.3)
+    descriptors.push('muted')
+
+  if (l > 0.8)
+    descriptors.push('light')
+  else if (l < 0.3)
+    descriptors.push('dark')
+
+  return descriptors.length > 0
+    ? `${descriptors.join(' ')} ${baseName}`
+    : baseName
+}
+
+export function getColorContrast(hex: string): 'light' | 'dark' {
+  // Convert hex to RGB
+  const bigint = parseInt(hex.replace(/^#/, ''), 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+
+  // Calculate luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+
+  // Return 'light' or 'dark' based on luminance
+  return luminance > 0.5 ? 'dark' : 'light'
+}

--- a/packages/core/src/color/utils.ts
+++ b/packages/core/src/color/utils.ts
@@ -1,19 +1,25 @@
 /**
+ * Converts a hex color string to RGB (Red, Green, Blue).
+ * @param hex
+ * @returns
+ */
+export function hexToRGB(hex: string): { r: number, g: number, b: number } {
+  hex = hex.replace(/^#/, '')
+  const bigint = parseInt(hex, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return { r, g, b }
+}
+
+/**
  * Converts a hex color string to HSL (Hue, Saturation, Lightness).
  * @param hex Hex color string (e.g., "#ff5733")
  * @returns An object containing hue, saturation, and lightness values.
  */
 export function hexToHSL(hex: string): { h: number, s: number, l: number } {
-  // Remove the hash at the start if it's there
-  hex = hex.replace(/^#/, '')
+  let { r, g, b } = hexToRGB(hex)
 
-  // Parse the r, g, b values from the hex string
-  const bigint = parseInt(hex, 16)
-  let r = (bigint >> 16) & 255
-  let g = (bigint >> 8) & 255
-  let b = bigint & 255
-
-  // Convert to HSL
   r /= 255
   g /= 255
   b /= 255
@@ -54,7 +60,6 @@ export function hexToHSL(hex: string): { h: number, s: number, l: number } {
  * @returns A human-readable color name based on the hue, saturation, and lightness.
  */
 export function getColorName(hex: string) {
-  // Convert RGB to HSL
   const { h, s, l } = hexToHSL(hex)
 
   // Handle achromatic colors (low saturation)
@@ -118,15 +123,7 @@ export function getColorName(hex: string) {
 }
 
 export function getColorContrast(hex: string): 'light' | 'dark' {
-  // Convert hex to RGB
-  const bigint = parseInt(hex.replace(/^#/, ''), 16)
-  const r = (bigint >> 16) & 255
-  const g = (bigint >> 8) & 255
-  const b = bigint & 255
-
-  // Calculate luminance
+  const { r, g, b } = hexToRGB(hex)
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-
-  // Return 'light' or 'dark' based on luminance
   return luminance > 0.5 ? 'dark' : 'light'
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,8 @@ export * from './Avatar'
 export * from './Calendar'
 export * from './Checkbox'
 export * from './Collapsible'
+export * from './ColorSwatch'
+export * from './ColorSwatchPicker'
 export * from './Combobox'
 // utilities
 export * from './ConfigProvider'


### PR DESCRIPTION
Working towards adding a variety of color controls as described in #501.

The motivation for me is that our company is using Reka UI and we're in need of a swatch controls only, so I may be slower in implementing other types of color controls.

I've been using [React Aria](https://react-spectrum.adobe.com/react-aria/ColorSwatch.html) as inspiration so far.

Some things to consider:
- `ColorSwatch` just logs a warning in development if the color string provided is a not a valid colour hex string. Should this behaviour be stricter to enforce valid colours? Or, perhaps accept an object instead to reduce errors like `{ r: number; g: number; b: number; }`
- Color utils only provide English descriptions for colours e.g. "muted light green" or "vibrant dark blue". Do we need localisation options for these? For now I gave the option to overwrite the generated description with custom ones so perhaps that's good enough for now. I could also include that in `ConfigProvider`?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ColorSwatch component for displaying individual colors with optional labels
  * Added ColorSwatchPicker component for selecting colors from a predefined set with visual selection indicators

* **Documentation**
  * Added comprehensive component documentation including API references
  * Added demo examples using both CSS and Tailwind styling approaches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->