### PR TITLE
fix: range highlight in range calendar

### DIFF
--- a/packages/core/src/RangeCalendar/RangeCalendar.test.ts
+++ b/packages/core/src/RangeCalendar/RangeCalendar.test.ts
@@ -818,4 +818,24 @@ describe('handles maximumDays', () => {
     expect(getByTestId('date-1-18')).toHaveAttribute('aria-disabled', 'true')
     expect(getByTestId('date-1-17')).not.toHaveAttribute('aria-disabled', 'true')
   })
+
+  it('highlights dates within the maximum range identical to disabled dates range', async () => {
+    const { getByTestId, user } = setup({
+      calendarProps: {
+        placeholder: new CalendarDate(1980, 1, 15),
+        maximumDays: 4,
+      },
+    })
+    const startDay = getByTestId('date-1-15')
+    const secondDay = getByTestId('date-1-16') // same day
+    const maximumDay = getByTestId('date-1-18') // 4 days ahead
+    const beyondMaximumDay = getByTestId('date-1-19') // 5 days ahead
+    await user.click(startDay)
+    await user.hover(secondDay)
+    expect(startDay).toHaveAttribute('data-selection-start')
+    expect(secondDay).toHaveAttribute('data-highlighted')
+    expect(maximumDay).toHaveAttribute('data-highlighted-end')
+    expect(maximumDay).toHaveAttribute('data-highlighted')
+    expect(beyondMaximumDay).not.toHaveAttribute('data-highlighted')
+  })
 })

--- a/packages/core/src/RangeCalendar/story/RangeCalendarValidation.story.vue
+++ b/packages/core/src/RangeCalendar/story/RangeCalendarValidation.story.vue
@@ -55,6 +55,13 @@ const maxValue = new CalendarDate(2024, 2, 20)
         :max-value="maxValue"
       />
     </Variant>
+
+    <Variant title="Maximum Days">
+      <RangeCalendar
+        :default-value="defaultValue"
+        :maximum-days="5"
+      />
+    </Variant>
   </Story>
 </template>
 ..

--- a/packages/core/src/RangeCalendar/useRangeCalendar.ts
+++ b/packages/core/src/RangeCalendar/useRangeCalendar.ts
@@ -131,7 +131,7 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
     if (props.maximumDays?.value && !props.end.value) {
       // Determine the direction of selection and limit to maximum days
       const cappedEnd = isStartBeforeFocused
-        ? start.add({ days: props.maximumDays.value })
+        ? start.add({ days: props.maximumDays.value - 1 })
         : start.subtract({ days: props.maximumDays.value })
 
       return {


### PR DESCRIPTION
I noticed that when you provide maximumDays prop to the RangeCalendar. It highlights date further then the date possible to select. Here is the fix to it. 
both are examples with maximum-days = 5
Before: 
<img width="430" height="445" alt="image" src="https://github.com/user-attachments/assets/81cf1c77-53e3-47d1-9664-df5a9425521f" />

After: 
(Only the clickable dates are highlighted) 
<img width="635" height="512" alt="image" src="https://github.com/user-attachments/assets/90232d8b-20b0-4842-a0e3-16ee5a7f73c1" />
 
I have already joined your discord channel, my discord id: limzikiki 
