### PR TITLE
test(focus-scope): shadow root issue example

### DIFF
--- a/packages/core/src/Combobox/story/ComboboxShadowRoot.story.vue
+++ b/packages/core/src/Combobox/story/ComboboxShadowRoot.story.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import type { Component } from 'vue'
+import { createApp, useTemplateRef, watch } from 'vue'
+
+import _Dialog from './_Dialog.vue'
+
+const options = [
+  { name: 'Fruit', children: [
+    { name: 'Apple' },
+    { name: 'Banana' },
+    { name: 'Orange' },
+    { name: 'Honeydew' },
+    { name: 'Grapes' },
+    { name: 'Watermelon' },
+    { name: 'Cantaloupe' },
+    { name: 'Pear' },
+  ] },
+  { name: 'Vegetable', children: [
+    { name: 'Cabbage' },
+    { name: 'Broccoli' },
+    { name: 'Carrots' },
+    { name: 'Lettuce' },
+    { name: 'Spinach' },
+    { name: 'Bok Choy' },
+    { name: 'Cauliflower' },
+    { name: 'Potatoes' },
+  ] },
+]
+
+function mountShadowRoot(container: HTMLDivElement, component: Component) {
+  const elementWithShadow = container as Element & { shadowRoot: ShadowRoot | null }
+  const shadowRoot
+    = elementWithShadow.shadowRoot || elementWithShadow.attachShadow({ mode: 'open' })
+
+  document.querySelectorAll('style, link[rel="stylesheet"]').forEach((node) => {
+    shadowRoot.appendChild(node.cloneNode(true))
+  })
+
+  const shadowMountPoint = document.createElement('div')
+  shadowRoot.appendChild(shadowMountPoint)
+
+  const shadowPortalTarget = document.createElement('div')
+  shadowPortalTarget.id = `portal-shadow-root`
+  shadowRoot.appendChild(shadowPortalTarget)
+
+  createApp(component, {
+    dialogPortalTarget: shadowPortalTarget,
+  }).mount(shadowMountPoint)
+}
+
+function resetShadowRoot(container: HTMLDivElement) {
+  const elementWithShadow = container as Element & { shadowRoot: ShadowRoot | null }
+  if (elementWithShadow.shadowRoot) {
+    elementWithShadow.shadowRoot.innerHTML = ''
+  }
+}
+
+const container = useTemplateRef('container')
+
+watch(
+  container,
+  (newVal) => {
+    if (newVal) {
+      resetShadowRoot(newVal)
+      mountShadowRoot(newVal, _Dialog)
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <Story
+    title="Combobox/ShadowRoot"
+    :layout="{ type: 'single', iframe: false }"
+  >
+    <Variant title="default">
+      <div
+        id="shadow-root-container"
+        ref="container"
+        class="h-96"
+      />
+    </Variant>
+  </Story>
+</template>

--- a/packages/core/src/Combobox/story/_Dialog.vue
+++ b/packages/core/src/Combobox/story/_Dialog.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ref } from 'vue'
+import {
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+} from '../../Dialog'
+import ComboboxManualFilter from './_ComboboxManualFilter.vue'
+
+defineProps<{ dialogPortalTarget: HTMLDivElement }>()
+const dialogOpen = ref(false)
+</script>
+
+<template>
+  <DialogRoot v-model:open="dialogOpen">
+    <DialogTrigger
+      class="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
+    >
+      Edit profile
+    </DialogTrigger>
+    <DialogPortal :to="dialogPortalTarget">
+      <Transition name="fade">
+        <DialogOverlay
+          class="bg-blackA9 fixed inset-0"
+        />
+      </Transition>
+      <Transition name="fade">
+        <DialogContent
+          :is-escape-key-down-default="true"
+          class="fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none"
+          @pointer-down-outside.prevent
+        >
+          <DialogTitle class="text-mauve12 m-0 text-[17px] font-medium">
+            Edit profile
+          </DialogTitle>
+          <ComboboxManualFilter />
+          <div class="mt-[25px] flex justify-end">
+            <DialogClose as-child>
+              <button
+                class="bg-green4 text-green11 hover:bg-green5 focus:shadow-green7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-medium leading-none focus:shadow-[0_0_0_2px] focus:outline-none"
+              >
+                Save changes
+              </button>
+            </DialogClose>
+          </div>
+          <DialogClose
+            class="text-violet11 hover:bg-violet4 focus:shadow-violet7 absolute top-[10px] right-[10px] inline-flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-full focus:shadow-[0_0_0_2px] focus:outline-none"
+            aria-label="Close"
+          >
+            <Icon icon="lucide:x" />
+          </DialogClose>
+        </DialogContent>
+      </Transition>
+    </DialogPortal>
+  </DialogRoot>
+</template>
+
+<style>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
#1667 

This is a reproduction branch about the focus isse mentionnedn in #1667 :
> When using an input field inside a Dialog that dynamically updates content within the Dialog, the focus keeps switching back to DialogContent, disrupting the user experience.


## What is not working
When rendering a `Dialog`component (or anything that can be teleported) into the shadow root.
Then rendering another component that will update the DOM (here a combobox opening a list) at some point.
If we have the focus on the inner component (e.g. combobox) when the DOM is updated, we loose the focus.

## How to reproduce

- clone the repo
- install dependencies
- run `pnpm story:dev`
- wait for all stories to load
- go on http://localhost:6006/__sandbox.html?storyId=packages-core-src-combobox-story-comboboxshadowroot-story-vue&variantId=packages-core-src-combobox-story-comboboxshadowroot-story-vue-0
- click on the button to open the dialog inside the shadow root
- focus the input inside the dialog (by click on keyboard)
- start typing inside the input
- you should loose the focus


### Expected behaviour
The focus should not be lost.
Here is an example of how it should behave.

> [!NOTE]  
> Here everything is teleported into the body so it's working. It would be nice to have it working inside the shadow-root:

https://github.com/user-attachments/assets/3f13ced8-7fe3-4bf3-a6d5-ff7b0fb3a3ff

### Faulty behaviour
Here, everything is mounted into shadow-root, the portal target as well. So the `Dialog` overlay and content will mount inside the portal-target within shadow root. The `Combobox` will be mounted inside the `Dialog` content, and its list will be rendered inline.
The focus is lost when we start typing and the list is shown:

https://github.com/user-attachments/assets/f39823a1-deb3-4d1e-9f00-e0184f408570

