### PR TITLE
feat(ContextMenu): support `pressOpenDelay` to configure the long-press duration

### DIFF
--- a/docs/content/meta/ContextMenuRoot.md
+++ b/docs/content/meta/ContextMenuRoot.md
@@ -13,6 +13,13 @@
     'type': 'boolean',
     'required': false,
     'default': 'true'
+  },
+  {
+    'name': 'pressOpenDelay',
+    'description': '<p>The duration from when the trigger is pressed until the menu openes.</p>\n',
+    'type': 'number',
+    'required': false,
+    'default': '700'
   }
 ]" />
 

--- a/packages/core/src/ContextMenu/ContextMenuRoot.vue
+++ b/packages/core/src/ContextMenu/ContextMenuRoot.vue
@@ -10,9 +10,17 @@ type ContextMenuRootContext = {
   modal: Ref<boolean>
   dir: Ref<Direction>
   triggerElement: Ref<HTMLElement | undefined>
+  pressOpenDelay: Ref<number>
 }
 
-export interface ContextMenuRootProps extends Omit<MenuProps, 'open'> {}
+export interface ContextMenuRootProps extends Omit<MenuProps, 'open'> {
+  /**
+   * The duration from when the trigger is pressed until the menu openes.
+   *
+   * @defaultValue 700
+   */
+  pressOpenDelay?: number
+}
 export type ContextMenuRootEmits = MenuEmits
 
 export const [injectContextMenuRootContext, provideContextMenuRootContext]
@@ -29,9 +37,10 @@ defineOptions({
 
 const props = withDefaults(defineProps<ContextMenuRootProps>(), {
   modal: true,
+  pressOpenDelay: 700,
 })
 const emits = defineEmits<ContextMenuRootEmits>()
-const { dir: propDir, modal } = toRefs(props)
+const { dir: propDir, modal, pressOpenDelay } = toRefs(props)
 useForwardExpose()
 const dir = useDirection(propDir)
 
@@ -46,6 +55,7 @@ provideContextMenuRootContext({
   dir,
   modal,
   triggerElement,
+  pressOpenDelay,
 })
 
 watch(open, (value) => {

--- a/packages/core/src/ContextMenu/ContextMenuTrigger.vue
+++ b/packages/core/src/ContextMenu/ContextMenuTrigger.vue
@@ -74,7 +74,10 @@ async function handlePointerDown(event: PointerEvent) {
     if (isTouchOrPen(event) && !event.defaultPrevented) {
       // clear the long press here in case there's multiple touch points
       clearLongPress()
-      longPressTimer.value = window.setTimeout(() => handleOpen(event), 700)
+      longPressTimer.value = window.setTimeout(
+        () => handleOpen(event),
+        rootContext.pressOpenDelay.value,
+      )
     }
   }
 }


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2123