### PR TITLE
fix(RadioGroup): export RadioGroupItemEmits type (#2086)

### DIFF
--- a/packages/core/src/RadioGroup/index.ts
+++ b/packages/core/src/RadioGroup/index.ts
@@ -5,6 +5,7 @@ export {
 export {
   injectRadioGroupItemContext,
   default as RadioGroupItem,
+  type RadioGroupItemEmits,
   type RadioGroupItemProps,
 } from './RadioGroupItem.vue'
 export {


### PR DESCRIPTION
Exported missing RadioGroupItemEmits type from its Vue component for improved type safety and usage consistency.

Fixes Issue #2086