### PR TITLE
fix(build): transpile `import.meta` in outputs

### DIFF
--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -14,6 +14,17 @@ export default defineConfig({
   sourcemap: true,
   hash: false,
 
+  /**
+   * Quick fix for tsdown not convert "import.meta" for non-esm output.
+   * When tsdown resolves the issue, this can be removed.
+   *
+   * @see https://github.com/rolldown/tsdown/issues/370
+   */
+  define: {
+    'import.meta.env.DEV': 'undefined',
+    'import.meta.env.MODE': 'undefined',
+  },
+
   inputOptions: {
     preserveEntrySignatures: 'allow-extension',
     experimental: {


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2082

@zernonia This is a hotfix for the build process. After switching to `tsdown`, `import.meta` isn't transpiled and might cause runtime errors.
Once `tsdown` resolves [this issue](https://github.com/rolldown/tsdown/issues/370), we can safely revert this.