### PR TITLE
fix: check open when focusing menu items

### DIFF
--- a/packages/core/src/Menu/MenuItemImpl.vue
+++ b/packages/core/src/Menu/MenuItemImpl.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import { injectMenuContext } from './MenuRoot.vue'
 
 export interface MenuItemImplProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with the item. */
@@ -28,6 +29,7 @@ defineOptions({
 
 const props = defineProps<MenuItemImplProps>()
 
+const menuContext = injectMenuContext()
 const contentContext = injectMenuContentContext()
 const { forwardRef } = useForwardExpose()
 const { CollectionItem } = useCollection()
@@ -35,11 +37,9 @@ const { CollectionItem } = useCollection()
 const isFocused = ref(false)
 
 async function handlePointerMove(event: PointerEvent) {
-  if (event.defaultPrevented)
+  if (event.defaultPrevented || !isMouseEvent(event) || !menuContext.open.value) {
     return
-  if (!isMouseEvent(event))
-    return
-
+  }
   if (props.disabled) {
     contentContext.onItemLeave(event)
   }


### PR DESCRIPTION
Resolves https://github.com/unovue/reka-ui/issues/2101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed menu pointer interaction handling to properly respect menu open/closed state, preventing unnecessary pointer move events from being processed when the menu is not active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->