### PR TITLE
Fix Tree docs not mentioning a Space keybind

### DIFF
--- a/docs/content/docs/components/tree.md
+++ b/docs/content/docs/components/tree.md
@@ -328,7 +328,7 @@ Adheres to the [Tree WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/pa
 <KeyboardTable
   :data="[
     {
-      keys: ['Enter'],
+      keys: ['Enter', 'Space'],
       description: 'When highlight on <code>TreeItem</code>, selects the focused item.',
     },
     {


### PR DESCRIPTION
https://github.com/unovue/reka-ui/blob/58179ec8f877c15bf547271a84546b4c6728ac3c/packages/core/src/Tree/TreeItem.vue#L180