### PR TITLE
fix(DatePicker): pass through step property to field

### DIFF
--- a/packages/core/src/DatePicker/DatePickerField.vue
+++ b/packages/core/src/DatePicker/DatePickerField.vue
@@ -28,6 +28,7 @@ const rootContext = injectDatePickerRootContext()
       isDateUnavailable: rootContext.isDateUnavailable,
       required: rootContext.required.value,
       dir: rootContext.dir.value,
+      step: rootContext.step.value,
     }"
     @update:model-value="(date: DateValue | undefined) => {
       if (date && rootContext.modelValue.value && date.compare(rootContext.modelValue.value) === 0) return

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -4,7 +4,7 @@ import type { DateValue } from '@internationalized/date'
 import type { Ref } from 'vue'
 import type { CalendarRootProps, DateFieldRoot, DateFieldRootProps, PopoverRootEmits, PopoverRootProps } from '..'
 import type { Matcher, WeekDayFormat } from '@/date'
-import type { Granularity, HourCycle } from '@/shared/date'
+import type { DateStep, Granularity, HourCycle } from '@/shared/date'
 import type { Direction } from '@/shared/types'
 import { computed, ref, toRefs, watch } from 'vue'
 import { createContext, useDirection } from '@/shared'
@@ -40,6 +40,7 @@ type DatePickerRootContext = {
   onDateChange: (date: DateValue | undefined) => void
   onPlaceholderChange: (date: DateValue) => void
   dir: Ref<Direction>
+  step: Ref<DateStep | undefined>
 }
 
 export type DatePickerRootProps = DateFieldRootProps & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect'>
@@ -104,6 +105,7 @@ const {
   hourCycle,
   defaultValue,
   dir: propDir,
+  step,
 } = toRefs(props)
 
 const dir = useDirection(propDir)
@@ -165,6 +167,7 @@ provideDatePickerRootContext({
   hourCycle,
   dateFieldRef,
   dir,
+  step,
   onDateChange(date: DateValue | undefined) {
     if (!date || !modelValue.value) {
       modelValue.value = date?.copy() ?? undefined

--- a/packages/core/src/DateRangePicker/DateRangePickerField.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerField.vue
@@ -28,6 +28,7 @@ const rootContext = injectDateRangePickerRootContext()
       isDateUnavailable: rootContext.isDateUnavailable,
       required: rootContext.required.value,
       dir: rootContext.dir.value,
+      step: rootContext.step.value,
     }"
     @update:model-value="(date) => {
       if (date.start && rootContext.modelValue.value.start && date.end && rootContext.modelValue.value.end && date.start.compare(rootContext.modelValue.value.start) === 0 && date.end.compare(rootContext.modelValue.value.end) === 0) return

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -4,7 +4,7 @@ import type { DateValue } from '@internationalized/date'
 import type { Ref } from 'vue'
 import type { DateRangeFieldRoot, DateRangeFieldRootProps, PopoverRootEmits, PopoverRootProps, RangeCalendarRootProps } from '..'
 import type { Matcher, WeekDayFormat } from '@/date'
-import type { DateRange, Granularity, HourCycle } from '@/shared/date'
+import type { DateRange, DateStep, Granularity, HourCycle } from '@/shared/date'
 
 import type { Direction } from '@/shared/types'
 import { createContext, useDirection } from '@/shared'
@@ -45,6 +45,7 @@ type DateRangePickerRootContext = {
   allowNonContiguousRanges: Ref<boolean>
   fixedDate: Ref<'start' | 'end' | undefined>
   maximumDays?: Ref<number | undefined>
+  step: Ref<DateStep | undefined>
 }
 
 export type DateRangePickerRootProps = DateRangeFieldRootProps & PopoverRootProps & Pick<RangeCalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'isDateUnavailable' | 'isDateHighlightable' | 'allowNonContiguousRanges' | 'fixedDate' | 'maximumDays'>
@@ -118,6 +119,7 @@ const {
   allowNonContiguousRanges,
   fixedDate,
   maximumDays,
+  step,
 } = toRefs(props)
 
 const dir = useDirection(propsDir)
@@ -183,6 +185,7 @@ provideDateRangePickerRootContext({
   dir,
   fixedDate,
   maximumDays,
+  step,
   onStartValueChange(date: DateValue | undefined) {
     emits('update:startValue', date)
   },


### PR DESCRIPTION
This PR addresses the issue where the root `step` prop was not being passed to the `DatePickerField`/`DateRangePickerField` components.