### PR TITLE
fix(DatePicker): allow using `initialFocus` to control the calendar's auto-focus when opened

### DIFF
--- a/packages/core/src/DatePicker/DatePickerCalendar.vue
+++ b/packages/core/src/DatePicker/DatePickerCalendar.vue
@@ -30,7 +30,6 @@ const rootContext = injectDatePickerRootContext()
     }"
     :model-value="rootContext.modelValue.value"
     :placeholder="rootContext.placeholder.value"
-    :initial-focus="rootContext.initialFocus.value"
     :multiple="false"
     @update:model-value="(date: DateValue | undefined) => {
       if (date && rootContext.modelValue.value && isEqualDay(date, rootContext.modelValue.value)) return

--- a/packages/core/src/DatePicker/DatePickerCalendar.vue
+++ b/packages/core/src/DatePicker/DatePickerCalendar.vue
@@ -30,7 +30,7 @@ const rootContext = injectDatePickerRootContext()
     }"
     :model-value="rootContext.modelValue.value"
     :placeholder="rootContext.placeholder.value"
-    initial-focus
+    :initial-focus="rootContext.initialFocus.value"
     :multiple="false"
     @update:model-value="(date: DateValue | undefined) => {
       if (date && rootContext.modelValue.value && isEqualDay(date, rootContext.modelValue.value)) return

--- a/packages/core/src/DatePicker/DatePickerContent.vue
+++ b/packages/core/src/DatePicker/DatePickerContent.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { PopoverContentEmits, PopoverContentProps, PopoverPortalProps } from '..'
 import { computed } from 'vue'
