### PR TITLE
feat(ScrollArea): add glimpse scrollbar mode

### DIFF
--- a/packages/core/src/ScrollArea/ScrollAreaRoot.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaRoot.vue
@@ -35,7 +35,8 @@ export interface ScrollAreaRootProps extends PrimitiveProps {
    * `auto` - means that scrollbars are visible when content is overflowing on the corresponding orientation. <br>
    * `always` - means that scrollbars are always visible regardless of whether the content is overflowing.<br>
    * `scroll` - means that scrollbars are visible when the user is scrolling along its corresponding orientation.<br>
-   * `hover` - when the user is scrolling along its corresponding orientation and when the user is hovering over the scroll area.
+   * `hover` - when the user is scrolling along its corresponding orientation and when the user is hovering over the scroll area.<br>
+   * `glimpse` - a hybrid approach that briefly shows scrollbars when the user enters the scroll area, then hides them until further interaction.
    */
   type?: ScrollType
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbar.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbar.vue
@@ -34,6 +34,7 @@ import {
 } from 'vue'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import ScrollAreaScrollbarAuto from './ScrollAreaScrollbarAuto.vue'
+import ScrollAreaScrollbarGlimpse from './ScrollAreaScrollbarGlimpse.vue'
 import ScrollAreaScrollbarHover from './ScrollAreaScrollbarHover.vue'
 import ScrollAreaScrollbarScroll from './ScrollAreaScrollbarScroll.vue'
 import ScrollAreaScrollbarVisible from './ScrollAreaScrollbarVisible.vue'
@@ -94,6 +95,14 @@ provideScrollAreaScrollbarContext({
   >
     <slot />
   </ScrollAreaScrollbarScroll>
+  <ScrollAreaScrollbarGlimpse
+    v-else-if="rootContext.type.value === 'glimpse'"
+    v-bind="$attrs"
+    :ref="forwardRef"
+    :force-mount="forceMount"
+  >
+    <slot />
+  </ScrollAreaScrollbarGlimpse>
   <ScrollAreaScrollbarAuto
     v-else-if="rootContext.type.value === 'auto'"
     v-bind="$attrs"

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarGlimpse.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarGlimpse.vue
@@ -1,0 +1,145 @@
+<script lang="ts">
+import type { ScrollAreaScrollbarAutoProps } from './ScrollAreaScrollbarAuto.vue'
+
+export interface ScrollAreaScrollbarGlimpseProps extends ScrollAreaScrollbarAutoProps {}
+</script>
+
+<script setup lang="ts">
+import { useDebounceFn } from '@vueuse/core'
+import { computed, onMounted, onUnmounted, watchEffect } from 'vue'
+import { Presence } from '@/Presence'
+import { useForwardExpose } from '@/shared'
+import { useStateMachine } from '../shared/useStateMachine'
+import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
+import { injectScrollAreaScrollbarContext } from './ScrollAreaScrollbar.vue'
+import ScrollAreaScrollbarAuto from './ScrollAreaScrollbarAuto.vue'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+defineProps<ScrollAreaScrollbarGlimpseProps>()
+
+const rootContext = injectScrollAreaRootContext()
+const scrollbarContext = injectScrollAreaScrollbarContext()
+
+const { forwardRef } = useForwardExpose()
+
+const { state, dispatch } = useStateMachine('hidden', {
+  hidden: {
+    POINTER_ENTER: 'glimpse',
+    SCROLL: 'scrolling',
+  },
+  glimpse: {
+    HIDE: 'hidden',
+    POINTER_LEAVE: 'hidden',
+    SCROLL: 'scrolling',
+    POINTER_ENTER: 'glimpse',
+  },
+  scrolling: {
+    SCROLL_END: 'idle',
+    POINTER_ENTER: 'interacting',
+  },
+  interacting: {
+    SCROLL: 'interacting',
+    POINTER_LEAVE: 'idle',
+  },
+  idle: {
+    HIDE: 'hidden',
+    SCROLL: 'scrolling',
+    POINTER_ENTER: 'interacting',
+  },
+})
+
+const visible = computed(() => state.value !== 'hidden')
+
+function handlePointerEnter() {
+  dispatch('POINTER_ENTER')
+}
+
+function handlePointerLeave() {
+  dispatch('POINTER_LEAVE')
+}
+
+const debounceScrollEnd = useDebounceFn(() => dispatch('SCROLL_END'), 100)
+
+watchEffect((onCleanup) => {
+  if (state.value === 'glimpse') {
+    const timeId = window.setTimeout(
+      () => dispatch('HIDE'),
+      rootContext.scrollHideDelay.value,
+    )
+
+    onCleanup(() => {
+      window.clearTimeout(timeId)
+    })
+  }
+})
+
+watchEffect((onCleanup) => {
+  if (state.value === 'idle') {
+    const timeId = window.setTimeout(
+      () => dispatch('HIDE'),
+      rootContext.scrollHideDelay.value,
+    )
+
+    onCleanup(() => {
+      window.clearTimeout(timeId)
+    })
+  }
+})
+
+watchEffect((onCleanup) => {
+  const viewport = rootContext.viewport.value
+  const scrollDirection = scrollbarContext.isHorizontal.value
+    ? 'scrollLeft'
+    : 'scrollTop'
+
+  if (viewport) {
+    let prevScrollPos = viewport[scrollDirection]
+    const handleScroll = () => {
+      const scrollPos = viewport[scrollDirection]
+      const hasScrollInDirectionChanged = prevScrollPos !== scrollPos
+      if (hasScrollInDirectionChanged) {
+        dispatch('SCROLL')
+        debounceScrollEnd()
+      }
+      prevScrollPos = scrollPos
+    }
+    viewport.addEventListener('scroll', handleScroll)
+
+    onCleanup(() => {
+      viewport.removeEventListener('scroll', handleScroll)
+    })
+  }
+})
+
+onMounted(() => {
+  const scrollArea = rootContext.scrollArea.value
+
+  if (scrollArea) {
+    scrollArea.addEventListener('pointerenter', handlePointerEnter)
+    scrollArea.addEventListener('pointerleave', handlePointerLeave)
+  }
+})
+
+onUnmounted(() => {
+  const scrollArea = rootContext.scrollArea.value
+  if (scrollArea) {
+    scrollArea.removeEventListener('pointerenter', handlePointerEnter)
+    scrollArea.removeEventListener('pointerleave', handlePointerLeave)
+  }
+})
+</script>
+
+<template>
+  <Presence :present="forceMount || visible">
+    <ScrollAreaScrollbarAuto
+      v-bind="$attrs"
+      :ref="forwardRef"
+      :data-state="visible ? 'visible' : 'hidden'"
+    >
+      <slot />
+    </ScrollAreaScrollbarAuto>
+  </Presence>
+</template>

--- a/packages/core/src/ScrollArea/index.ts
+++ b/packages/core/src/ScrollArea/index.ts
@@ -13,6 +13,10 @@ export {
   type ScrollAreaScrollbarProps,
 } from './ScrollAreaScrollbar.vue'
 export {
+  default as ScrollAreaScrollbarGlimpse,
+  type ScrollAreaScrollbarGlimpseProps,
+} from './ScrollAreaScrollbarGlimpse.vue'
+export {
   default as ScrollAreaThumb,
   type ScrollAreaThumbProps,
 } from './ScrollAreaThumb.vue'

--- a/packages/core/src/ScrollArea/types.ts
+++ b/packages/core/src/ScrollArea/types.ts
@@ -9,4 +9,4 @@ export interface Sizes {
   }
 }
 
-export type ScrollType = 'auto' | 'always' | 'scroll' | 'hover'
+export type ScrollType = 'auto' | 'always' | 'scroll' | 'hover' | 'glimpse'


### PR DESCRIPTION
This pull request adds a new `glimpse` scroll type to the `ScrollArea` component, which briefly displays scrollbars when the user enters the scroll area, then hides them until further interaction. This enhances scrollbar visibility options and mimics modern UX patterns found in editors like Zed.

**Changes:**

Added `"glimpse"` as a valid `ScrollType` value in `types.ts` and documented its behavior in the `ScrollAreaRootProps` interface. [[1]](diffhunk://#diff-f971a72a25a4cd2fe10b0e757872bb80e9156c98b4b5f74cc46bccc40f55dc91L12-R12) [[2]](diffhunk://#diff-e8223d4a994d4228997bf417e97f2f50f9b7e4db52911c5e3cf95f4ed22b2ccbL38-R39)

Created a new `ScrollAreaScrollbarGlimpse.vue` component that manages scrollbar visibility through state machine logic, responding to pointer enter/leave and scroll events.

Updated `ScrollAreaScrollbar.vue` to conditionally render the `ScrollAreaScrollbarGlimpse` component when the scroll type is `glimpse`. [[1]](diffhunk://#diff-bf2a94c94f099f09b62476e86596f06698ed7ee76b1e374936155b5828fc6c63R37) [[2]](diffhunk://#diff-bf2a94c94f099f09b62476e86596f06698ed7ee76b1e374936155b5828fc6c63R98-R105)