### PR TITLE
refactor(useId): move inject config call to after Vue's useId check

### DIFF
--- a/packages/core/src/shared/useId.ts
+++ b/packages/core/src/shared/useId.ts
@@ -16,12 +16,13 @@ export function useId(deterministicId?: string | null | undefined, prefix = 'rek
   if (deterministicId)
     return deterministicId
 
-  const configProviderContext = injectConfigProviderContext({ useId: undefined })
-
   if ('useId' in vue) {
     return `${prefix}-${vue.useId?.()}`
   }
-  else if (configProviderContext.useId) {
+
+  const configProviderContext = injectConfigProviderContext({ useId: undefined })
+  
+  if (configProviderContext.useId) {
     return `${prefix}-${configProviderContext.useId()}`
   }
 


### PR DESCRIPTION
https://github.com/rollup/rollup/pull/6029 fixed the issue where Reka UI's `useId()` would pull in the entirety of Vue because we were checking if Vue's built-in `useId()` was available.

After that fix, Reka's `useId()` now looks like this when bundled:

```
function Je(e,t="reka"){return xe({useId:void 0}),`${t}-${R?.()}`}
```

The `xe()` call comes from `injectConfigProviderContext()`, which is redundant given that we're not using its value at all when the built-in `useId()` is available.

This PR moves the injection call after the Vue check, resulting in a code like this

```
function Je(e,t="reka"){return `${t}-${R?.()}`}
```