### PR TITLE
feat(SelectContent): add `disableOutsidePointerEvents` prop

### DIFF
--- a/packages/core/src/Select/SelectContentImpl.vue
+++ b/packages/core/src/Select/SelectContentImpl.vue
@@ -3,7 +3,7 @@ import type {
   ComponentPublicInstance,
   Ref,
 } from 'vue'
-import type { PointerDownOutsideEvent } from '@/DismissableLayer'
+import type { DismissableLayerProps, PointerDownOutsideEvent } from '@/DismissableLayer'
 import type { PopperContentProps } from '@/Popper'
 import type { AcceptableValue } from '@/shared/types'
 import { useCollection } from '@/Collection'
@@ -60,7 +60,7 @@ export type SelectContentImplEmits = {
   pointerDownOutside: [event: PointerDownOutsideEvent]
 }
 
-export interface SelectContentImplProps extends PopperContentProps {
+export interface SelectContentImplProps extends PopperContentProps, DismissableLayerProps {
   /**
    *  The positioning mode to use
    *
@@ -99,6 +99,7 @@ const props = withDefaults(defineProps<SelectContentImplProps>(), {
   align: 'start',
   position: 'item-aligned',
   bodyLock: true,
+  disableOutsidePointerEvents: true,
 })
 const emits = defineEmits<SelectContentImplEmits>()
 
@@ -285,7 +286,7 @@ provideSelectContentContext({
     >
       <DismissableLayer
         as-child
-        disable-outside-pointer-events
+        :disable-outside-pointer-events="disableOutsidePointerEvents"
         @focus-outside.prevent
         @dismiss="rootContext.onOpenChange(false)"
         @escape-key-down="emits('escapeKeyDown', $event)"


### PR DESCRIPTION
Related to https://github.com/unovue/reka-ui/issues/1670, https://github.com/nuxt/ui/issues/4956

This PR lets you override the SelectContent with `:disable-outside-pointer-events="false"` to avoid adding `pointer-events: none;` on the body, to be used alongside `:body-lock="false"` which matches the implementation of Combobox.

Is there a reason there are no `:modal="false"` prop for those components like on Dialog, DropdownMenu, Popover, etc?