### PR TITLE
Use `select` event instead f `click` in DropdownMenuItem demo

### DIFF
--- a/docs/components/demo/DropdownMenu/css/index.vue
+++ b/docs/components/demo/DropdownMenu/css/index.vue
@@ -25,7 +25,7 @@ const checkboxOne = ref(false)
 const checkboxTwo = ref(false)
 const person = ref('pedro')
 
-function handleClick() {
+function handleSelect() {
   // eslint-disable-next-line no-alert
   alert('hello!')
 }
@@ -48,7 +48,7 @@ function handleClick() {
         <DropdownMenuItem
           value="New Tab"
           class="DropdownMenuItem"
-          @click="handleClick"
+          @select="handleSelect"
         >
           New Tab
           <div

--- a/docs/components/demo/DropdownMenu/tailwind/index.vue
+++ b/docs/components/demo/DropdownMenu/tailwind/index.vue
@@ -24,7 +24,7 @@ const checkboxOne = ref(false)
 const checkboxTwo = ref(false)
 const person = ref('pedro')
 
-function handleClick() {
+function handleSelect() {
   // eslint-disable-next-line no-alert
   alert('hello!')
 }
@@ -47,7 +47,7 @@ function handleClick() {
         <DropdownMenuItem
           value="New Tab"
           class="group text-xs leading-none text-grass11 rounded-[3px] flex items-center h-[25px] px-[5px] relative pl-[25px] select-none outline-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:bg-green9 data-[highlighted]:text-green1"
-          @click="handleClick"
+          @select="handleSelect"
         >
           New Tab
           <div


### PR DESCRIPTION
Since the example / demo is most often the place developers look first, it would make sense to use the exposed `select` event here, instead of a generic `click` event.

Originally I had planned to open an issue, because when using the click event, I had some strange behavior when selecting an item: Despite the menu closing, the `pointer-events: none` style was still applied to the `body`element. Despite my best efforts, I was not able to create a minimal (not) working example. My best guess is some weird timing issues in the async functions I used. If I do manage to reproduce the behaviour, I will create an issue.

Short story is, when I used `select` instead of `click`, the `pointer-events: none;` was removed correctly, so maybe this will prevent others from running into the same issue. And, I do think regardless of a possible issue, documenting the `select` event does make more sense than the current `@click`. 