### PR TITLE
fix(useForwardExpose): expose specified ref properties to parent ref

### DIFF
--- a/packages/core/src/shared/useForwardExpose.test.ts
+++ b/packages/core/src/shared/useForwardExpose.test.ts
@@ -162,4 +162,136 @@ describe('useForwardRef', async () => {
     await flushPromises()
     expect(wrapper.attributes('test')).toBe('[object HTMLSpanElement]')
   })
+
+  // PR #2339: Test that child component's expose properties are correctly merged into parent's expose
+  it('should forward child component exposed properties to parent ref', async () => {
+    // Define an inner component with expose
+    const InnerComp = defineComponent({
+      setup(_, { expose }) {
+        const innerValue = ref('inner-value')
+        const innerMethod = () => 'inner-method-result'
+        // Child component exposes its properties and methods
+        expose({ innerValue, innerMethod })
+        return () => h('span', {}, 'inner component')
+      },
+    })
+
+    // Middle component using useForwardExpose
+    const comp = defineComponent({
+      components: { InnerComp },
+      setup() {
+        const { forwardRef } = useForwardExpose()
+        return { forwardRef }
+      },
+      template: `
+        <div>
+          <InnerComp :ref="forwardRef" />
+        </div>
+      `,
+    })
+
+    // Parent component accesses via ref
+    const parentRef = ref<any>()
+    const wrapper = mount(
+      defineComponent(() => {
+        return () => h('div', {}, [h(comp, { ref: parentRef })])
+      }),
+    )
+
+    await flushPromises()
+    // Verify child component's exposed properties are accessible through parent ref
+    expect(parentRef.value?.innerValue).toBe('inner-value')
+    expect(parentRef.value?.innerMethod()).toBe('inner-method-result')
+  })
+
+  it('should merge child component exposed properties with parent component props', async () => {
+    // Define an inner component with expose
+    const InnerComp = defineComponent({
+      setup(_, { expose }) {
+        const childExposedValue = ref('child-exposed')
+        expose({ childExposedValue })
+        return () => h('span', {}, 'inner component')
+      },
+    })
+
+    // Middle component using useForwardExpose, also receiving props
+    const comp = defineComponent({
+      components: { InnerComp },
+      props: {
+        parentProp: {
+          type: String,
+          default: 'parent-prop-value',
+        },
+      },
+      setup() {
+        const { forwardRef } = useForwardExpose()
+        return { forwardRef }
+      },
+      template: `
+        <div>
+          <InnerComp :ref="forwardRef" />
+        </div>
+      `,
+    })
+
+    const parentRef = ref<any>()
+    const wrapper = mount(
+      defineComponent(() => {
+        return () =>
+          h('div', {}, [h(comp, { ref: parentRef, parentProp: 'custom-value' })])
+      }),
+    )
+
+    await flushPromises()
+    // Verify both parent's props and child's expose are accessible
+    expect(parentRef.value?.parentProp).toBe('custom-value')
+    expect(parentRef.value?.childExposedValue).toBe('child-exposed')
+    expect(parentRef.value?.$el).toBeInstanceOf(HTMLSpanElement)
+  })
+
+  it('should forward multiple exposed properties from child component', async () => {
+    // Inner component exposing multiple properties and methods
+    const InnerComp = defineComponent({
+      setup(_, { expose }) {
+        const count = ref(0)
+        const message = ref('hello')
+        const increment = () => count.value++
+        const getMessage = () => message.value
+        // Expose multiple properties and methods
+        expose({ count, message, increment, getMessage })
+        return () => h('button', {}, 'inner')
+      },
+    })
+
+    // Component using useForwardExpose
+    const comp = defineComponent({
+      components: { InnerComp },
+      setup() {
+        const { forwardRef } = useForwardExpose()
+        return { forwardRef }
+      },
+      template: `
+        <div>
+          <InnerComp :ref="forwardRef" />
+        </div>
+      `,
+    })
+
+    const parentRef = ref<any>()
+    const wrapper = mount(
+      defineComponent(() => {
+        return () => h('div', {}, [h(comp, { ref: parentRef })])
+      }),
+    )
+
+    await flushPromises()
+    // Verify all exposed properties and methods are accessible
+    expect(parentRef.value?.count).toBe(0)
+    expect(parentRef.value?.message).toBe('hello')
+    expect(parentRef.value?.getMessage()).toBe('hello')
+    // Call method to modify state
+    parentRef.value?.increment()
+    expect(parentRef.value?.count).toBe(1)
+    expect(parentRef.value?.$el).toBeInstanceOf(HTMLButtonElement)
+  })
 })

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -1,11 +1,9 @@
-import type { ComponentInternalInstance, ComponentPublicInstance } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 // reference: https://github.com/vuejs/rfcs/issues/258#issuecomment-1068697672
 import { unrefElement } from '@vueuse/core'
 import { computed, getCurrentInstance, ref } from 'vue'
 
