### PR TITLE
Ensure FocusScope adheres to the Dialog WAI-ARIA design pattern

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -37,7 +37,7 @@ export interface FocusScopeProps extends PrimitiveProps {
 import { isClient } from '@vueuse/shared'
 import { nextTick, reactive, ref, watchEffect } from 'vue'
 import { Primitive } from '@/Primitive'
-import { createFocusScopesStack, removeLinks } from './stack'
+import { createFocusScopesStack } from './stack'
 import {
   AUTOFOCUS_ON_MOUNT,
   AUTOFOCUS_ON_UNMOUNT,
@@ -152,7 +152,7 @@ watchEffect(async (cleanupFn) => {
     container.dispatchEvent(mountEvent)
 
     if (!mountEvent.defaultPrevented) {
-      focusFirst(removeLinks(getTabbableCandidates(container)), {
+      focusFirst(getTabbableCandidates(container), {
         select: true,
       })
       if (getActiveElement() === previouslyFocusedElement)


### PR DESCRIPTION
Per the documentation for the popover component, the popover component adheres to the Dialog WAI-ARIA design pattern: https://reka-ui.com/docs/components/popover#accessibility

However, when testing, if the popover contains a list of links and then a button, the focus will go to the button, not the link. From my understanding of the design pattern, this isn't correct as links are focusable elements too.

I'm not sure why it was originally like this - the PR that added the code doesn't give any details and there's no comments on the function or usages: https://github.com/unovue/reka-ui/pull/281

(the pattern can be found here: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)

----

This is my first contribution to this project - you don't have a CONTRIBUTING.md so let me know if I've done anything wrong! I'm just joined your discord too if that's quicker than communicating here :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined focus scope initialization to optimize which elements are eligible for focus assignment when components mount, improving initial focus behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->