### PR TITLE
docs(Primitive): fixed broken link to composition guide

### DIFF
--- a/docs/content/docs/utilities/primitive.md
+++ b/docs/content/docs/utilities/primitive.md
@@ -27,7 +27,7 @@ When you are building a component, in some cases you might want to allow user to
       required: false,
       type: 'boolean',
       default: 'false',
-      description: '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.<br><br>Read our <a href=&quot;/guides/composition&quot;>Composition</a> guide for more details.</p>',
+      description: '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.<br><br>Read our <a href=&quot;/docs/guides/composition&quot;>Composition</a> guide for more details.</p>',
     }
   ]"
 />


### PR DESCRIPTION
Fixed broken link to the composition guide page. Old link was missing `/docs`