### PR TITLE
fix(Listbox): prevent autofocus to avoid breaking other focusable elements

### DIFF
--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import type { AcceptableValue, DataOrientation, Direction, FormFieldProps } from '@/shared/types'
 import { usePrimitiveElement } from '@/Primitive'
 import { getFocusIntent } from '@/RovingFocus/utils'
-import { createContext, findValuesBetween, useDirection, useFormControl, useKbd, useTypeahead } from '@/shared'
+import { createContext, findValuesBetween, getActiveElement, useDirection, useFormControl, useKbd, useTypeahead } from '@/shared'
 import { Primitive } from '..'
 
 type ListboxRootContext<T> = {
@@ -162,7 +162,7 @@ function changeHighlight(el: HTMLElement, scrollIntoView = true) {
     return
 
   highlightedElement.value = el
-  if (focusable.value)
+  if (focusable.value && currentElement.value?.contains(getActiveElement()))
     highlightedElement.value.focus()
   if (scrollIntoView)
     highlightedElement.value.scrollIntoView({ block: 'nearest' })


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2056

Previously, `Listbox` would automatically focus the highlighted item. This could interfere with other autofocusable elements, e.g., https://stackblitz.com/edit/rwxsez1n?file=src%2FApp.vue (the `autofocus` input wouldn't receive focus). This PR fixes this issue.

However, this PR doesn't completely resolve the keyboard navigation issue as described in the issue above. This is caused by [`scrollIntoView`](https://github.com/unovue/reka-ui/blob/v2/packages/core/src/Listbox/ListboxRoot.vue#L168) because it alters the starting point of keyboard navigation (`Tab`) (it's not entirely clear why `scrollIntoView` has this effect). We can't simply remove `scrollIntoView`, though, as automatically scrolling to the highlighted item seems more important than the keyboard navigation starting point, unless more issues are reported.