### PR TITLE
docs: fix broken showcase image links, improve padding

### DIFF
--- a/docs/.vitepress/custom/Showcase.vue
+++ b/docs/.vitepress/custom/Showcase.vue
@@ -6,7 +6,7 @@ const { frontmatter } = useData()
 </script>
 
 <template>
-  <div class="content pb-20 px-4 md:px-0">
+  <div class="content pb-20 px-4 2xl:px-0">
     <div class="mx-auto w-full">
       <div class="mt-8 mb-16 md:mt-24 md:mb-24 flex flex-col">
         <h1 class="text-4xl lg:text-5xl font-bold">

--- a/docs/.vitepress/custom/Showcase.vue
+++ b/docs/.vitepress/custom/Showcase.vue
@@ -6,7 +6,7 @@ const { frontmatter } = useData()
 </script>
 
 <template>
-  <div class="content pb-20 px-4 2xl:px-0">
+  <div class="content pb-20 px-4 lg:px-6">
     <div class="mx-auto w-full">
       <div class="mt-8 mb-16 md:mt-24 md:mb-24 flex flex-col">
         <h1 class="text-4xl lg:text-5xl font-bold">

--- a/docs/content/showcase.md
+++ b/docs/content/showcase.md
@@ -7,7 +7,7 @@ packages:
   - title: Shadcn Vue
     description: An unofficial, community-led Vue port of shadcn/ui.
     url: https://www.shadcn-vue.com/
-    image: https://www.shadcn-vue.com/og.png
+    image: https://www.shadcn-vue.com/__og-image__/static/og.png
 
   - title: Nuxt UI
     description: A UI Library for Modern Web Apps, powered by Vue & Tailwind CSS.
@@ -83,7 +83,7 @@ projects:
   - title: Movie Tracker
     description: Your guide to movies and TV shows. Find movies and shows, create lists, share your thoughts.
     url: https://movie-tracker.app/en
-    image: https://raw.githubusercontent.com/dapzer/movie-tracker/refs/heads/master/apps/frontend/src/public/ogImageEn.webp
+    image: https://raw.githubusercontent.com/dapzer/movie-tracker/refs/heads/master/apps/frontend/public/ogImageEn.webp
 
 starters:
   - title: shadcn-docs


### PR DESCRIPTION
This fixes some small issues on the Showcase page:
- corrected urls for two broken images
- improved x-padding on the page (was missing on md-2xl screens and now stays there for large screens, so it's aligned with the navbar)

Before:
<img width="1440" height="877" alt="Screenshot 2025-12-18 at 19 41 27" src="https://github.com/user-attachments/assets/15961320-da0f-40f8-97eb-9ba73c589061" />

After:
<img width="1440" height="876" alt="Screenshot 2025-12-18 at 19 49 27" src="https://github.com/user-attachments/assets/c964bb7f-c352-4184-8c8f-899276b21f2a" />
