### PR TITLE
feat(ListboxVirtualizer/TreeVirtualizer): handle `estimateSize` as function

### DIFF
--- a/packages/core/src/Listbox/ListboxVirtualizer.vue
+++ b/packages/core/src/Listbox/ListboxVirtualizer.vue
@@ -5,7 +5,7 @@ export interface ListboxVirtualizerProps<T extends AcceptableValue = AcceptableV
   /** Number of items rendered outside the visible area */
   overscan?: number
   /** Estimated size (in px) of each item */
-  estimateSize?: number
+  estimateSize?: number | ((index: number) => number)
   /** Text content for each item to achieve type-ahead feature */
   textContent?: (option: T) => string
 }
@@ -64,7 +64,10 @@ const virtualizer = useVirtualizer(
     get scrollPaddingEnd() { return padding.value.end },
     get count() { return props.options.length },
     get horizontal() { return rootContext.orientation.value === 'horizontal' },
-    estimateSize() {
+    estimateSize(index) {
+      if (typeof props.estimateSize === 'function')
+        return props.estimateSize(index)
+
       return props.estimateSize ?? 28
     },
     getScrollElement() { return parentEl.value },

--- a/packages/core/src/Tree/TreeVirtualizer.vue
+++ b/packages/core/src/Tree/TreeVirtualizer.vue
@@ -3,7 +3,7 @@ export interface TreeVirtualizerProps {
   /** Number of items rendered outside the visible area */
   overscan?: number
   /** Estimated size (in px) of each item */
-  estimateSize?: number
+  estimateSize?: number | ((index: number) => number)
   /** Text content for each item to achieve type-ahead feature */
   textContent?: (item: Record<string, any>) => string
 }
@@ -79,7 +79,10 @@ const virtualizer = useVirtualizer(
     getItemKey(index) {
       return index + rootContext.getKey(rootContext.expandedItems.value[index].value)
     },
-    estimateSize() {
+    estimateSize(index) {
+      if (typeof props.estimateSize === 'function')
+        return props.estimateSize(index)
+
       return props.estimateSize ?? 28
     },
     getScrollElement() { return parentEl.value },


### PR DESCRIPTION
This PR lets you use `estimateSize` as a function which receives the item index as implemented in TanStack Virtual: https://tanstack.com/virtual/latest/docs/api/virtualizer#estimatesize