### PR TITLE
fix(ComboboxCancel): reset model value on clear without requiring input

### DIFF
--- a/packages/core/src/Combobox/ComboboxCancel.vue
+++ b/packages/core/src/Combobox/ComboboxCancel.vue
@@ -23,9 +23,10 @@ function handleClick() {
   if (rootContext.inputElement.value) {
     rootContext.inputElement.value.value = ''
     rootContext.inputElement.value.focus()
-    if (rootContext.resetModelValueOnClear?.value) {
-      rootContext.modelValue.value = rootContext.multiple.value ? [] : null
-    }
+  }
+
+  if (rootContext.resetModelValueOnClear?.value) {
+    rootContext.modelValue.value = rootContext.multiple.value ? [] : null
   }
 }
 </script>


### PR DESCRIPTION
## Description

The `ComboboxCancel` component's `resetModelValueOnClear` logic is currently nested inside the `if (rootContext.inputElement.value)` check, which means the model value is only reset when an input element exists in the DOM.

This causes issues when using `ComboboxCancel` with combobox implementations where the input is inside the content (e.g., Nuxt UI [SelectMenu](https://ui.nuxt.com/docs/components/select-menu) component). In these cases, when the dropdown is closed, there's no input element mounted, and clicking the clear button does nothing.

## Changes

Move the `resetModelValueOnClear` logic outside the input element check so the model value is always reset regardless of whether an input element is present.
