### PR TITLE
fix(DateField): prevent day value from being incorrectly constrained …

### DIFF
--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -46,7 +46,15 @@ function commonSegmentAttrs(props: SegmentAttrProps) {
 function daySegmentAttrs(props: SegmentAttrProps) {
   const { segmentValues, placeholder } = props
   const isEmpty = segmentValues.day === null
-  const date = segmentValues.day ? placeholder.set({ day: segmentValues.day }) : placeholder
+
+  // Include month from segmentValues to ensure correct max days calculation
+  const dateFields: { day?: number, month?: number } = {}
+  if (segmentValues.day)
+    dateFields.day = segmentValues.day
+  if (segmentValues.month)
+    dateFields.month = segmentValues.month
+
+  const date = Object.keys(dateFields).length > 0 ? placeholder.set(dateFields) : placeholder
 
   const valueNow = date.day
   const valueMin = 1
@@ -864,12 +872,9 @@ export function useDateField(props: UseDateFieldProps) {
       if (Object.values(props.segmentValues.value).every(item => item !== null)) {
         const updateObject = { ...props.segmentValues.value as Record<AnyExceptLiteral, number> }
 
-        let dateRef = props.placeholder.value.copy()
-
-        Object.keys(updateObject).forEach((part) => {
-          const value = updateObject[part as AnyExceptLiteral]
-          dateRef = dateRef.set({ [part]: value })
-        })
+        // Set all date fields at once to avoid order-dependent constraints
+        // (e.g., setting day: 31 before month: 3 would incorrectly constrain the day)
+        const dateRef = props.placeholder.value.set(updateObject)
 
         props.modelValue.value = dateRef.copy()
       }


### PR DESCRIPTION
…during input

When entering dates like "3/31/" and starting to type the year, the day was
incorrectly changed from 31 to 30. This occurred because date fields were
being set sequentially (day before month), causing the @internationalized/date
library to constrain the day based on the placeholder's month instead of the
user-entered month.


https://github.com/user-attachments/assets/b3ac1c7f-42d7-4543-acf0-1d107dd0a874


Changes:
- Set all date fields simultaneously in handleSegmentKeydown to avoid order-dependent constraints
- Include month from segmentValues in daySegmentAttrs for correct aria-valuemax calculation

Fixes issue where months with 31 days would be constrained to 30 or fewer
days during initial input.