### PR TITLE
feat(Menubar): support `unmountOnHide`

### DIFF
--- a/docs/content/meta/MenubarRoot.md
+++ b/docs/content/meta/MenubarRoot.md
@@ -25,6 +25,13 @@
     'description': '<p>The controlled value of the menu to open. Can be used as <code>v-model</code>.</p>\n',
     'type': 'string',
     'required': false
+  },
+  {
+    'name': 'unmountOnHide',
+    'description': '<p>When <code>true</code>, the element will be unmounted on closed state.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'true'
   }
 ]" />
 

--- a/packages/core/src/Menu/MenuContent.vue
+++ b/packages/core/src/Menu/MenuContent.vue
@@ -31,15 +31,21 @@ const rootContext = injectMenuRootContext()
 </script>
 
 <template>
-  <Presence :present="forceMount || menuContext.open.value">
+  <Presence
+    v-slot="{ present }"
+    :present="forceMount || menuContext.open.value"
+    :force-mount="forceMount || !rootContext.unmountOnHide.value"
+  >
     <MenuRootContentModal
       v-if="rootContext.modal.value"
+      v-show="present"
       v-bind="{ ...$attrs, ...forwarded }"
     >
       <slot />
     </MenuRootContentModal>
     <MenuRootContentNonModal
       v-else
+      v-show="present"
       v-bind="{ ...$attrs, ...forwarded }"
     >
       <slot />

--- a/packages/core/src/Menu/MenuRoot.vue
+++ b/packages/core/src/Menu/MenuRoot.vue
@@ -16,6 +16,7 @@ export interface MenuRootContext {
   dir: Ref<Direction>
   isUsingKeyboardRef: Ref<boolean>
   modal: Ref<boolean>
+  unmountOnHide: Ref<boolean>
 }
 
 export interface MenuProps {
@@ -33,6 +34,12 @@ export interface MenuProps {
    * When set to `true`, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
    */
   modal?: boolean
+  /**
+   * When `true`, the element will be unmounted on closed state.
+   *
+   * @defaultValue `true`
+   */
+  unmountOnHide?: boolean
 }
 
 export type MenuEmits = {
@@ -57,9 +64,10 @@ import { PopperRoot } from '@/Popper'
 const props = withDefaults(defineProps<MenuProps>(), {
   open: false,
   modal: true,
+  unmountOnHide: true,
 })
 const emits = defineEmits<MenuEmits>()
-const { modal, dir: propDir } = toRefs(props)
+const { modal, dir: propDir, unmountOnHide } = toRefs(props)
 const dir = useDirection(propDir)
 
 const open = useVModel(props, 'open', emits)
@@ -85,6 +93,7 @@ provideMenuRootContext({
   isUsingKeyboardRef,
   dir,
   modal,
+  unmountOnHide,
 })
 </script>
 

--- a/packages/core/src/Menubar/Menubar.test.ts
+++ b/packages/core/src/Menubar/Menubar.test.ts
@@ -3,15 +3,18 @@ import { findByRole } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { nextTick } from 'vue'
 import Menubar from './story/_Menubar.vue'
+import MenubarUnmountOnHide from './story/_MenubarUnmountOnHide.vue'
+
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
 
 describe('given default Menubar', () => {
   let wrapper: VueWrapper<InstanceType<typeof Menubar>>
-  globalThis.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  }
 
   beforeEach(() => {
     document.body.innerHTML = ''
@@ -54,6 +57,96 @@ describe('given default Menubar', () => {
 
       it('should emit select event', () => {
         expect(wrapper.emitted('select')?.length).toBe(1)
+      })
+    })
+  })
+})
+
+describe('given Menubar with default `unmountOnHide` (true)', () => {
+  let wrapper: VueWrapper<InstanceType<typeof MenubarUnmountOnHide>>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(MenubarUnmountOnHide, { attachTo: document.body })
+  })
+
+  it('should not render menu content when closed', () => {
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false)
+  })
+
+  describe('after opening and closing a menu', () => {
+    beforeEach(async () => {
+      // Open menu
+      await wrapper.find('button').trigger('pointerdown', {
+        button: 0,
+        ctrlKey: false,
+      })
+      await nextTick()
+
+      // Verify it opened
+      expect(wrapper.find('[role="menu"]').exists()).toBe(true)
+
+      // Close by clicking item
+      const item = wrapper.find('[role="menu"]').find('[role="menuitem"]')
+      await item.trigger('click')
+      await nextTick()
+    })
+
+    it('should remove menu content from DOM', () => {
+      expect(wrapper.find('[role="menu"]').exists()).toBe(false)
+    })
+  })
+})
+
+describe('given Menubar with `unmountOnHide: false`', () => {
+  let wrapper: VueWrapper<InstanceType<typeof MenubarUnmountOnHide>>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(MenubarUnmountOnHide, {
+      attachTo: document.body,
+      props: { unmountOnHide: false },
+    })
+  })
+
+  it('should keep menu content in DOM when closed', async () => {
+    // Content should be in DOM but hidden
+    const menus = wrapper.findAll('[role="menu"]')
+    expect(menus.length).toBeGreaterThan(0)
+  })
+
+  it('should hide menu content with display:none when closed', async () => {
+    const menu = wrapper.find('[role="menu"]')
+    expect(menu.exists()).toBe(true)
+    expect(menu.isVisible()).toBe(false)
+  })
+
+  describe('after opening a menu', () => {
+    beforeEach(async () => {
+      await wrapper.find('button').trigger('pointerdown', {
+        button: 0,
+        ctrlKey: false,
+      })
+      await nextTick()
+    })
+
+    it('should show the menu content', () => {
+      const menu = wrapper.find('[role="menu"]')
+      expect(menu.exists()).toBe(true)
+      expect(menu.isVisible()).toBe(true)
+    })
+
+    describe('after selecting an item', () => {
+      beforeEach(async () => {
+        const item = wrapper.find('[role="menu"]').find('[role="menuitem"]')
+        await item.trigger('click')
+        await nextTick()
+      })
+
+      it('should keep menu content in DOM but hidden', () => {
+        const menu = wrapper.find('[role="menu"]')
+        expect(menu.exists()).toBe(true)
+        expect(menu.isVisible()).toBe(false)
       })
     })
   })

