### PR TITLE
fix(Tree): don't mutate the expanded state

### DIFF
--- a/packages/core/src/Tree/TreeRoot.vue
+++ b/packages/core/src/Tree/TreeRoot.vue
@@ -254,7 +254,7 @@ provideTreeRootContext({
     if (expanded.value.includes(key))
       expanded.value = expanded.value.filter(val => val !== key)
     else
-      expanded.value.push(key)
+      expanded.value = [...expanded.value, key]
   },
   getKey: props.getKey,
   getChildren: props.getChildren,


### PR DESCRIPTION
I was wondering why the tree wasn't opening properly, turns out the component is mutating the array rather than reassigning the state