### PR TITLE
docs: only support tailwind for previewing example component

### DIFF
--- a/docs/.vitepress/components/ComponentPreview.vue
+++ b/docs/.vitepress/components/ComponentPreview.vue
@@ -11,7 +11,7 @@ const props = withDefaults(defineProps<{
 }>(), { type: 'demo' })
 
 const cssFramework = useStorage<'css' | 'tailwind' | 'pinceau'>('cssFramework', 'tailwind')
-const parsedFiles = computed(() => JSON.parse(decodeURIComponent(props.files ?? ''))[cssFramework.value])
+const parsedFiles = computed(() => JSON.parse(decodeURIComponent(props.files ?? ''))[props.type === 'example' ? 'tailwind' : cssFramework.value])
 </script>
 
 <template>


### PR DESCRIPTION
When you set cssFramework as `css` somewhere else, there are no files for previewing.

step 1
<img width="840" height="228" alt="image" src="https://github.com/user-attachments/assets/71cb1590-95cb-4f72-8afd-a7c340dedf99" />

step 2
<img width="1379" height="496" alt="image" src="https://github.com/user-attachments/assets/2a2c0aa1-44e7-4b73-a146-d63a43408341" />

step 3
<img width="920" height="499" alt="image" src="https://github.com/user-attachments/assets/bc7b940d-1ab2-493d-97b9-698365d6b1a7" />
