### PR TITLE
#2160 Fix Select flicker

### DIFF
--- a/packages/core/src/Select/SelectContent.vue
+++ b/packages/core/src/Select/SelectContent.vue
@@ -66,7 +66,7 @@ watch(present, () => {
     </SelectContentImpl>
   </Presence>
 
-  <div v-else-if="fragment">
+  <div v-if="fragment">
     <Teleport :to="fragment">
       <SelectProvider :context="rootContext">
         <slot />


### PR DESCRIPTION
I have documented this issue in #2160, this PR contains a proposal to fix it.

My solution is, basically, to always render the options in the Fragment; regardless of whether the options are showing in the popover or not. I'm not sure if rendering them twice can have any unintended consequences, but from the few tests I've done, it seems to work fine.

Edit: Well, it seems the tests are not passing so I'm converting this to a draft 😅. I'll look into it, but in the meantime if someone comes across this I'd appreciate some feedback on whether this is the right fix.

Edit 2: I've look into the tests, and honestly they are too coupled to internals of how the component works. I think a maintainer should look at this before I waste any time trying to understand that, so I'm moving this back to Ready for review until I get some feedback.