### PR TITLE
feat: close combobox on blur with openOnFocus option

### DIFF
--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -60,6 +60,11 @@ function handleFocus() {
     rootContext.onOpenChange(true)
 }
 
+function handleBlur() {
+  if (rootContext.openOnFocus.value && rootContext.open.value)
+    rootContext.onOpenChange(false)
+}
+
 function handleClick() {
   if (rootContext.openOnClick.value && !rootContext.open.value)
     rootContext.onOpenChange(true)
@@ -121,6 +126,7 @@ watch(rootContext.filterState, () => {
     @input="handleInput"
     @keydown.down.up.prevent="handleKeyDown"
     @focus="handleFocus"
+    @blur="handleBlur"
   >
     <slot />
   </ListboxFilter>


### PR DESCRIPTION
This PR updates the recent feature introduced in [#2050](https://github.com/unovue/reka-ui/pull/2050) to ensure consistent combobox behavior. Now, the combobox will close on blur when using `openOnFocus`—matching the default behavior when selecting an item without using the `openOnFocus` option. This aligns our component’s UX with the example shown in the Atlassian Design System: https://atlassian.design/components/select/country-select/examples.

Ref https://github.com/unovue/reka-ui/issues/1917