### PR TITLE
fix(useHideOthers): fix edge case with useHideOthers when nested in a a native popover

### DIFF
--- a/packages/core/src/shared/useHideOthers.ts
+++ b/packages/core/src/shared/useHideOthers.ts
@@ -16,7 +16,8 @@ export function useHideOthers(target: MaybeElementRef) {
     // disable hideOthers on test mode
     if (import.meta.env.MODE === 'test')
       return
-    if (el)
+    // Skip if inside a closed native popover
+    if (el && !el.closest('[popover]:not(:popover-open)'))
       undo = hideOthers(el)
     else if (undo)
       undo()


### PR DESCRIPTION
resolves #2240

this should also fix it for other elements that are using native popover.

## Summary
  Fixes `useHideOthers` applying `aria-hidden` when nested inside a closed native popover.

## Problem
  When a component using `useHideOthers` is inside a native `<div popover>`, it runs even when the popover is closed.

## Solution
  Skip `hideOthers` when inside a closed native popover. This is a simple non-reactive fix. It doesn't track when the popover opens/closes. Could be made reactive if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed behavior of native popovers to properly manage visibility of surrounding elements when popovers are closed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->