### PR TITLE
fix (TagsInputInput.vue) - delimiter problems

### DIFF
--- a/packages/core/src/TagsInput/TagsInputInput.vue
+++ b/packages/core/src/TagsInput/TagsInputInput.vue
@@ -86,6 +86,11 @@ function handleInput(event: InputEvent) {
     const target = event.target as HTMLInputElement
     target.value = target.value.replace(delimiter, '')
 
+    if (target.value.trim() === '') {
+      target.value = ''
+      return
+    }
+
     const isAdded = context.onAddValue(target.value)
     if (isAdded)
       target.value = ''


### PR DESCRIPTION
(❤️ Updated: resolves https://github.com/unovue/reka-ui/issues/2137)

This code fixes several cases:

1.  Replace whole string with delimiter
2. Enter only delimiter
3. Enter space/spaces and then delemiter

Every one of these cases causes the creation of an empty tag


https://github.com/user-attachments/assets/8db89cf2-112a-401d-81d8-15517c2bcc0f

The first part of the video shows next  [Tags Input](https://reka-ui.com/docs/components/tags-input) cases.  Second part shows the same cases on the fixed version

1. Replacing "Orange" with ",".
2. "," - delimeter only
3. Few spaces + delimeter (using a different number of spaces leads to the creation of separate strings).