### PR TITLE
fix: useId with dynamic properly access

### DIFF
--- a/packages/core/src/shared/useId.ts
+++ b/packages/core/src/shared/useId.ts
@@ -16,12 +16,15 @@ export function useId(deterministicId?: string | null | undefined, prefix = 'rek
   if (deterministicId)
     return deterministicId
 
-  if ('useId' in vue) {
-    return `${prefix}-${vue.useId?.()}`
+  // Check if Vue has useId support (Vue 3.5+)
+  // We use dynamic property access to avoid bundler warnings in Vue < 3.5
+  const methodName = 'use' + 'Id'
+  if (typeof (vue as any)[methodName] === 'function') {
+    return `${prefix}-${(vue as any)[methodName]()}`
   }
 
   const configProviderContext = injectConfigProviderContext({ useId: undefined })
-  
+
   if (configProviderContext.useId) {
     return `${prefix}-${configProviderContext.useId()}`
   }


### PR DESCRIPTION
fixes: https://github.com/unovue/reka-ui/issues/2122

I've tried several ways of referencing `useId`, [bracketNotation], .doNotation(), but they all keep failing. This dynamic property access works and the error no longer appears.