### PR TITLE
fix(2347): always show select arrow and leave display to the select content

### DIFF
--- a/packages/core/src/Select/SelectArrow.vue
+++ b/packages/core/src/Select/SelectArrow.vue
@@ -7,20 +7,18 @@ export interface SelectArrowProps extends PopperArrowProps {}
 <script setup lang="ts">
 import { PopperArrow } from '@/Popper'
 import { injectSelectContentContext, SelectContentDefaultContextValue } from './SelectContentImpl.vue'
-import { injectSelectRootContext } from './SelectRoot.vue'
 
 const props = withDefaults(defineProps<SelectArrowProps>(), {
   width: 10,
   height: 5,
   as: 'svg',
 })
-const rootContext = injectSelectRootContext()
 const contentContext = injectSelectContentContext(SelectContentDefaultContextValue)
 </script>
 
 <template>
   <PopperArrow
-    v-if="rootContext.open.value && contentContext.position === 'popper'"
+    v-if="contentContext.position === 'popper'"
     v-bind="props"
   >
     <slot />

--- a/packages/core/src/Select/story/SelectDemo.story.vue
+++ b/packages/core/src/Select/story/SelectDemo.story.vue
@@ -2,6 +2,7 @@
 import { Icon } from '@iconify/vue'
 import { ref } from 'vue'
 import {
+  SelectArrow,
   SelectContent,
   SelectGroup,
   SelectItem,
@@ -104,6 +105,8 @@ const POSITION = ['item-aligned', 'popper'] as const
                 >
                   <Icon icon="radix-icons:chevron-down" />
                 </SelectScrollDownButton>
+
+                <SelectArrow class="fill-white" />
               </SelectContent>
             </Transition>
           </SelectPortal>


### PR DESCRIPTION
Closes #2347 

The `SelectArrow` was toggled on and off based on if the `rootContext.open.value` is set which means that when the select is closed this values immediately gets set to false and the arrow disappears without animation. I looked at the other components that use the `PopperArrow` and they do not have such behaviour so I removed it.

I don't have insights into if the `rootContext.open.value` is really needed or no. So let me know if there is a reason for it.

Thanks!