--- a/packages/core/src/Menubar/MenubarContent.vue
+++ b/packages/core/src/Menubar/MenubarContent.vue
@@ -8,7 +8,7 @@ export interface MenubarContentProps extends MenuContentProps {}
 </script>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { MenuContent } from '@/Menu'
 import { useForwardExpose, useForwardPropsEmits, useId } from '@/shared'
 import { wrapArray } from '@/shared/useTypeahead'
@@ -30,6 +30,15 @@ menuContext.contentId ||= useId(undefined, 'reka-menubar-content')
 const { getItems } = useCollection({ key: 'Menubar' })
 
 const hasInteractedOutsideRef = ref(false)
+
+const open = computed(() => Boolean(rootContext.modelValue.value) && rootContext.modelValue.value === menuContext.value)
+const previousOpen = ref(open.value)
+watch(open, () => {
+  // make sure all DOM was flush then update the last state.
+  setTimeout(() => {
+    previousOpen.value = open.value
+  })
+})
 
 function handleArrowNavigation(event: KeyboardEvent) {
   const target = event.target as HTMLElement
@@ -78,8 +87,7 @@ function handleArrowNavigation(event: KeyboardEvent) {
       '--reka-menubar-trigger-height': 'var(--reka-popper-anchor-height)',
     }"
     @close-auto-focus="(event) => {
-      const menubarOpen = Boolean(rootContext.modelValue.value);
-      if (!menubarOpen && !hasInteractedOutsideRef) {
+      if (!open && !hasInteractedOutsideRef) {
         menuContext.triggerElement.value?.focus();
       }
 
@@ -94,6 +102,10 @@ function handleArrowNavigation(event: KeyboardEvent) {
     }"
     @interact-outside="
       (event) => {
+        if (!open || !previousOpen) {
+          event.preventDefault();
+        }
+
         hasInteractedOutsideRef = true;
       }
     "

--- a/packages/core/src/Menubar/MenubarMenu.vue
+++ b/packages/core/src/Menubar/MenubarMenu.vue
@@ -58,6 +58,7 @@ provideMenubarMenuContext({
     :open="open"
     :modal="false"
     :dir="rootContext.dir.value"
+    :unmount-on-hide="rootContext.unmountOnHide.value"
     @update:open="
       (value) => {
         // Menu only calls `@update:open` when dismissing so we

--- a/packages/core/src/Menubar/MenubarRoot.vue
+++ b/packages/core/src/Menubar/MenubarRoot.vue
@@ -17,6 +17,13 @@ export interface MenubarRootProps {
   dir?: Direction
   /** When `true`, keyboard navigation will loop from last item to first, and vice versa. */
   loop?: boolean
+
+  /**
+   * When `true`, the element will be unmounted on closed state.
+   *
+   * @defaultValue `true`
+   */
+  unmountOnHide?: boolean
 }
 export type MenubarRootEmits = {
   /** Event handler called when the value changes. */
@@ -27,6 +34,7 @@ export interface MenubarRootContext {
   modelValue: Ref<string>
   dir: Ref<Direction>
   loop: Ref<boolean>
+  unmountOnHide: Ref<boolean>
   onMenuOpen: (value: string) => void
   onMenuClose: () => void
   onMenuToggle: (value: string) => void
@@ -44,6 +52,7 @@ import { RovingFocusGroup } from '@/RovingFocus'
 
 const props = withDefaults(defineProps<MenubarRootProps>(), {
   loop: false,
+  unmountOnHide: true,
 })
 const emit = defineEmits<MenubarRootEmits>()
 
@@ -64,12 +73,13 @@ const modelValue = useVModel(props, 'modelValue', emit, {
 
 const currentTabStopId = ref<string | null>(null)
 
-const { dir: propDir, loop } = toRefs(props)
+const { dir: propDir, loop, unmountOnHide } = toRefs(props)
 const dir = useDirection(propDir)
 provideMenubarRootContext({
   modelValue,
   dir,
   loop,
+  unmountOnHide,
   onMenuOpen: (value) => {
     modelValue.value = value
     currentTabStopId.value = value

--- a/packages/core/src/Menubar/MenubarTrigger.vue
+++ b/packages/core/src/Menubar/MenubarTrigger.vue
@@ -10,7 +10,7 @@ export interface MenubarTriggerProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { MenuAnchor } from '@/Menu'
 import {
   Primitive,
@@ -67,14 +67,17 @@ onMounted(() => {
               rootContext.onMenuOpen(menuContext.value);
               // prevent trigger focusing when opening
               // this allows the content to be given focus without competition
-              if (!open) event.preventDefault();
+              const menubarOpen = Boolean(rootContext.modelValue.value);
+              if (menubarOpen && !open) event.preventDefault();
             }
           }"
           @pointerenter="() => {
             const menubarOpen = Boolean(rootContext.modelValue.value);
             if (menubarOpen && !open) {
               rootContext.onMenuOpen(menuContext.value);
-              triggerElement?.focus()
+              nextTick(() => {
+                triggerElement?.focus()
+              })
             }
           }"
           @keydown.enter.space.arrow-down="(event) => {

--- a/packages/core/src/Menubar/story/_MenubarUnmountOnHide.vue
+++ b/packages/core/src/Menubar/story/_MenubarUnmountOnHide.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarRoot,
+  MenubarTrigger,
+} from '..'
+
+const props = withDefaults(defineProps<{
+  unmountOnHide?: boolean
+}>(), {
+  unmountOnHide: true,
+})
+
+const currentMenu = ref('')
+</script>
+
+<template>
+  <div>
+    <MenubarRoot
+      v-model="currentMenu"
+      :unmount-on-hide="props.unmountOnHide"
+    >
+      <MenubarMenu value="file">
+        <MenubarTrigger>
+          File
+        </MenubarTrigger>
+        <MenubarContent
+          align="start"
+          :side-offset="5"
+        >
+          <MenubarItem>
+            New Tab
+          </MenubarItem>
+          <MenubarItem>
+            New Window
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+
+      <MenubarMenu value="edit">
+        <MenubarTrigger>
+          Edit
+        </MenubarTrigger>
+        <MenubarContent
+          align="start"
+          :side-offset="5"
+        >
+          <MenubarItem>
+            Undo
+          </MenubarItem>
+          <MenubarItem>
+            Redo
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </MenubarRoot>
+  </div>
+</template>


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2057

(`unmountOnHide` for other components is coming 🚀)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `unmountOnHide` property to menu components (default: true), controlling whether menu content unmounts or remains hidden in the DOM when closed.
  * Updated documentation to reflect the new configurable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->