### PR TITLE
docs: add vuelor to showcase

### DIFF
--- a/docs/content/showcase.md
+++ b/docs/content/showcase.md
@@ -34,6 +34,11 @@ packages:
     url: https://unaui.com/
     image: https://unaui.com/hero.png
 
+  - title: Vuelor
+    description: A truly flexible, accessible, and Tailwind-ready color picker with developer experience in mind.
+    url: https://vuelor.dev/
+    image: https://vuelor.dev/og.jpg
+
 projects:
   - title: UnInbox
     description: Modern email for teams and professionals.


### PR DESCRIPTION
Added a new package to the Showcase section of the docs — [Vuelor](https://vuelor.dev/), a color picker component built with Reka UI and Tailwind CSS.