### PR TITLE
fix: use `toValue` from Vue, but not from VueUse

### DIFF
--- a/packages/core/src/shared/useFormControl.ts
+++ b/packages/core/src/shared/useFormControl.ts
@@ -1,6 +1,6 @@
 import type { MaybeElementRef } from '@vueuse/core'
-import { toValue, unrefElement } from '@vueuse/core'
-import { computed } from 'vue'
+import { unrefElement } from '@vueuse/core'
+import { computed, toValue } from 'vue'
 
 export function useFormControl(el: MaybeElementRef) {
   // We set this to true by default so that events bubble to forms without JS (SSR)


### PR DESCRIPTION
The `toValue` utility function from VueUse is deprecated since v12 in favor of the same function from Vue itself.
In a recent release of VueUse v14, it was completely removed, which causes runtime errors.

This is the only place in Reka UI where an old `toValue` function was still used.