### PR TITLE
fix(TimeField/DateField/DateRangeField): filter redundant brackets with `hideTimeZone`

### DIFF
--- a/packages/core/src/TimeField/TimeField.test.ts
+++ b/packages/core/src/TimeField/TimeField.test.ts
@@ -105,6 +105,14 @@ describe('timeField', async () => {
     expect(queryByTestId('dayPeriod')).toBeInTheDocument()
   })
 
+  it('filter time zone brackets for specific locales', async () => {
+    const { queryByTestId } = setup({
+      timeFieldProps: { modelValue: calendarDateTime, locale: 'zh-TW', hideTimeZone: true },
+    })
+    expect(queryByTestId('input')).not.toHaveTextContent('[')
+    expect(queryByTestId('input')).not.toHaveTextContent(']')
+  })
+
   it('focuses first segment on label click', async () => {
     const { user, input, label } = setup()
     await user.click(label)

--- a/packages/core/src/shared/date/parser.ts
+++ b/packages/core/src/shared/date/parser.ts
@@ -197,6 +197,16 @@ function createContentArr(props: CreateContentArrProps) {
       if (segment.part === 'timeZoneName' && (!isZonedDateTime(props.dateRef) || hideTimeZone))
         return false
 
+      // In some locales (e.g., zh-TW), the time zone is represented with square brackets.
+      // We also filter out these literals that are just brackets.
+      // @see https://github.com/unovue/reka-ui/issues/1670
+      if (
+        (!isZonedDateTime(props.dateRef) || hideTimeZone)
+        && segment.part === 'literal' && ['[', ']'].includes(segment.value.trim())
+      ) {
+        return false
+      }
+
       return true
     })
 


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2356