### PR TITLE
test(focus-scope): shadow root issue patched example

### DIFF
--- a/packages/core/src/Combobox/story/ComboboxShadowRoot.story.vue
+++ b/packages/core/src/Combobox/story/ComboboxShadowRoot.story.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import type { Component } from 'vue'
+import { createApp, useTemplateRef, watch } from 'vue'
+
+import _Dialog from './_Dialog.vue'
+
+const options = [
+  { name: 'Fruit', children: [
+    { name: 'Apple' },
+    { name: 'Banana' },
+    { name: 'Orange' },
+    { name: 'Honeydew' },
+    { name: 'Grapes' },
+    { name: 'Watermelon' },
+    { name: 'Cantaloupe' },
+    { name: 'Pear' },
+  ] },
+  { name: 'Vegetable', children: [
+    { name: 'Cabbage' },
+    { name: 'Broccoli' },
+    { name: 'Carrots' },
+    { name: 'Lettuce' },
+    { name: 'Spinach' },
+    { name: 'Bok Choy' },
+    { name: 'Cauliflower' },
+    { name: 'Potatoes' },
+  ] },
+]
+
+function mountShadowRoot(container: HTMLDivElement, component: Component) {
+  const elementWithShadow = container as Element & { shadowRoot: ShadowRoot | null }
+  const shadowRoot
+    = elementWithShadow.shadowRoot || elementWithShadow.attachShadow({ mode: 'open' })
+
+  document.querySelectorAll('style, link[rel="stylesheet"]').forEach((node) => {
+    shadowRoot.appendChild(node.cloneNode(true))
+  })
+
+  const shadowMountPoint = document.createElement('div')
+  shadowRoot.appendChild(shadowMountPoint)
+
+  const shadowPortalTarget = document.createElement('div')
+  shadowPortalTarget.id = `portal-shadow-root`
+  shadowRoot.appendChild(shadowPortalTarget)
+
+  createApp(component, {
+    dialogPortalTarget: shadowPortalTarget,
+  }).mount(shadowMountPoint)
+}
+
+function resetShadowRoot(container: HTMLDivElement) {
+  const elementWithShadow = container as Element & { shadowRoot: ShadowRoot | null }
+  if (elementWithShadow.shadowRoot) {
+    elementWithShadow.shadowRoot.innerHTML = ''
+  }
+}
+
+const container = useTemplateRef('container')
+
+watch(
+  container,
+  (newVal) => {
+    if (newVal) {
+      resetShadowRoot(newVal)
+      mountShadowRoot(newVal, _Dialog)
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <Story
+    title="Combobox/ShadowRoot"
+    :layout="{ type: 'single', iframe: false }"
+  >
+    <Variant title="default">
+      <div
+        id="shadow-root-container"
+        ref="container"
+        class="h-96"
+      />
+    </Variant>
+  </Story>
+</template>

--- a/packages/core/src/Combobox/story/_Dialog.vue
+++ b/packages/core/src/Combobox/story/_Dialog.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ref } from 'vue'
+import {
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+} from '../../Dialog'
+import ComboboxManualFilter from './_ComboboxManualFilter.vue'
+
+defineProps<{ dialogPortalTarget: HTMLDivElement }>()
+const dialogOpen = ref(false)
+</script>
+
+<template>
+  <DialogRoot v-model:open="dialogOpen">
+    <DialogTrigger
+      class="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
+    >
+      Edit profile
+    </DialogTrigger>
+    <DialogPortal :to="dialogPortalTarget">
+      <Transition name="fade">
+        <DialogOverlay
+          class="bg-blackA9 fixed inset-0"
+        />
+      </Transition>
+      <Transition name="fade">
+        <DialogContent
+          :is-escape-key-down-default="true"
+          class="fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none"
+          @pointer-down-outside.prevent
+        >
+          <DialogTitle class="text-mauve12 m-0 text-[17px] font-medium">
+            Edit profile
+          </DialogTitle>
+          <ComboboxManualFilter />
+          <div class="mt-[25px] flex justify-end">
+            <DialogClose as-child>
+              <button
+                class="bg-green4 text-green11 hover:bg-green5 focus:shadow-green7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-medium leading-none focus:shadow-[0_0_0_2px] focus:outline-none"
+              >
+                Save changes
+              </button>
+            </DialogClose>
+          </div>
+          <DialogClose
+            class="text-violet11 hover:bg-violet4 focus:shadow-violet7 absolute top-[10px] right-[10px] inline-flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-full focus:shadow-[0_0_0_2px] focus:outline-none"
+            aria-label="Close"
+          >
+            <Icon icon="lucide:x" />
+          </DialogClose>
+        </DialogContent>
+      </Transition>
+    </DialogPortal>
+  </DialogRoot>
+</template>
+
+<style>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -1,9 +1,14 @@
 import type { RenderResult } from '@testing-library/vue'
+import type { VueWrapper } from '@vue/test-utils'
 import userEvent from '@testing-library/user-event'
-import { render, waitFor } from '@testing-library/vue'
+import { fireEvent, render, waitFor } from '@testing-library/vue'
+import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
+import { sleep } from '@/test'
 import { FocusScope } from '.'
+import Dialog from './story/shadowDom/_Dialog.vue'
+import ShadowRootContainer from './story/shadowDom/ShadowRootContainer.vue'
 
 const INNER_NAME_INPUT_LABEL = 'Name'
 const INNER_EMAIL_INPUT_LABEL = 'Email'
@@ -21,7 +26,7 @@ const TestField = ({
   `,
 })
 
-describe('focusScope', () => {
+describe('focusScope (light DOM)', () => {
   describe('given a default FocusScope', () => {
     let rendered: RenderResult
     let tabbableFirst: HTMLInputElement
@@ -131,6 +136,215 @@ describe('focusScope', () => {
       await userEvent.tab({ shift: true })
       await userEvent.tab()
       waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
+    })
+  })
+})
+
+describe('focusScope (shadow root)', () => {
+  function renderInShadowRoot(component: unknown) {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const shadow = host.attachShadow({ mode: 'open' })
+    const container = document.createElement('div')
+    shadow.appendChild(container)
+    const rendered = render(component, { container, baseElement: container })
+    return { rendered, host }
+  }
+
+  function getActiveElement(container: Element): Element | null {
+    const root = container.getRootNode()
+    if ((root as ShadowRoot).host)
+      return (root as ShadowRoot).activeElement
+    return null
+  }
+
+  it('keeps focus on input while adding or removing shadow elements during typing', async () => {
+    const { rendered, host } = renderInShadowRoot(defineComponent({
+      components: { FocusScope },
+      data: () => ({ value: '' }),
+      template: `
+        <FocusScope asChild loop trapped>
+          <div>
+            <label>
+              <span>${INNER_NAME_INPUT_LABEL}</span>
+              <input type="text" aria-label="${INNER_NAME_INPUT_LABEL}" v-model="value" />
+            </label>
+            <span v-if="value" data-testid="shadow-extra">extra</span>
+          </div>
+        </FocusScope>
+      `,
+    }))
+
+    try {
+      await nextTick()
+      const input = rendered.getByLabelText(INNER_NAME_INPUT_LABEL)
+      input.focus()
+      expect(getActiveElement(rendered.container)).toBe(input)
+      await userEvent.type(input, 'Foo')
+
+      await waitFor(() => expect(rendered.queryByTestId('shadow-extra')).not.toBeNull())
+      expect(getActiveElement(rendered.container)).toBe(input)
+      expect((getActiveElement(rendered.container) as HTMLInputElement).value).toBe('Foo')
+
+      await userEvent.keyboard('{Backspace>5}')
+      await waitFor(() => expect(rendered.queryByTestId('shadow-extra')).toBeNull())
+      expect(getActiveElement(rendered.container)).toBe(input)
+    }
+    finally {
+      rendered.unmount()
+      host?.remove()
+    }
+  })
+
+  type ShadowRootTestCase = {
+    description: string
+    testCase: 'shadowDomOnly' | 'mixedBodyAndShadowDom' | 'bodyOnly'
+  }
+
+  describe('shadow DOM focus loop test', () => {
+    const testSuite: ShadowRootTestCase[] = [
+      {
+        description: 'given a Dialog in the document body, with nested dismissable layers also in the document body',
+        testCase: 'bodyOnly',
+      },
+      {
+        description: 'given a Dialog inside a ShadowRoot, with nested dismissable layers also inside the ShadowRoot',
+        testCase: 'shadowDomOnly',
+      },
+      {
+        description: 'given a Dialog in the document body, with nested dismissable layers inside a ShadowRoot',
+        testCase: 'mixedBodyAndShadowDom',
+      },
+    ]
+
+    testSuite.forEach(({ description, testCase }) => {
+      describe(description, () => {
+        let wrapper: VueWrapper<InstanceType<typeof ShadowRootContainer>>
+        let shadowHost: HTMLElement
+        let shadowRoot: ShadowRoot
+
+        function getDialogOverlay(): HTMLElement | null {
+          if (testCase === 'shadowDomOnly') {
+            return shadowRoot.querySelector('[data-testid="dialog-overlay"]')
+          }
+          else {
+            return document.body.querySelector('[data-testid="dialog-overlay"]')
+          }
+        }
+
+        function getDialogTrigger(): HTMLElement | null {
+          if (testCase === 'shadowDomOnly') {
+            return shadowRoot.querySelector('[data-testid="dialog-trigger"]')
+          }
+          else {
+            return document.body.querySelector('[data-testid="dialog-trigger"]')
+          }
+        }
+
+        function getDialogContent(): HTMLElement | null {
+          if (testCase === 'shadowDomOnly') {
+            return shadowRoot.querySelector('[data-testid="dialog-content"]')
+          }
+          else {
+            return document.body.querySelector('[data-testid="dialog-content"]')
+          }
+        }
+
+        function getQueryRoot(): Document | ShadowRoot {
+          if (testCase === 'bodyOnly') {
+            return document
+          }
+          else {
+            return shadowRoot
+          }
+        }
+
+        beforeEach(async () => {
+          document.body.innerHTML = ''
+          if (testCase === 'shadowDomOnly') {
+            wrapper = mount(ShadowRootContainer, { attachTo: document.body, props: { withDialog: true } })
+            await nextTick()
+            shadowHost = wrapper.find('#shadow-root-container').element as HTMLElement
+            shadowRoot = (shadowHost as unknown as { shadowRoot: ShadowRoot }).shadowRoot!
+            // Open the dialog
+            const trigger = getDialogTrigger() as HTMLElement
+            await fireEvent.click(trigger)
+            await sleep(1)
+            const dialogOverlay = getDialogOverlay()
+            expect(dialogOverlay).toBeTruthy()
+            const dialogContent = getDialogContent()
+            expect(dialogContent).toBeTruthy()
+          }
+          else if (testCase === 'mixedBodyAndShadowDom') {
+            wrapper = mount(Dialog, { attachTo: document.body, props: { hasShadowRootInside: true } })
+            await nextTick()
+
+            // Open the dialog
+            const trigger = getDialogTrigger() as HTMLElement
+            await fireEvent.click(trigger)
+            await sleep(1)
+            const dialogOverlay = getDialogOverlay()
+            expect(dialogOverlay).toBeTruthy()
+            const dialogContent = getDialogContent()
+            expect(dialogContent).toBeTruthy()
+
+            shadowHost = dialogContent?.querySelector('#shadow-root-container') as HTMLElement
+            shadowRoot = (shadowHost as unknown as { shadowRoot: ShadowRoot }).shadowRoot!
+          }
+          else {
+            wrapper = mount(Dialog, { attachTo: document.body })
+            await nextTick()
+
+            // Open the dialog
+            const trigger = getDialogTrigger() as HTMLElement
+            await fireEvent.click(trigger)
+            await sleep(1)
+            const dialogOverlay = getDialogOverlay()
+            expect(dialogOverlay).toBeTruthy()
+            const dialogContent = getDialogContent()
+            expect(dialogContent).toBeTruthy()
+          }
+        })
+
+        afterEach(async () => {
+          await wrapper.unmount()
+          await nextTick()
+        })
+
+        if (testCase !== 'bodyOnly') {
+          it('shadowRoot should be defined', () => {
+            expect(shadowRoot).toBeDefined()
+          })
+        }
+
+        it('should loop focus within the FocusScope in the ShadowRoot', async () => {
+          const queryRoot = getQueryRoot()
+          const nameInput = queryRoot.querySelector(`input[name="name"]`) as HTMLElement
+          const emailInput = queryRoot.querySelector(`input[name="email"]`) as HTMLElement
+          const submitButton = queryRoot.querySelector('button[type="submit"]') as HTMLElement
+          const closeDialogButton = testCase === 'shadowDomOnly'
+            ? shadowRoot.querySelector('[data-testid="dialog-close"]') as HTMLElement
+            : document.querySelector('[data-testid="dialog-close"]') as HTMLElement
+
+          // Focus the first input
+          nameInput.focus()
+          await waitFor(() => expect(queryRoot.activeElement).toBe(nameInput))
+
+          await userEvent.tab()
+          await waitFor(() => expect(queryRoot.activeElement).toBe(emailInput))
+          await userEvent.tab()
+          await waitFor(() => expect(queryRoot.activeElement).toBe(submitButton))
+          await userEvent.tab()
+          await waitFor(() => expect(testCase === 'shadowDomOnly' ? shadowRoot.activeElement : document.activeElement).toBe(closeDialogButton))
+          // Tab again should loop back to the first focusable element
+          await userEvent.tab()
+          await waitFor(() => expect(queryRoot.activeElement).toBe(nameInput))
+
+          // Reverse tab should go to the last focusable element
+          await userEvent.tab({ shift: true })
+          await waitFor(() => expect(testCase === 'shadowDomOnly' ? shadowRoot.activeElement : document.activeElement).toBe(closeDialogButton))
+        })
+      })
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -68,14 +68,25 @@ const focusScope = reactive({
   },
 })
 
+function getEventRoot(container: HTMLElement | null): Document | ShadowRoot {
+  const rootNode = container?.getRootNode()
+  if (rootNode instanceof ShadowRoot)
+    return rootNode
+  return document
+}
+
 watchEffect((cleanupFn) => {
   if (!isClient)
     return
   const container = currentElement.value
+  const root = getEventRoot(container)
   if (!props.trapped)
     return
 
-  function handleFocusIn(event: FocusEvent) {
+  function handleFocusIn(event: Event) {
+    if (!(event instanceof FocusEvent))
+      return
+
     if (focusScope.paused || !container)
       return
     const target = event.target as HTMLElement | null
@@ -84,7 +95,10 @@ watchEffect((cleanupFn) => {
     else focus(lastFocusedElementRef.value, { select: true })
   }
 
-  function handleFocusOut(event: FocusEvent) {
+  function handleFocusOut(event: Event) {
+    if (!(event instanceof FocusEvent))
+      return
+
     if (focusScope.paused || !container)
       return
     const relatedTarget = event.relatedTarget as HTMLElement | null
@@ -122,15 +136,17 @@ watchEffect((cleanupFn) => {
       focus(container)
   }
 
-  document.addEventListener('focusin', handleFocusIn)
-  document.addEventListener('focusout', handleFocusOut)
+  root.addEventListener('focusin', handleFocusIn)
+  root.addEventListener('focusout', handleFocusOut)
+
   const mutationObserver = new MutationObserver(handleMutations)
   if (container)
     mutationObserver.observe(container, { childList: true, subtree: true })
 
   cleanupFn(() => {
-    document.removeEventListener('focusin', handleFocusIn)
-    document.removeEventListener('focusout', handleFocusOut)
+    root.removeEventListener('focusin', handleFocusIn)
+    root.removeEventListener('focusout', handleFocusOut)
+
     mutationObserver.disconnect()
   })
 })
@@ -213,6 +229,38 @@ function handleKeyDown(event: KeyboardEvent) {
         event.preventDefault()
         if (props.loop)
           focus(last, { select: true })
+      }
+      else {
+        const focusedRoot = focusedElement.getRootNode()
+        const containerRoot = container.getRootNode()
+        const isInShadowDOM = focusedRoot instanceof ShadowRoot || containerRoot instanceof ShadowRoot
+
+        if (!isInShadowDOM)
+          return
+
+        event.preventDefault()
+        const allTabbable = getTabbableCandidates(container)
+
+        if (allTabbable.length === 0)
+          return
+
+        const currentIndex = allTabbable.indexOf(focusedElement)
+
+        if (currentIndex === -1) {
+          if (event.shiftKey)
+            focus(last, { select: true })
+          else
+            focus(first, { select: true })
+          return
+        }
+
+        const nextIndex = event.shiftKey
+          ? currentIndex - 1
+          : currentIndex + 1
+        const nextElement = allTabbable[nextIndex]
+        if (nextElement) {
+          focus(nextElement, { select: true })
+        }
       }
     }
   }

--- a/packages/core/src/FocusScope/story/FocusScopeShadowRoot.story.vue
+++ b/packages/core/src/FocusScope/story/FocusScopeShadowRoot.story.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import Dialog from './shadowDom/_Dialog.vue'
+import ShadowRootContainer from './shadowDom/ShadowRootContainer.vue'
+</script>
+
+<template>
+  <Story
+    group="utilities"
+    title="FocusScope/ShadowRoot"
+    :layout="{ type: 'single' }"
+  >
+    <div class="text-center flex-col gap-8 flex p-2">
+      <div>
+        <span>Dialog in body and focusable elements in shadow root</span>
+        <Dialog :has-shadow-root-inside="true" />
+      </div>
+      <div>
+        <span>Dialog and focusable elements in shadow root</span>
+        <ShadowRootContainer with-dialog />
+      </div>
+      <div>
+        <span>Dialog and focusable elements in body</span>
+        <Dialog />
+      </div>
+    </div>
+  </Story>
+</template>

--- a/packages/core/src/FocusScope/story/shadowDom/FocusableLayersElements.vue
+++ b/packages/core/src/FocusScope/story/shadowDom/FocusableLayersElements.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="flex gap-2">
+    <input
+      name="name"
+      placeholder="Name"
+    >
+    <input
+      name="email"
+      placeholder="Email"
+    >
+    <button type="submit">
+      Submit
+    </button>
+  </div>
+</template>

--- a/packages/core/src/FocusScope/story/shadowDom/ShadowRootContainer.vue
+++ b/packages/core/src/FocusScope/story/shadowDom/ShadowRootContainer.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import type { Component } from 'vue'
+import { createApp, useTemplateRef, watch } from 'vue'
+import Dialog from './_Dialog.vue'
+import FocusableLayersElements from './FocusableLayersElements.vue'
+
+const props = defineProps<{ withDialog?: boolean }>()
+
+let shadowApp: ReturnType<typeof createApp> | null = null
+
+function mountShadowRoot(container: HTMLDivElement, component: Component) {
+  const elementWithShadow = container as Element & { shadowRoot: ShadowRoot | null }
+  const shadowRoot
+    = elementWithShadow.shadowRoot || elementWithShadow.attachShadow({ mode: 'open' })
+
+  document.querySelectorAll('style, link[rel="stylesheet"]').forEach((node) => {
+    shadowRoot.appendChild(node.cloneNode(true))
+  })
+
+  const shadowMountPoint = document.createElement('div')
+  shadowRoot.appendChild(shadowMountPoint)
+
+  const shadowPortalTarget = document.createElement('div')
+  shadowPortalTarget.id = `portal-shadow-root`
+  shadowRoot.appendChild(shadowPortalTarget)
+
+  shadowApp = createApp(component, {
+    portalTarget: shadowPortalTarget,
+  })
+  shadowApp.mount(shadowMountPoint)
+}
+
+function resetShadowRoot(container: HTMLDivElement) {
+  if (shadowApp) {
+    shadowApp.unmount()
+    shadowApp = null
+  }
+  const elementWithShadow = container as Element & { shadowRoot: ShadowRoot | null }
+  if (elementWithShadow.shadowRoot) {
+    elementWithShadow.shadowRoot.innerHTML = ''
+  }
+}
+
+const container = useTemplateRef('container')
+
+watch(
+  container,
+  (newVal) => {
+    if (newVal) {
+      resetShadowRoot(newVal)
+      mountShadowRoot(newVal, props.withDialog ? Dialog : FocusableLayersElements)
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <div
+    id="shadow-root-container"
+    ref="container"
+  />
+</template>

--- a/packages/core/src/FocusScope/story/shadowDom/_Dialog.vue
+++ b/packages/core/src/FocusScope/story/shadowDom/_Dialog.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ref } from 'vue'
+import {
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+
+} from '../../../Dialog'
+
+import FocusableLayersElements from './FocusableLayersElements.vue'
+import ShadowRootContainer from './ShadowRootContainer.vue'
+
+defineProps<{ portalTarget?: HTMLDivElement, hasShadowRootInside?: boolean }>()
+
+const dialogOpen = ref(false)
+</script>
+
+<template>
+  <div class="w-100 flex justify-center">
+    <DialogRoot v-model:open="dialogOpen">
+      <DialogTrigger
+        data-testid="dialog-trigger"
+        class="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
+      >
+        Main Trigger
+      </DialogTrigger>
+      <DialogPortal :to="portalTarget">
+        <Transition name="fade">
+          <DialogOverlay
+            data-testid="dialog-overlay"
+            class="bg-blackA9 fixed inset-0"
+          />
+        </Transition>
+        <Transition name="fade">
+          <DialogContent
+            data-testid="dialog-content"
+            class="fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[750px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none"
+          >
+            <DialogTitle class="text-mauve12 m-0 text-[17px] font-medium">
+              Edit profile
+            </DialogTitle>
+
+            <template v-if="hasShadowRootInside">
+              <ShadowRootContainer :with-dialog="false" />
+            </template>
+            <template v-else>
+              <FocusableLayersElements />
+            </template>
+
+            <DialogClose
+              data-testid="dialog-close"
+              class="text-violet11 hover:bg-violet4 focus:shadow-violet7 absolute top-[10px] right-[10px] inline-flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-full focus:shadow-[0_0_0_2px] focus:outline-none"
+              aria-label="Close"
+            >
+              <Icon icon="lucide:x" />
+            </DialogClose>
+          </DialogContent>
+        </Transition>
+      </DialogPortal>
+    </DialogRoot>
+  </div>
+</template>

--- a/packages/core/src/FocusScope/utils.ts
+++ b/packages/core/src/FocusScope/utils.ts
@@ -39,7 +39,7 @@ export function getTabbableEdges(container: HTMLElement) {
  * See: https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker
  * Credit: https://github.com/discord/focus-layers/blob/master/src/util/wrapFocus.tsx#L1
  */
-export function getTabbableCandidates(container: HTMLElement) {
+export function getTabbableCandidates(container: HTMLElement | ShadowRoot) {
   const nodes: HTMLElement[] = []
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
     acceptNode: (node: any) => {
@@ -49,6 +49,11 @@ export function getTabbableCandidates(container: HTMLElement) {
       // `.tabIndex` is not the same as the `tabindex` attribute. It works on the
       // runtime's understanding of tabbability, so this automatically accounts
       // for any kind of element that could be tabbed to.
+      if (node.shadowRoot) {
+        const shadowNodes = getTabbableCandidates(node.shadowRoot as ShadowRoot)
+        nodes.push(...shadowNodes)
+      }
+
       return node.tabIndex >= 0
         ? NodeFilter.FILTER_ACCEPT
         : NodeFilter.FILTER_SKIP


### PR DESCRIPTION
This is an example branch about the focus isse mentionned in #1667 :
> When using an input field inside a Dialog that dynamically updates content within the Dialog, the focus keeps switching back to DialogContent, disrupting the user experience.

The reproduction branch is this one: https://github.com/unovue/reka-ui/pull/2331
The fix is here: https://github.com/unovue/reka-ui/pull/2352


## What has been patched
See the patch here: https://github.com/unovue/reka-ui/pull/2352

## How to reproduce

- clone the repo
- install dependencies
- run `pnpm story:dev`
- wait for all stories to load
- go on http://localhost:6006/__sandbox.html?storyId=packages-core-src-combobox-story-comboboxshadowroot-story-vue&variantId=packages-core-src-combobox-story-comboboxshadowroot-story-vue-0
- click on the button to open the dialog inside the shadow root
- focus the input inside the dialog (by click on keyboard)
- start typing inside the input
- you should not loose the focus anymore on the input


### Expected behaviour
The focus should not be lost.
Here is an example of how it should behave.

https://github.com/user-attachments/assets/084fa28d-9cb6-4d82-be6b-7bfe9845e1f8

