### PR TITLE
fix(TagsInput): handle `number` and `bigint` in items

### DIFF
--- a/packages/core/src/TagsInput/TagsInputRoot.vue
+++ b/packages/core/src/TagsInput/TagsInputRoot.vue
@@ -5,7 +5,7 @@ import type { Direction, FormFieldProps } from '@/shared/types'
 import { computed, ref, toRefs } from 'vue'
 import { createContext, useArrowNavigation, useDirection, useFormControl, useForwardExpose } from '@/shared'
 
-export type AcceptableInputValue = string | Record<string, any>
+export type AcceptableInputValue = string | number | bigint | Record<string, any>
 
 export interface TagsInputRootProps<T = AcceptableInputValue> extends PrimitiveProps, FormFieldProps {
   /** The controlled value of the tags input. Can be bind as `v-model`. */


### PR DESCRIPTION
I added `number` and `bigint` in `AcceptableInputValue` to have consistent types when used inside a Combobox like on https://reka-ui.com/examples/combobox-tags-input 

I think it was better to update that type instead of using `AcceptableValue` to avoid a breaking change.

Related to https://github.com/nuxt/ui/issues/5018