### PR TITLE
fix(TagsInputInput.vue): delimiter no longer works if input is empty …

### DIFF
--- a/packages/core/src/TagsInput/TagsInputInput.vue
+++ b/packages/core/src/TagsInput/TagsInputInput.vue
@@ -23,7 +23,24 @@ const props = withDefaults(defineProps<TagsInputInputProps>(), {
 
 const context = injectTagsInputRootContext()
 const { forwardRef, currentElement } = useForwardExpose()
-
+function handleTagAdd(value: string) {
+  if (context.allowEmptyTags.value) {
+    const isAdded = context.onAddValue(value)
+    if (isAdded)
+      value = ''
+  }
+  else {
+    if (value && value.trim()) {
+      const isAdded = context.onAddValue(value)
+      if (isAdded)
+        value = ''
+    }
+    else {
+      value = ''
+    }
+  }
+  return value
+}
 function handleBlur(event: Event) {
   context.selectedElement.value = undefined
 
@@ -33,10 +50,7 @@ function handleBlur(event: Event) {
   const target = event.target as HTMLInputElement
   if (!target.value)
     return
-
-  const isAdded = context.onAddValue(target.value)
-  if (isAdded)
-    target.value = ''
+  target.value = handleTagAdd(target.value)
 }
 
 function handleTab(event: Event) {
@@ -66,10 +80,7 @@ async function handleCustomKeydown(event: Event) {
   const target = event.target as HTMLInputElement
   if (!target.value)
     return
-
-  const isAdded = context.onAddValue(target.value)
-  if (isAdded)
-    target.value = ''
+  target.value = handleTagAdd(target.value)
 
   // prevent reloading when using inside of form
   event.preventDefault()
@@ -79,16 +90,12 @@ function handleInput(event: InputEvent) {
   context.isInvalidInput.value = false
   if (event.data === null)
     return
-
   const delimiter = context.delimiter.value
   const matchesDelimiter = delimiter === event.data || (delimiter instanceof RegExp && delimiter.test(event.data))
   if (matchesDelimiter) {
     const target = event.target as HTMLInputElement
     target.value = target.value.replace(delimiter, '')
-
-    const isAdded = context.onAddValue(target.value)
-    if (isAdded)
-      target.value = ''
+    target.value = handleTagAdd(target.value)
   }
 }
 
@@ -103,7 +110,8 @@ function handlePaste(event: ClipboardEvent) {
     if (context.delimiter.value) {
       const splitValue = value.split(context.delimiter.value)
       splitValue.forEach((v) => {
-        context.onAddValue(v)
+        handleTagAdd(v)
+        // context.onAddValue(v)
       })
     }
     else {

--- a/packages/core/src/TagsInput/TagsInputRoot.vue
+++ b/packages/core/src/TagsInput/TagsInputRoot.vue
@@ -33,6 +33,8 @@ export interface TagsInputRootProps<T = AcceptableInputValue> extends PrimitiveP
   convertValue?: (value: string) => T
   /** Display the value of the tag. Useful when you want to apply modifications to the value like adding a suffix or when using object as values */
   displayValue?: (value: T) => string
+  //* * Allow empty tags*/
+  allowEmptyTags?: boolean
 }
 
 export type TagsInputRootEmits<T = AcceptableInputValue> = {
@@ -62,6 +64,7 @@ export interface TagsInputRootContext<T = AcceptableInputValue> {
   max: Ref<number>
   id: Ref<string | undefined> | undefined
   displayValue: (value: T) => string
+  allowEmptyTags: Ref<boolean>
 }
 
 export const [injectTagsInputRootContext, provideTagsInputRootContext]
@@ -79,6 +82,7 @@ const props = withDefaults(defineProps<TagsInputRootProps<T>>(), {
   delimiter: ',',
   max: 0,
   displayValue: (value: T) => value.toString(),
+
 })
 const emits = defineEmits<TagsInputRootEmits<T>>()
 
@@ -89,7 +93,7 @@ defineSlots<{
   }) => any
 }>()
 
-const { addOnPaste, disabled, delimiter, max, id, dir: propDir, addOnBlur, addOnTab } = toRefs(props)
+const { addOnPaste, disabled, delimiter, max, id, dir: propDir, addOnBlur, addOnTab, allowEmptyTags } = toRefs(props)
 const dir = useDirection(propDir)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
@@ -233,6 +237,7 @@ provideTagsInputRootContext({
   max,
   id,
   displayValue: props.displayValue as (value: AcceptableInputValue) => string,
+  allowEmptyTags,
 })
 </script>
 


### PR DESCRIPTION
-added allowEmptyTags prop to TagInputRoot,vue.
-created handleTagAdd function in TagInputInput.vue that will check if empty tags are allowed or not.
#2137 