### PR TITLE
feat(Menu): allow more value types

### DIFF
--- a/packages/core/src/Menu/MenuRadioGroup.vue
+++ b/packages/core/src/Menu/MenuRadioGroup.vue
@@ -1,21 +1,22 @@
 <script lang="ts">
 import type { Ref } from 'vue'
 import type { MenuGroupProps } from './MenuGroup.vue'
+import type { AcceptableValue } from '@/shared/types'
 import { createContext, useForwardProps } from '@/shared'
 
 interface MenuRadioGroupContext {
-  modelValue: Ref<string>
-  onValueChange: (payload: string) => void
+  modelValue: Ref<AcceptableValue>
+  onValueChange: (payload: AcceptableValue) => void
 }
 
 export interface MenuRadioGroupProps extends MenuGroupProps {
   /** The value of the selected item in the group. */
-  modelValue?: string
+  modelValue?: AcceptableValue
 }
 
 export type MenuRadioGroupEmits = {
   /** Event handler called when the value changes. */
-  'update:modelValue': [payload: string]
+  'update:modelValue': [payload: AcceptableValue]
 }
 
 export const [injectMenuRadioGroupContext, provideMenuRadioGroupContext]

--- a/packages/core/src/Menu/MenuRadioItem.vue
+++ b/packages/core/src/Menu/MenuRadioItem.vue
@@ -3,6 +3,7 @@ import type {
   MenuItemEmits,
   MenuItemProps,
 } from './MenuItem.vue'
+import type { AcceptableValue } from '@/shared/types'
 import { reactiveOmit } from '@vueuse/shared'
 import { useForwardProps } from '@/shared'
 
@@ -10,7 +11,7 @@ export type MenuRadioItemEmits = MenuItemEmits
 
 export interface MenuRadioItemProps extends MenuItemProps {
   /** The unique value of the item. */
-  value: string
+  value: AcceptableValue
 }
 </script>
 


### PR DESCRIPTION
Currently MenuRadioGroup only accepts strings as model value in terms of typing, but it actually works just fine with other types.

I have cases where I would like to have numbers or just `null` as a value without having to create a proxy that convert the values from and to strings. The current types doesn’t allow me to do so, so here’s a contribution to fix that.