-import { PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
+import { injectDatePickerRootContext, PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
 
 export interface DatePickerContentProps extends PopoverContentProps {
   /**
@@ -16,6 +16,8 @@ export interface DatePickerContentEmits extends PopoverContentEmits {}
 const props = defineProps<DatePickerContentProps>()
 const emits = defineEmits<DatePickerContentEmits>()
 
+const rootContext = injectDatePickerRootContext()
+
 const propsToForward = computed(() => ({
   ...props,
   portal: undefined,
@@ -27,6 +29,13 @@ const forwarded = useForwardPropsEmits(propsToForward, emits)
   <PopoverPortal v-bind="portal">
     <PopoverContent
       v-bind="{ ...forwarded, ...$attrs }"
+      @open-auto-focus="event => {
+        emits('openAutoFocus', event)
+
+        if (!rootContext.initialFocus.value) {
+          event.preventDefault()
+        }
+      }"
     >
       <slot />
     </PopoverContent>

--- a/packages/core/src/DatePicker/DatePickerContent.vue
+++ b/packages/core/src/DatePicker/DatePickerContent.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { PopoverContentEmits, PopoverContentProps, PopoverPortalProps } from '..'
 import { computed } from 'vue'
+import { handleCalendarInitialFocus } from '@/shared/date'
 import { PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
-import { injectDatePickerRootContext } from './DatePickerRoot.vue'
 
 export interface DatePickerContentProps extends PopoverContentProps {
   /**
@@ -16,8 +16,6 @@ export interface DatePickerContentEmits extends PopoverContentEmits {}
 <script setup lang="ts">
 const props = defineProps<DatePickerContentProps>()
 const emits = defineEmits<DatePickerContentEmits>()
-
-const rootContext = injectDatePickerRootContext()
 
 const propsToForward = computed(() => ({
   ...props,
@@ -33,7 +31,8 @@ const forwarded = useForwardPropsEmits(propsToForward, emits)
       @open-auto-focus="event => {
         emits('openAutoFocus', event)
 
-        if (!rootContext.initialFocus.value) {
+        if (!event.defaultPrevented && event.target) {
+          handleCalendarInitialFocus(event.target as HTMLElement)
           event.preventDefault()
         }
       }"

--- a/packages/core/src/DatePicker/DatePickerContent.vue
+++ b/packages/core/src/DatePicker/DatePickerContent.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
 import type { PopoverContentEmits, PopoverContentProps, PopoverPortalProps } from '..'
 import { computed } from 'vue'
-import { injectDatePickerRootContext, PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
+import { PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
+import { injectDatePickerRootContext } from './DatePickerRoot.vue'
 
 export interface DatePickerContentProps extends PopoverContentProps {
   /**

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -32,6 +32,7 @@ type DatePickerRootContext = {
   numberOfMonths: Ref<number>
   disabled: Ref<boolean>
   readonly: Ref<boolean>
+  initialFocus: Ref<boolean>
   isDateDisabled?: Matcher
   isDateUnavailable?: Matcher
   defaultOpen: Ref<boolean>
@@ -42,7 +43,7 @@ type DatePickerRootContext = {
   dir: Ref<Direction>
 }
 
-export type DatePickerRootProps = DateFieldRootProps & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect'>
+export type DatePickerRootProps = DateFieldRootProps & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'initialFocus'>
 
 export type DatePickerRootEmits = {
   /** Event handler called whenever the model value changes */
@@ -85,6 +86,7 @@ const {
   locale,
   disabled,
   readonly,
+  initialFocus,
   pagedNavigation,
   weekStartsOn,
   weekdayFormat,
@@ -150,6 +152,7 @@ provideDatePickerRootContext({
   fixedWeeks,
   numberOfMonths,
   readonly,
+  initialFocus,
   preventDeselect,
   modelValue,
   placeholder,

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -32,7 +32,6 @@ type DatePickerRootContext = {
   numberOfMonths: Ref<number>
   disabled: Ref<boolean>
   readonly: Ref<boolean>
-  initialFocus: Ref<boolean>
   isDateDisabled?: Matcher
   isDateUnavailable?: Matcher
   defaultOpen: Ref<boolean>
@@ -43,7 +42,7 @@ type DatePickerRootContext = {
   dir: Ref<Direction>
 }
 
-export type DatePickerRootProps = DateFieldRootProps & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'initialFocus'>
+export type DatePickerRootProps = DateFieldRootProps & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect'>
 
 export type DatePickerRootEmits = {
   /** Event handler called whenever the model value changes */
@@ -75,7 +74,6 @@ const props = withDefaults(defineProps<DatePickerRootProps>(), {
   numberOfMonths: 1,
   disabled: false,
   readonly: false,
-  initialFocus: false,
   placeholder: undefined,
   locale: 'en',
   isDateDisabled: undefined,
@@ -86,7 +84,6 @@ const {
   locale,
   disabled,
   readonly,
-  initialFocus,
   pagedNavigation,
   weekStartsOn,
   weekdayFormat,
@@ -152,7 +149,6 @@ provideDatePickerRootContext({
   fixedWeeks,
   numberOfMonths,
   readonly,
-  initialFocus,
   preventDeselect,
   modelValue,
   placeholder,

--- a/packages/core/src/DateRangePicker/DateRangePickerCalendar.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerCalendar.vue
@@ -31,7 +31,7 @@ const rootContext = injectDateRangePickerRootContext()
       fixedDate: rootContext.fixedDate.value,
       maximumDays: rootContext.maximumDays?.value,
     }"
-    initial-focus
+    :initial-focus="rootContext.initialFocus.value"
     :model-value="rootContext.modelValue.value"
     :placeholder="rootContext.placeholder.value"
     @update:start-value="(date) => {

--- a/packages/core/src/DateRangePicker/DateRangePickerCalendar.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerCalendar.vue
@@ -31,7 +31,6 @@ const rootContext = injectDateRangePickerRootContext()
       fixedDate: rootContext.fixedDate.value,
       maximumDays: rootContext.maximumDays?.value,
     }"
-    :initial-focus="rootContext.initialFocus.value"
     :model-value="rootContext.modelValue.value"
     :placeholder="rootContext.placeholder.value"
     @update:start-value="(date) => {

--- a/packages/core/src/DateRangePicker/DateRangePickerContent.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerContent.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
 import type { PopoverContentEmits, PopoverContentProps, PopoverPortalProps } from '..'
 import { computed } from 'vue'
-import { injectDateRangePickerRootContext, PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
+import { PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
+import { injectDateRangePickerRootContext } from './DateRangePickerRoot.vue'
 
 export interface DateRangePickerContentProps extends PopoverContentProps {
   /**

--- a/packages/core/src/DateRangePicker/DateRangePickerContent.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerContent.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { PopoverContentEmits, PopoverContentProps, PopoverPortalProps } from '..'
 import { computed } from 'vue'
-import { PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
+import { injectDateRangePickerRootContext, PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
 
 export interface DateRangePickerContentProps extends PopoverContentProps {
   /**
@@ -16,6 +16,8 @@ export interface DateRangePickerContentEmits extends PopoverContentEmits {}
 const props = defineProps<DateRangePickerContentProps>()
 const emits = defineEmits<DateRangePickerContentEmits>()
 
+const rootContext = injectDateRangePickerRootContext()
+
 const propsToForward = computed(() => ({
   ...props,
   portal: undefined,
@@ -27,6 +29,13 @@ const forwarded = useForwardPropsEmits(propsToForward, emits)
   <PopoverPortal v-bind="portal">
     <PopoverContent
       v-bind="{ ...forwarded, ...$attrs }"
+      @open-auto-focus="event => {
+        emits('openAutoFocus', event)
+
+        if (!rootContext.initialFocus.value) {
+          event.preventDefault()
+        }
+      }"
     >
       <slot />
     </PopoverContent>

--- a/packages/core/src/DateRangePicker/DateRangePickerContent.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerContent.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { PopoverContentEmits, PopoverContentProps, PopoverPortalProps } from '..'
 import { computed } from 'vue'
+import { handleCalendarInitialFocus } from '@/shared/date'
 import { PopoverContent, PopoverPortal, useForwardPropsEmits } from '..'
-import { injectDateRangePickerRootContext } from './DateRangePickerRoot.vue'
 
 export interface DateRangePickerContentProps extends PopoverContentProps {
   /**
@@ -16,8 +16,6 @@ export interface DateRangePickerContentEmits extends PopoverContentEmits {}
 <script setup lang="ts">
 const props = defineProps<DateRangePickerContentProps>()
 const emits = defineEmits<DateRangePickerContentEmits>()
-
-const rootContext = injectDateRangePickerRootContext()
 
 const propsToForward = computed(() => ({
   ...props,
@@ -33,7 +31,8 @@ const forwarded = useForwardPropsEmits(propsToForward, emits)
       @open-auto-focus="event => {
         emits('openAutoFocus', event)
 
-        if (!rootContext.initialFocus.value) {
+        if (!event.defaultPrevented && event.target) {
+          handleCalendarInitialFocus(event.target as HTMLElement)
           event.preventDefault()
         }
       }"

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -20,6 +20,7 @@ type DateRangePickerRootContext = {
   granularity: Ref<Granularity | undefined>
   hideTimeZone: Ref<boolean>
   required: Ref<boolean>
+  initialFocus: Ref<boolean>
   locale: Ref<string>
   dateFieldRef: Ref<InstanceType<typeof DateRangeFieldRoot> | undefined>
   modelValue: Ref<{ start: DateValue | undefined, end: DateValue | undefined }>
@@ -47,7 +48,7 @@ type DateRangePickerRootContext = {
   maximumDays?: Ref<number | undefined>
 }
 
-export type DateRangePickerRootProps = DateRangeFieldRootProps & PopoverRootProps & Pick<RangeCalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'isDateUnavailable' | 'isDateHighlightable' | 'allowNonContiguousRanges' | 'fixedDate' | 'maximumDays'>
+export type DateRangePickerRootProps = DateRangeFieldRootProps & PopoverRootProps & Pick<RangeCalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'isDateUnavailable' | 'isDateHighlightable' | 'allowNonContiguousRanges' | 'fixedDate' | 'maximumDays' | 'initialFocus'>
 
 export type DateRangePickerRootEmits = {
   /** Event handler called whenever the model value changes */
@@ -96,6 +97,7 @@ const {
   locale,
   disabled,
   readonly,
+  initialFocus,
   pagedNavigation,
   weekStartsOn,
   weekdayFormat,
@@ -166,6 +168,7 @@ provideDateRangePickerRootContext({
   fixedWeeks,
   numberOfMonths,
   readonly,
+  initialFocus,
   preventDeselect,
   modelValue,
   placeholder,

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -20,7 +20,6 @@ type DateRangePickerRootContext = {
   granularity: Ref<Granularity | undefined>
   hideTimeZone: Ref<boolean>
   required: Ref<boolean>
-  initialFocus: Ref<boolean>
   locale: Ref<string>
   dateFieldRef: Ref<InstanceType<typeof DateRangeFieldRoot> | undefined>
   modelValue: Ref<{ start: DateValue | undefined, end: DateValue | undefined }>
@@ -48,7 +47,7 @@ type DateRangePickerRootContext = {
   maximumDays?: Ref<number | undefined>
 }
 
-export type DateRangePickerRootProps = DateRangeFieldRootProps & PopoverRootProps & Pick<RangeCalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'isDateUnavailable' | 'isDateHighlightable' | 'allowNonContiguousRanges' | 'fixedDate' | 'maximumDays' | 'initialFocus'>
+export type DateRangePickerRootProps = DateRangeFieldRootProps & PopoverRootProps & Pick<RangeCalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'isDateUnavailable' | 'isDateHighlightable' | 'allowNonContiguousRanges' | 'fixedDate' | 'maximumDays'>
 
 export type DateRangePickerRootEmits = {
   /** Event handler called whenever the model value changes */
@@ -83,7 +82,6 @@ const props = withDefaults(defineProps<DateRangePickerRootProps>(), {
   numberOfMonths: 1,
   disabled: false,
   readonly: false,
-  initialFocus: false,
   placeholder: undefined,
   locale: 'en',
   isDateDisabled: undefined,
@@ -97,7 +95,6 @@ const {
   locale,
   disabled,
   readonly,
-  initialFocus,
   pagedNavigation,
   weekStartsOn,
   weekdayFormat,
@@ -168,7 +165,6 @@ provideDateRangePickerRootContext({
   fixedWeeks,
   numberOfMonths,
   readonly,
-  initialFocus,
   preventDeselect,
   modelValue,
   placeholder,


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2027