### PR TITLE
fix(Editable): ensure `submit` always emits the latest value

### DIFF
--- a/packages/core/src/Editable/Editable.test.ts
+++ b/packages/core/src/Editable/Editable.test.ts
@@ -8,7 +8,11 @@ import Editable from './story/_Editable.vue'
 
 const kbd = useTestKbd()
 
-function setup(props: { editableProps?: EditableRootProps, emits?: { 'onUpdate:modelValue'?: (data: string) => void } } = {}) {
+function setup(props: {
+  editableProps?: EditableRootProps
+  onSubmit?: (data: string) => void
+  emits?: { 'onUpdate:modelValue'?: (data: string) => void }
+} = {}) {
   const user = userEvent.setup()
   const returned = render(Editable, { props })
   const editable = returned.getByTestId('root')
@@ -83,12 +87,18 @@ describe('editable', () => {
   })
 
   it('submits the value when pressing enter', async () => {
-    const { input, preview, rerender } = setup({ editableProps: { modelValue: '', submitMode: 'enter' }, emits: { 'onUpdate:modelValue': (data: string) => rerender({ modelValue: data }) } })
+    let submittedValue = ''
+    const { input, preview, rerender } = setup({
+      editableProps: { modelValue: '', submitMode: 'enter' },
+      onSubmit: data => submittedValue = data,
+      emits: { 'onUpdate:modelValue': (data: string) => rerender({ modelValue: data }) },
+    })
 
     await userEvent.type(input, 'New Value')
     await userEvent.keyboard(kbd.ENTER)
     expect(preview).toBeVisible()
     expect(preview).toHaveTextContent('New Value')
+    expect(submittedValue).toBe('New Value')
   })
 
   it('submits the value on blur', async () => {

--- a/packages/core/src/Editable/EditableRoot.vue
+++ b/packages/core/src/Editable/EditableRoot.vue
@@ -168,7 +168,7 @@ function submit() {
   isEditing.value = false
 
   emits('update:state', 'submit')
-  emits('submit', modelValue.value)
+  emits('submit', inputValue.value)
 }
 
 function handleDismiss() {


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2277