-type ForwardRef = ComponentPublicInstance | ComponentInternalInstance
-
-export function useForwardExpose<T extends ForwardRef>() {
+export function useForwardExpose<T extends ComponentPublicInstance>() {
   const instance = getCurrentInstance()!
 
   const currentRef = ref<Element | T | null>()
@@ -58,10 +56,10 @@ export function useForwardExpose<T extends ForwardRef>() {
     Object.defineProperty(ret, '$el', {
       enumerable: true,
       configurable: true,
-      get: () => (ref instanceof Element ? ref : (ref as ComponentPublicInstance).$el),
+      get: () => (ref instanceof Element ? ref : ref.$el),
     })
 
-    instance.exposed = Object.assign({}, ret, (ref as ComponentInternalInstance))
+    instance.exposed = Object.assign({}, ret, ref)
   }
 
   return { forwardRef, currentRef, currentElement }

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -1,9 +1,11 @@
-import type { ComponentPublicInstance } from 'vue'
+import type { ComponentInternalInstance, ComponentPublicInstance } from 'vue'
 // reference: https://github.com/vuejs/rfcs/issues/258#issuecomment-1068697672
 import { unrefElement } from '@vueuse/core'
 import { computed, getCurrentInstance, ref } from 'vue'
 
-export function useForwardExpose<T extends ComponentPublicInstance>() {
+type ForwardRef = ComponentPublicInstance | ComponentInternalInstance
+
+export function useForwardExpose<T extends ForwardRef>() {
   const instance = getCurrentInstance()!
 
   const currentRef = ref<Element | T | null>()
@@ -56,10 +58,10 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
     Object.defineProperty(ret, '$el', {
       enumerable: true,
       configurable: true,
-      get: () => (ref instanceof Element ? ref : ref.$el),
+      get: () => (ref instanceof Element ? ref : (ref as ComponentPublicInstance).$el),
     })
 
-    instance.exposed = ret
+    instance.exposed = Object.assign({}, ret, (ref as ComponentInternalInstance))
   }
 
   return { forwardRef, currentRef, currentElement }

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -59,7 +59,23 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
       get: () => (ref instanceof Element ? ref : ref.$el),
     })
 
-    instance.exposed = Object.assign({}, ret, ref)
+    // ref not is Element
+    // and `useForwardExpose.test.ts > useForwardRef > should forward plain DOM element ref - 2` Passing in `$el`
+    if (!(ref instanceof Element) && !Object.hasOwn(ref, '$el')) {
+      // Retrieves the `exposed` data that has not been unwrapped by `vue` from `$.exposed`.
+      const childExposed = ref.$.exposed
+      const merged = Object.assign({}, ret)
+
+      for (const key in childExposed) {
+        Object.defineProperty(merged, key, {
+          enumerable: true,
+          configurable: true,
+          get: () => childExposed[key],
+        })
+      }
+
+      instance.exposed = merged
+    }
   }
 
   return { forwardRef, currentRef, currentElement }


### PR DESCRIPTION
fix [shadcn-vue](https://github.com/unovue/shadcn-vue/pull/1625)

This PR resolves the issue of specifying the `expose` of a `child component` and merging it into the `expose` of the `current component`.