### PR TITLE
fix(DatePicker/DateRangePicker/Calendar/RangeCalendar)!: make `weekStartsOn` locale-independent

### DIFF
--- a/packages/core/src/date/comparators.ts
+++ b/packages/core/src/date/comparators.ts
@@ -143,7 +143,13 @@ export function getLastFirstDayOfWeek<T extends DateValue = DateValue>(
   firstDayOfWeek: number,
   locale: string,
 ): T {
-  const day = getDayOfWeek(date, locale)
+  /**
+   * "firstDayOfWeek" is fixed to 0(Sunday) to avoid confusion regarding locales.
+   * This also aligns with other date libraries, e.g., date-fns.
+   *
+   * #see https://github.com/unovue/reka-ui/issues/2157
+   */
+  const day = getDayOfWeek(date, locale, 'sun')
 
   if (firstDayOfWeek > day)
     return date.subtract({ days: day + 7 - firstDayOfWeek }) as T
@@ -159,7 +165,14 @@ export function getNextLastDayOfWeek<T extends DateValue = DateValue>(
   firstDayOfWeek: number,
   locale: string,
 ): T {
-  const day = getDayOfWeek(date, locale)
+  /**
+   * "firstDayOfWeek" is fixed to 0(Sunday) to avoid confusion regarding locales.
+   * This also aligns with other date libraries, e.g., date-fns.
+   *
+   * #see https://github.com/unovue/reka-ui/issues/2157
+   */
+  const day = getDayOfWeek(date, locale, 'sun')
+
   const lastDayOfWeek = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1
 
   if (day === lastDayOfWeek)


### PR DESCRIPTION
resolves https://github.com/unovue/reka-ui/issues/2157
resolves https://github.com/unovue/reka-ui/issues/2264

❗❗This may be a breaking change for those who rely on `weekStartsOn` to behave differently across locales.

As I've seen more users confused by this implicit behavior, I think it's better to define `weekStartsOn` in a fixed and explicit way, where the day of the week is always `Sun(0), Mon(1), ..., Sat(6)`. This also aligns with other date libraries, e.g., [date-fns](https://date-fns.org/docs/startOfWeek), making it more predictable.

However, this would break users who rely on the previous behavior by specifying different `weekStartsOn` values for different locales to make the calendar always start on "Monday" or other days.

For example:

Before: `locale="en-GB" :weekStartsOn="0"` === `locale="en-US" :weekStartsOn="1"` === `"week starts on Monday"`

After: `locale="en-GB" :weekStartsOn="1"` === `locale="en-US" :weekStartsOn="1"` === `"week starts on Monday"`

I've also considered adding a new prop (e.g., `fixedWeekStartsOn: boolean`) to only change the behavior when this prop is set, which could avoid breaking changes. However, this would add complexity to the library, and the default behavior would still remain confusing (and we'd have to document it, etc.). WDYT? cc @zernonia 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized day-of-week calculations to consistently use Sunday as the reference point, improving accuracy and consistency when determining specific days of the week across different locales.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->