### PR TITLE
docs: fix StackBlitz playground

### DIFF
--- a/docs/codeeditor/index.ts
+++ b/docs/codeeditor/index.ts
@@ -82,7 +82,6 @@ function constructFiles(componentName: string, sources: Record<string, string>) 
     '@vitejs/plugin-vue': 'latest',
     'vue-tsc': 'latest',
     'tailwindcss': '^3.4.13',
-    'postcss': 'latest',
     'autoprefixer': 'latest',
     'typescript': 'latest',
   }

--- a/docs/codeeditor/index.ts
+++ b/docs/codeeditor/index.ts
@@ -3,8 +3,15 @@ import { getParameters } from 'codesandbox/lib/api/define'
 import { version } from '../../package.json'
 
 export function makeCodeSandboxParams(componentName: string, sources: Record<string, string>) {
-  let files = {}
+  let files: Record<string, any> = {}
   files = constructFiles(componentName, sources)
+  files['.codesandbox/Dockerfile'] = {
+    content: [
+      'FROM node:20',
+      'ENV COREPACK_ENABLE_DOWNLOAD_PROMPT = 0',
+      'RUN corepack enable',
+    ].join('\n'),
+  }
   return getParameters({ files, template: 'node' })
 }
 
@@ -41,13 +48,12 @@ export default defineConfig({
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
-        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Vite + Vue + TS</title>
       </head>
       <body>
         <div id="app"></div>
-        <script type="module" src="/src/main.ts"></script>
+        <script type="module" src="./src/main.ts"></script>
       </body>
     </html>
     `,
@@ -70,6 +76,7 @@ function constructFiles(componentName: string, sources: Record<string, string>) 
     'tailwindcss': '^3.4.13',
     'postcss': 'latest',
     'autoprefixer': 'latest',
+    'typescript': 'latest',
   }
 
   const componentFiles = Object.keys(sources).filter(key => key.endsWith('.vue') && key !== 'index.vue')
@@ -85,7 +92,13 @@ function constructFiles(componentName: string, sources: Record<string, string>) 
     'package.json': {
       content: {
         name: `reka-ui-${componentName.toLowerCase().replace(/ /g, '-')}`,
-        scripts: { start: 'vite' },
+        private: true,
+        version: '0.0.0',
+        type: 'module',
+        scripts: {
+          start: 'vite',
+          dev: 'vite',
+        },
         dependencies,
         devDependencies,
       },

--- a/docs/codeeditor/index.ts
+++ b/docs/codeeditor/index.ts
@@ -105,11 +105,11 @@ function constructFiles(componentName: string, sources: Record<string, string>) 
       isBinary: false,
     },
     ...viteConfig,
-    'tailwind.config.js': sources['tailwind.config.js'] && {
+    'tailwind.config.cjs': sources['tailwind.config.js'] && {
       content: sources['tailwind.config.js'],
       isBinary: false,
     },
-    'postcss.config.js': sources['tailwind.config.js'] && {
+    'postcss.config.cjs': sources['tailwind.config.js'] && {
       content: `module.exports = {
   plugins: {
     tailwindcss: {},

--- a/docs/codeeditor/index.ts
+++ b/docs/codeeditor/index.ts
@@ -7,10 +7,11 @@ export function makeCodeSandboxParams(componentName: string, sources: Record<str
   files = constructFiles(componentName, sources)
   files['.codesandbox/Dockerfile'] = {
     content: [
-      'FROM node:20',
+      'FROM node:23',
       'ENV COREPACK_ENABLE_DOWNLOAD_PROMPT = 0',
       'RUN corepack enable',
     ].join('\n'),
+    isBinary: false,
   }
   return getParameters({ files, template: 'node' })
 }
@@ -34,11 +35,18 @@ export function makeStackblitzParams(componentName: string, sources: Record<stri
 }
 
 const viteConfig = {
-  'vite.config.js': {
+  'vite.config.ts': {
     content: `import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import tailwind from 'tailwindcss'
+import autoprefixer from 'autoprefixer'
 
 export default defineConfig({
+  css: {
+    postcss: {
+      plugins: [tailwind(), autoprefixer()],
+    }
+  },
   plugins: [vue()],
 })`,
     isBinary: false,
@@ -92,12 +100,14 @@ function constructFiles(componentName: string, sources: Record<string, string>) 
     'package.json': {
       content: {
         name: `reka-ui-${componentName.toLowerCase().replace(/ /g, '-')}`,
+        description: `Demo project for ${componentName} from Reka UI`,
+        keywords: [],
         private: true,
         version: '0.0.0',
-        type: 'module',
         scripts: {
           start: 'vite',
           dev: 'vite',
+          serve: 'vite',
         },
         dependencies,
         devDependencies,
@@ -106,16 +116,7 @@ function constructFiles(componentName: string, sources: Record<string, string>) 
     },
     ...viteConfig,
     'tailwind.config.cjs': sources['tailwind.config.js'] && {
-      content: sources['tailwind.config.js'],
-      isBinary: false,
-    },
-    'postcss.config.cjs': sources['tailwind.config.js'] && {
-      content: `module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  }
-}`,
+      content: sources['tailwind.config.js'].replace('content: [\'./**/*.vue\']', 'content: [\'./src/**/*.{vue,ts,js}\', \'./index.html\']'),
       isBinary: false,
     },
     'src/main.ts': {

--- a/docs/components/CodeSandbox.vue
+++ b/docs/components/CodeSandbox.vue
@@ -28,7 +28,10 @@ defineProps<{
       :value="makeCodeSandboxParams(name, sources)"
     >
 
-    <Tooltip :content="`Open ${name} in CodeSandbox`">
+    <Tooltip
+      :content="`Open ${name} in CodeSandbox <br/><br/> (TailwindCSS is not working in sandbox)`"
+      class="break-words max-w-6"
+    >
       <button
         type="submit"
         aria-label="Open on CodeSandbox"

--- a/docs/components/CodeSandbox.vue
+++ b/docs/components/CodeSandbox.vue
@@ -22,16 +22,6 @@ defineProps<{
       value="file=src/App.vue"
     >
     <input
-      type="hidden"
-      name="environment"
-      value="server"
-    >
-    <input
-      type="hidden"
-      name="hidedevtools"
-      value="1"
-    >
-    <input
       :key="name"
       type="hidden"
       name="parameters"

--- a/docs/components/Tooltip.vue
+++ b/docs/components/Tooltip.vue
@@ -19,7 +19,10 @@ defineProps<{
         class="border border-muted data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-foreground select-none rounded-md bg-background px-[15px] py-[10px] text-xs leading-none will-change-[transform,opacity]"
         :side-offset="6"
       >
-        {{ content }}
+        <span
+          class="contents"
+          v-html="content"
+        />
       </TooltipContent>
     </TooltipPortal>
   </TooltipRoot>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "simple-git-hooks",
-      "unrs-resolver"
+      "unrs-resolver",
+      "vue-demi"
     ]
   },
   "simple-git-hooks": {


### PR DESCRIPTION
StackBlitz playgrounds are working fine now ✅ 

~~If anyone wants to create a repro, use this link https://0b1c95ee.reka-ui.pages.dev/docs/components/checkbox and create StackBlitz playground from there until this PR is reviewed and merged~~

Merged

---

But not Codesandbox ❌ 

CodeSandbox has two types

1. `sandbox`
 1.1 for small demos
 1.2 limited server/terminal features 
 1.3 can't control node version
 1.3 **`can`** be created dynamically with `https://codesandbox.io/api/v1/sandboxes/define`
 
 
 2. `devbox`
  2.1 **`can't`** be created dynamically with ``https://codesandbox.io/api/v1/sandboxes/define``
  

The SDK we are using is `codesandbox/lib/api/define` and `https://codesandbox.io/api/v1/sandboxes/define` API
The new one is `@codesandbox/sdk`, which I'm not familiar with. It also requires a `CSB_API_KEY`
 