### PR TITLE
docs: fix nav dropdown menu is behind the navbar

### DIFF
--- a/docs/.vitepress/components/DropdownMenu.vue
+++ b/docs/.vitepress/components/DropdownMenu.vue
@@ -26,7 +26,7 @@ defineProps<{
         position="popper"
         align="end"
         :side-offset="2"
-        class="z-10 bg-card border border-muted rounded-lg p-2 shadow-sm"
+        class="z-20 bg-card border border-muted rounded-lg p-2 shadow-sm"
       >
         <DropdownMenuItem
           v-for="item in items"


### PR DESCRIPTION
Close #2158

Fixes that the dropdown is hidden behind the navbar.

## before(current https://reka-ui.com/docs/overview/introduction , with page scrolled down)
<img width="1020" height="370" alt="image" src="https://github.com/user-attachments/assets/95bd0803-9af2-4ecd-b0fe-45921e073220" />

## after
<img width="1027" height="361" alt="image" src="https://github.com/user-attachments/assets/20f91834-83a9-47f1-9966-7bae81bbdace" />

closes #2158