### PR TITLE
fix(Tooltip): allow SVG as trigger

### DIFF
--- a/packages/core/src/shared/useGraceArea.ts
+++ b/packages/core/src/shared/useGraceArea.ts
@@ -44,7 +44,7 @@ export function useGraceArea(triggerElement: Ref<HTMLElement | undefined>, conta
   watchEffect((cleanupFn) => {
     if (pointerGraceArea.value) {
       const handleTrackPointerGrace = (event: PointerEvent) => {
-        if (!pointerGraceArea.value || !(event.target instanceof HTMLElement))
+        if (!pointerGraceArea.value || !(event.target instanceof Element))
           return
 
         const target = event.target


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2197

There are other places where we use `instance HTMLElement` as a guard (search for `instance HTMLElement` in the codebase); these might also need to change to `instanceof Element` to allow `SVGElement`. However, to minimize changes, I've left the others as they are for now, pending further reports.