### PR TITLE
fix(Menu):  correct emitted event types to match runtime behavior

### DIFF
--- a/packages/core/src/Menu/MenuContent.vue
+++ b/packages/core/src/Menu/MenuContent.vue
@@ -4,7 +4,7 @@ import type {
   MenuRootContentTypeProps,
 } from './MenuContentImpl.vue'
 
-export type MenuContentEmits = Omit<MenuContentImplEmits, 'entryFocus' | 'openAutoFocus'>
+export type MenuContentEmits = MenuContentImplEmits
 
 export interface MenuContentProps extends MenuRootContentTypeProps {
   /**


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2118

The `entryFocus`/`openAutoFocus` events were removed in PR https://github.com/unovue/reka-ui/pull/665/files#diff-8c2f58c8ccca9f2d06c2bde73a649a7b23180c696e73ede751e31c6623b5254dR7. I'm not sure why, but this caused the event types to mismatch the runtime behavior (these events are still emitted). So, I think it's better to revert this type omitting change.