### PR TITLE
fix(Combobox): don't focus the trigger element after closing

### DIFF
--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { DismissableLayerEmits, DismissableLayerProps } from '@/DismissableLayer'
 import type { PopperContentProps } from '@/Popper'
 
-import { createContext, useForwardExpose, useForwardProps, useHideOthers } from '@/shared'
+import { createContext, getActiveElement, useForwardExpose, useForwardProps, useHideOthers } from '@/shared'
 import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 
 export type ComboboxContentImplEmits = DismissableLayerEmits
@@ -26,7 +26,7 @@ export const [injectComboboxContentContext, provideComboboxContentContext]
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, toRefs } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { ListboxContent } from '@/Listbox'
 import { PopperContent } from '@/Popper'
@@ -76,6 +76,13 @@ onMounted(() => {
     if (isInputWithinContent.value) {
       rootContext.inputElement.value.focus()
     }
+  }
+})
+
+onUnmounted(() => {
+  const activeElement = getActiveElement()
+  if (isInputWithinContent.value && (!activeElement || activeElement === document.body)) {
+    rootContext.triggerElement.value?.focus()
   }
 })
 </script>

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -26,7 +26,7 @@ export const [injectComboboxContentContext, provideComboboxContentContext]
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue'
+import { computed, onMounted, ref, toRefs } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { ListboxContent } from '@/Listbox'
 import { PopperContent } from '@/Popper'
@@ -76,12 +76,6 @@ onMounted(() => {
     if (isInputWithinContent.value) {
       rootContext.inputElement.value.focus()
     }
-  }
-})
-
-onUnmounted(() => {
-  if (isInputWithinContent.value) {
-    rootContext.triggerElement.value?.focus()
   }
 })
 </script>


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2236

It seems like the auto-focusing of the trigger element after closing could cause issues like https://github.com/unovue/reka-ui/issues/2236. 
Also, suppose a user clicks another input element while the combobox is open, that input won't be focused; instead, the focus will quickly shift from the input element back to the combobox trigger element, which I imagine isn't the desired behavior.