### PR TITLE
feat(Splitter): add support for pixel sizing and constraints

### DIFF
--- a/docs/content/docs/components/splitter.md
+++ b/docs/content/docs/components/splitter.md
@@ -22,7 +22,8 @@ A component that divides your layout into resizable sections.
     'Supports nested layout.',
     'Supports Right to Left direction.',
     'Can resize across another panel.',
-    'Can be mounted conditionally.'
+    'Can be mounted conditionally.',
+    'Supports percent and pixel sizing.'
   ]"
 />
 
@@ -195,6 +196,31 @@ const panelRef = ref<InstanceType<typeof SplitterPanel>>()
   </SplitterGroup>
 </template>
 ```
+
+### Pixel sizing
+
+Use `sizeUnit="px"` when you need a panel to stay a fixed pixel width (great for sidebars) even if the parent container resizes. All sizing props (`defaultSize`, `minSize`, `maxSize`, `collapsedSize`) are interpreted using the chosen unit.
+
+```vue line=4-10
+<template>
+  <SplitterGroup direction="horizontal">
+    <SplitterPanel
+      size-unit="px"
+      :default-size="240"
+      :min-size="160"
+      :max-size="320"
+    >
+      Fixed-width sidebar
+    </SplitterPanel>
+    <SplitterResizeHandle />
+    <SplitterPanel>
+      Flexible content
+    </SplitterPanel>
+  </SplitterGroup>
+</template>
+```
+
+Pixel-sized panels also work with persistence (`autoSaveId`) and collapse/expand APIs; sizes are restored using the correct unit.
 
 ### Custom handle
 

--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -79,6 +79,7 @@ import { Primitive } from '@/Primitive'
 import { assert } from './utils/assert'
 import { calculateDeltaPercentage, calculateUnsafeDefaultLayout } from './utils/calculate'
 import { callPanelCallbacks } from './utils/callPanelCallbacks'
+import { fuzzyCompareNumbers } from './utils/compare'
 import debounce from './utils/debounce'
 import { getResizeHandleElement } from './utils/dom'
 import { getResizeEventCursorPosition, isKeyDown, isMouseEvent, isTouchEvent } from './utils/events'
@@ -92,6 +93,7 @@ import {
   reportConstraintsViolation,
 } from './utils/registry'
 import { computePanelFlexBoxStyle } from './utils/style'
+import { convertPanelConstraintsToPercent, hasPixelSizedPanel, recalculateLayoutForPixelPanels } from './utils/units'
 import { validatePanelGroupLayout } from './utils/validation'
 
 const props = withDefaults(defineProps<SplitterGroupProps>(), {
@@ -118,6 +120,7 @@ const dir = useDirection()
 const { forwardRef, currentElement: panelGroupElementRef } = useForwardExpose()
 
 const dragState = ref<DragState | null>(null)
+const groupSizeInPixels = ref<number | null>(null)
 const layout = ref<number[]>([])
 const panelIdToLastNotifiedSizeMapRef = ref<Record<string, number>>({})
 const panelSizeBeforeCollapseRef = ref<Map<string, number>>(new Map())
@@ -149,6 +152,45 @@ const eagerValuesRef = ref<{
   panelDataArrayChanged: false,
 })
 
+function getGroupSizeInPixels(): number | null {
+  if (groupSizeInPixels.value != null)
+    return groupSizeInPixels.value
+
+  const element = panelGroupElementRef.value
+  if (element && element instanceof HTMLElement) {
+    const rect = element.getBoundingClientRect()
+    const size = direction.value === 'horizontal' ? rect.width : rect.height
+
+    if (!Number.isNaN(size)) {
+      groupSizeInPixels.value = size
+      return size
+    }
+  }
+
+  return null
+}
+
+function getPanelConstraintsInPercent(groupSizeOverride?: number | null) {
+  const groupSize = groupSizeOverride ?? getGroupSizeInPixels()
+
+  return convertPanelConstraintsToPercent({
+    panelDataArray: eagerValuesRef.value.panelDataArray,
+    groupSizeInPixels: groupSize,
+  })
+}
+
+function getPanelDataWithPercentConstraints(groupSizeOverride?: number | null) {
+  const percentConstraints = getPanelConstraintsInPercent(groupSizeOverride)
+
+  if (!percentConstraints)
+    return null
+
+  return eagerValuesRef.value.panelDataArray.map((panelData, index) => ({
+    ...panelData,
+    constraints: percentConstraints[index],
+  }))
+}
+
 const setLayout = (val: number[]) => layout.value = val
 
 useWindowSplitterPanelGroupBehavior({
@@ -158,6 +200,33 @@ useWindowSplitterPanelGroupBehavior({
   panelDataArray: eagerValuesRef.value.panelDataArray,
   setLayout,
   panelGroupElement: panelGroupElementRef,
+  getPanelDataWithPercentConstraints,
+})
+
+watchEffect((onCleanup) => {
+  const element = panelGroupElementRef.value
+  if (!element)
+    return
+
+  if (typeof ResizeObserver !== 'function')
+    return
+
+  const resizeObserver = new ResizeObserver((entries) => {
+    const entry = entries[0]
+    if (!entry)
+      return
+
+    const { height, width } = entry.contentRect
+    const nextSize = direction.value === 'horizontal' ? width : height
+
+    if (!Number.isNaN(nextSize))
+      groupSizeInPixels.value = nextSize
+  })
+
+  if (element instanceof HTMLElement)
+    resizeObserver.observe(element)
+
+  onCleanup(() => resizeObserver.disconnect())
 })
 
 watchEffect(() => {
@@ -254,18 +323,24 @@ watch(() => eagerValuesRef.value.panelDataArrayChanged, () => {
     }
 
     if (unsafeLayout === null) {
+      const panelDataArrayWithPercentConstraints = getPanelDataWithPercentConstraints()
+      if (!panelDataArrayWithPercentConstraints)
+        return
+
       unsafeLayout = calculateUnsafeDefaultLayout({
-        panelDataArray,
+        panelDataArray: panelDataArrayWithPercentConstraints,
       })
     }
+
+    const panelConstraints = getPanelConstraintsInPercent()
+    if (!panelConstraints)
+      return
 
     // Validate even saved layouts in case something has changed since last render
     // e.g. for pixel groups, this could be the size of the window
     const nextLayout = validatePanelGroupLayout({
       layout: unsafeLayout,
-      panelConstraints: panelDataArray.map(
-        panelData => panelData.constraints,
-      ),
+      panelConstraints,
     })
 
     if (!areEqual(prevLayout, nextLayout)) {
@@ -280,6 +355,49 @@ watch(() => eagerValuesRef.value.panelDataArrayChanged, () => {
         panelIdToLastNotifiedSizeMapRef.value,
       )
     }
+  }
+})
+
+watch(groupSizeInPixels, (nextSize, prevSize) => {
+  if (prevSize == null || nextSize == null)
+    return
+
+  const { layout: prevLayout, panelDataArray } = eagerValuesRef.value
+  if (prevLayout.length === 0)
+    return
+  if (!hasPixelSizedPanel(panelDataArray))
+    return
+
+  const recalculatedLayout = recalculateLayoutForPixelPanels({
+    layout: prevLayout,
+    panelDataArray,
+    prevGroupSize: prevSize,
+    nextGroupSize: nextSize,
+  })
+
+  if (!recalculatedLayout)
+    return
+
+  const panelConstraints = getPanelConstraintsInPercent(nextSize)
+  if (!panelConstraints)
+    return
+
+  const nextLayout = validatePanelGroupLayout({
+    layout: recalculatedLayout,
+    panelConstraints,
+  })
+
+  if (!compareLayouts(prevLayout, nextLayout)) {
+    setLayout(nextLayout)
+
+    eagerValuesRef.value.layout = nextLayout
+    emits('layout', nextLayout)
+
+    callPanelCallbacks(
+      panelDataArray,
+      nextLayout,
+      panelIdToLastNotifiedSizeMapRef.value,
+    )
   }
 })
 
@@ -317,7 +435,9 @@ function registerResizeHandle(dragHandleId: string) {
     if (dir.value === 'rtl' && isHorizontal)
       delta = -delta
 
-    const panelConstraints = panelDataArray.map(panelData => panelData.constraints)
+    const panelConstraints = getPanelConstraintsInPercent()
+    if (!panelConstraints)
+      return
 
     const nextLayout = adjustLayoutByDelta({
       delta,
@@ -378,12 +498,15 @@ function registerResizeHandle(dragHandleId: string) {
 function resizePanel(panelData: PanelData, unsafePanelSize: number) {
   const { layout: prevLayout, panelDataArray } = eagerValuesRef.value
 
-  const panelConstraintsArray = panelDataArray.map(panelData => panelData.constraints)
+  const panelConstraintsArray = getPanelConstraintsInPercent()
+  if (!panelConstraintsArray)
+    return
 
   const { panelSize, pivotIndices } = panelDataHelper(
     panelDataArray,
     panelData,
     prevLayout,
+    panelConstraintsArray,
   )
 
   assert(panelSize != null)
@@ -420,39 +543,29 @@ function reevaluatePanelConstraints(panelData: PanelData, prevConstraints: Panel
   const index = findPanelDataIndex(panelDataArray, panelData)
   panelDataArray[index] = panelData
   eagerValuesRef.value.panelDataArrayChanged = true
-  const {
-    collapsedSize: prevCollapsedSize = 0,
-    collapsible: prevCollapsible,
-  } = prevConstraints
 
-  const {
-    collapsedSize: nextCollapsedSize = 0,
-    collapsible: nextCollapsible,
-    maxSize: nextMaxSize = 100,
-    minSize: nextMinSize = 0,
-  } = panelData.constraints
+  const panelConstraintsArray = getPanelConstraintsInPercent()
+  if (!panelConstraintsArray)
+    return
 
+  const nextConstraints = panelConstraintsArray[index]
   const { panelSize: prevPanelSize } = panelDataHelper(
     panelDataArray,
     panelData,
     layout,
+    panelConstraintsArray,
   )
-  if (prevPanelSize === null) {
-    // It's possible that the panels in this group have changed since the last render
-    return
-  }
 
-  if (
-    prevCollapsible
-    && nextCollapsible
-    && prevPanelSize === prevCollapsedSize
-  ) {
-    if (prevCollapsedSize !== nextCollapsedSize) {
+  if (prevPanelSize === null)
+    return
+
+  const nextCollapsedSize = nextConstraints?.collapsedSize ?? 0
+  const nextMaxSize = nextConstraints?.maxSize ?? 100
+  const nextMinSize = nextConstraints?.minSize ?? 0
+
+  if (nextConstraints?.collapsible && isPanelCollapsed(panelData)) {
+    if (prevPanelSize !== nextCollapsedSize)
       resizePanel(panelData, nextCollapsedSize)
-    }
-    else {
-      // Stay collapsed
-    }
   }
   else if (prevPanelSize < nextMinSize) {
     resizePanel(panelData, nextMinSize)
@@ -511,15 +624,15 @@ function collapsePanel(panelData: PanelData) {
   const { layout: prevLayout, panelDataArray } = eagerValuesRef.value
 
   if (panelData.constraints.collapsible) {
-    const panelConstraintsArray = panelDataArray.map(
-      panelData => panelData.constraints,
-    )
+    const panelConstraintsArray = getPanelConstraintsInPercent()
+    if (!panelConstraintsArray)
+      return
 
     const {
       collapsedSize = 0,
       panelSize,
       pivotIndices,
-    } = panelDataHelper(panelDataArray, panelData, prevLayout)
+    } = panelDataHelper(panelDataArray, panelData, prevLayout, panelConstraintsArray)
 
     assert(
       panelSize != null,
@@ -529,7 +642,13 @@ function collapsePanel(panelData: PanelData) {
     if (panelSize !== collapsedSize) {
       // Store size before collapse;
       // This is the size that gets restored if the expand() API is used.
-      panelSizeBeforeCollapseRef.value.set(panelData.id, panelSize)
+      const sizeUnit = panelData.constraints.sizeUnit ?? '%'
+      const groupSize = groupSizeInPixels.value ?? getGroupSizeInPixels()
+      const sizeBeforeCollapse = sizeUnit === 'px' && groupSize
+        ? (panelSize / 100) * groupSize
+        : panelSize
+
+      panelSizeBeforeCollapseRef.value.set(panelData.id, sizeBeforeCollapse)
 
       const isLastPanel
         = findPanelDataIndex(panelDataArray, panelData)
@@ -567,26 +686,35 @@ function expandPanel(panelData: PanelData) {
   const { layout: prevLayout, panelDataArray } = eagerValuesRef.value
 
   if (panelData.constraints.collapsible) {
-    const panelConstraintsArray = panelDataArray.map(
-      panelData => panelData.constraints,
-    )
+    const panelConstraintsArray = getPanelConstraintsInPercent()
+    if (!panelConstraintsArray)
+      return
 
     const {
       collapsedSize = 0,
-      panelSize,
+      panelSize = 0,
       minSize = 0,
       pivotIndices,
-    } = panelDataHelper(panelDataArray, panelData, prevLayout)
+    } = panelDataHelper(panelDataArray, panelData, prevLayout, panelConstraintsArray)
 
-    if (panelSize === collapsedSize) {
+    if (fuzzyCompareNumbers(panelSize, collapsedSize) <= 0) {
       // Restore this panel to the size it was before it was collapsed, if possible.
       const prevPanelSize = panelSizeBeforeCollapseRef.value.get(
         panelData.id,
       )
+      const sizeUnit = panelData.constraints.sizeUnit ?? '%'
+      const groupSize = groupSizeInPixels.value ?? getGroupSizeInPixels()
+
+      const restoredSize
+        = sizeUnit === 'px' && groupSize
+          ? prevPanelSize != null
+            ? (prevPanelSize / groupSize) * 100
+            : null
+          : prevPanelSize
 
       const baseSize
-        = prevPanelSize != null && prevPanelSize >= minSize
-          ? prevPanelSize
+        = restoredSize != null && restoredSize >= minSize
+          ? restoredSize
           : minSize
 
       const isLastPanel
@@ -635,18 +763,27 @@ function getPanelSize(panelData: PanelData) {
 function isPanelCollapsed(panelData: PanelData) {
   const { layout, panelDataArray } = eagerValuesRef.value
 
+  const panelConstraintsArray = getPanelConstraintsInPercent()
+
   const {
     collapsedSize = 0,
     collapsible,
     panelSize,
-  } = panelDataHelper(panelDataArray, panelData, layout)
+  } = panelDataHelper(
+    panelDataArray,
+    panelData,
+    layout,
+    panelConstraintsArray ?? undefined,
+  )
 
   if (!collapsible)
     return false
 
   // panelSize is undefined during ssr due to vue ssr reactivity limitation.
   if (panelSize === undefined) {
-    return panelData.constraints.defaultSize === panelData.constraints.collapsedSize
+    const panelIndex = findPanelDataIndex(panelDataArray, panelData)
+    const constraints = panelConstraintsArray?.[panelIndex] ?? panelData.constraints
+    return constraints.defaultSize === constraints.collapsedSize
   }
   else {
     return panelSize === collapsedSize
@@ -656,11 +793,18 @@ function isPanelCollapsed(panelData: PanelData) {
 function isPanelExpanded(panelData: PanelData) {
   const { layout, panelDataArray } = eagerValuesRef.value
 
+  const panelConstraintsArray = getPanelConstraintsInPercent()
+
   const {
     collapsedSize = 0,
     collapsible,
     panelSize,
-  } = panelDataHelper(panelDataArray, panelData, layout)
+  } = panelDataHelper(
+    panelDataArray,
+    panelData,
+    layout,
+    panelConstraintsArray ?? undefined,
+  )
 
   assert(
     panelSize != null,
@@ -702,6 +846,7 @@ function panelDataHelper(
   panelDataArray: PanelData[],
   panelData: PanelData,
   layout: number[],
+  panelConstraints?: PanelConstraints[] | null,
 ) {
   const panelIndex = findPanelDataIndex(panelDataArray, panelData)
 
@@ -710,10 +855,13 @@ function panelDataHelper(
     ? [panelIndex - 1, panelIndex]
     : [panelIndex, panelIndex + 1]
 
+  const constraints = panelConstraints ?? getPanelConstraintsInPercent()
+  const panelConstraintsFromGroup = constraints?.[panelIndex]
+
   const panelSize = layout[panelIndex]
 
   return {
-    ...panelData.constraints,
+    ...(panelConstraintsFromGroup ?? panelData.constraints),
     panelSize,
     pivotIndices,
   }

--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -502,6 +502,18 @@ function resizePanel(panelData: PanelData, unsafePanelSize: number) {
   if (!panelConstraintsArray)
     return
 
+  const panelIndex = findPanelDataIndex(panelDataArray, panelData)
+  const panelUnit = panelData.constraints.sizeUnit ?? '%'
+
+  // Convert px to percent if needed for internal calculation
+  let sizeInPercent = unsafePanelSize
+  if (panelUnit === 'px') {
+    const groupSize = getGroupSizeInPixels()
+    if (groupSize != null) {
+      sizeInPercent = (unsafePanelSize / groupSize) * 100
+    }
+  }
+
   const { panelSize, pivotIndices } = panelDataHelper(
     panelDataArray,
     panelData,
@@ -511,10 +523,10 @@ function resizePanel(panelData: PanelData, unsafePanelSize: number) {
 
   assert(panelSize != null)
 
-  const isLastPanel = findPanelDataIndex(panelDataArray, panelData) === panelDataArray.length - 1
+  const isLastPanel = panelIndex === panelDataArray.length - 1
   const delta = isLastPanel
-    ? panelSize - unsafePanelSize
-    : unsafePanelSize - panelSize
+    ? panelSize - sizeInPercent
+    : sizeInPercent - panelSize
 
   const nextLayout = adjustLayoutByDelta({
     delta,
@@ -756,6 +768,15 @@ function getPanelSize(panelData: PanelData) {
     panelSize != null,
     `Panel size not found for panel "${panelData.id}"`,
   )
+
+  // If the panel uses px units, convert from percent back to px
+  const panelUnit = panelData.constraints.sizeUnit ?? '%'
+  if (panelUnit === 'px') {
+    const groupSize = getGroupSizeInPixels()
+    if (groupSize != null) {
+      return (panelSize / 100) * groupSize
+    }
+  }
 
   return panelSize
 }

--- a/packages/core/src/Splitter/SplitterPanel.vue
+++ b/packages/core/src/Splitter/SplitterPanel.vue
@@ -162,11 +162,11 @@ defineExpose({
   collapse,
   /** If panel is currently collapsed, expand it to its most recent size. */
   expand,
-  /** Gets the current size of the panel as a percentage (1 - 100). */
+  /** Gets the current size of the panel (in the panel's sizeUnit: percentage for '%', pixels for 'px'). */
   getSize() {
     return getPanelSize(panelDataRef.value)
   },
-  /** Resize panel to the specified percentage (1 - 100). */
+  /** Resize panel to the specified size (in the panel's sizeUnit: percentage for '%', pixels for 'px'). */
   resize,
   /** Returns `true` if the panel is currently collapsed */
   isCollapsed,

--- a/packages/core/src/Splitter/SplitterPanel.vue
+++ b/packages/core/src/Splitter/SplitterPanel.vue
@@ -4,20 +4,22 @@ import { useId } from '@/shared'
 import { PRECISION } from './utils/constants'
 
 export interface SplitterPanelProps extends PrimitiveProps {
-  /** The size of panel when it is collapsed. */
+  /** The size of panel when it is collapsed; interpreted using `sizeUnit`. */
   collapsedSize?: number
   /** Should panel collapse when resized beyond its `minSize`. When `true`, it will be collapsed to `collapsedSize`. */
   collapsible?: boolean
-  /** Initial size of panel (numeric value between 1-100) */
+  /** Initial size of panel, interpreted using `sizeUnit` (percent by default). */
   defaultSize?: number
   /** Panel id (unique within group); falls back to `useId` when not provided */
   id?: string
-  /** The maximum allowable size of panel (numeric value between 1-100); defaults to `100` */
+  /** The maximum allowable size of panel, interpreted using `sizeUnit`; defaults to `100` (percent). */
   maxSize?: number
-  /** The minimum allowable size of panel (numeric value between 1-100); defaults to `10` */
+  /** The minimum allowable size of panel, interpreted using `sizeUnit`; defaults to `10` (percent). */
   minSize?: number
   /** The order of panel within group; required for groups with conditionally rendered panels */
   order?: number
+  /** Unit used for sizing values; `%` by default, or `px` for fixed sizing. */
+  sizeUnit?: '%' | 'px'
 }
 
 export type SplitterPanelEmits = {
@@ -49,6 +51,7 @@ export type PanelConstraints = {
   /** Panel id (unique within group); falls back to useId when not provided */
   maxSize?: number | undefined
   minSize?: number | undefined
+  sizeUnit?: '%' | 'px' | undefined
 }
 
 export type PanelData = {
@@ -107,6 +110,7 @@ const panelDataRef = computed(() => ({
     /** Panel id (unique within group); falls back to useId when not provided */
     maxSize: props.maxSize,
     minSize: props.minSize,
+    sizeUnit: props.sizeUnit ?? '%',
   },
   id: panelId,
   idIsFromProps: props.id !== undefined,
@@ -121,6 +125,7 @@ watch(() => panelDataRef.value.constraints, (constraints, prevConstraints) => {
     || prevConstraints.collapsible !== constraints.collapsible
     || prevConstraints.maxSize !== constraints.maxSize
     || prevConstraints.minSize !== constraints.minSize
+    || prevConstraints.sizeUnit !== constraints.sizeUnit
   ) {
     reevaluatePanelConstraints(panelDataRef.value, prevConstraints)
   }

--- a/packages/core/src/Splitter/story/SplitterPixelSizing.story.vue
+++ b/packages/core/src/Splitter/story/SplitterPixelSizing.story.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from '..'
+
+const isShowingExtra = ref(true)
+const collapsibleOpen = ref(true)
+const collapsiblePanelRef = ref<InstanceType<typeof SplitterPanel> | null>(null)
+
+function handleCollapsed() {
+  collapsibleOpen.value = false
+}
+
+function handleExpanded() {
+  collapsibleOpen.value = true
+}
+
+function toggleCollapsible() {
+  if (collapsibleOpen.value)
+    collapsiblePanelRef.value?.collapse?.()
+  else
+    collapsiblePanelRef.value?.expand?.()
+
+  collapsibleOpen.value = !collapsibleOpen.value
+}
+</script>
+
+<template>
+  <Story
+    title="Splitter/Pixel sized panels"
+    :layout="{ type: 'single', iframe: false }"
+  >
+    <Variant title="Fixed sidebar">
+      <div class="space-y-4">
+        <div
+          class="h-48 w-full"
+        >
+          <SplitterGroup direction="horizontal">
+            <SplitterPanel
+              size-unit="px"
+              :default-size="220"
+              :min-size="160"
+              :max-size="320"
+              class="flex items-center justify-center bg-blackA8 rounded-lg"
+            >
+              Sidebar (px)
+            </SplitterPanel>
+            <SplitterResizeHandle class="w-2 data-[state=active]:bg-white transition" />
+            <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+              Flexible content
+            </SplitterPanel>
+          </SplitterGroup>
+        </div>
+      </div>
+    </Variant>
+
+    <Variant title="Persistence (px)">
+      <div class="space-y-4">
+        <div
+          class="h-48 w-full"
+        >
+          <SplitterGroup
+            auto-save-id="pixel-persistence"
+            direction="horizontal"
+          >
+            <SplitterPanel
+              size-unit="px"
+              :default-size="200"
+              :min-size="140"
+              :max-size="320"
+              class="flex items-center justify-center bg-blackA8 rounded-lg"
+            >
+              Sidebar (px)
+            </SplitterPanel>
+            <SplitterResizeHandle class="w-2 data-[state=active]:bg-white transition" />
+            <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+              Resizable content
+            </SplitterPanel>
+          </SplitterGroup>
+        </div>
+      </div>
+    </Variant>
+
+    <Variant title="Conditional panel (px)">
+      <div class="space-y-4">
+        <div class="flex items-center gap-2">
+          <button
+            class="px-3 py-1.5 text-sm rounded bg-white hover:bg-slate-100 text-slate-800"
+            @click="isShowingExtra = !isShowingExtra"
+          >
+            {{ isShowingExtra ? 'Hide' : 'Show' }} extra panel
+          </button>
+        </div>
+
+        <div class="h-48 w-full">
+          <SplitterGroup direction="horizontal">
+            <SplitterPanel
+              class="flex items-center justify-center bg-blackA8 rounded-lg"
+              :min-size="15"
+            >
+              Primary
+            </SplitterPanel>
+            <SplitterResizeHandle class="w-2 data-[state=active]:bg-white transition" />
+
+            <template v-if="isShowingExtra">
+              <SplitterPanel
+                size-unit="px"
+                :default-size="180"
+                :min-size="140"
+                :max-size="260"
+                :order="2"
+                class="flex items-center justify-center bg-blackA8 rounded-lg"
+              >
+                Optional (px)
+              </SplitterPanel>
+              <SplitterResizeHandle class="w-2 data-[state=active]:bg-white transition" />
+            </template>
+
+            <SplitterPanel
+              :order="3"
+              class="flex items-center justify-center bg-blackA8 rounded-lg"
+            >
+              Main content
+            </SplitterPanel>
+          </SplitterGroup>
+        </div>
+      </div>
+    </Variant>
+
+    <Variant title="Collapsible (px)">
+      <div class="space-y-3">
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <button
+            class="px-3 py-1.5 text-sm rounded bg-white hover:bg-slate-100 text-slate-800"
+            @click="toggleCollapsible"
+          >
+            {{ collapsibleOpen ? 'Collapse' : 'Expand' }} sidebar
+          </button>
+        </div>
+
+        <div class="h-48 w-full">
+          <SplitterGroup direction="horizontal">
+            <SplitterPanel
+              ref="collapsiblePanelRef"
+              collapsible
+              size-unit="px"
+              :collapsed-size="48"
+              :default-size="200"
+              :min-size="140"
+              :max-size="260"
+              class="flex items-center justify-center bg-blackA8 rounded-lg"
+              :data-state="collapsibleOpen ? 'expanded' : 'collapsed'"
+              @collapse="handleCollapsed"
+              @expand="handleExpanded"
+            >
+              Collapsible (px)
+            </SplitterPanel>
+            <SplitterResizeHandle class="w-2 data-[state=active]:bg-white transition" />
+            <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+              Content area
+            </SplitterPanel>
+          </SplitterGroup>
+        </div>
+      </div>
+    </Variant>
+  </Story>
+</template>

--- a/packages/core/src/Splitter/utils/composables/useWindowSplitterPanelGroupBehavior.ts
+++ b/packages/core/src/Splitter/utils/composables/useWindowSplitterPanelGroupBehavior.ts
@@ -17,6 +17,7 @@ export function useWindowSplitterPanelGroupBehavior({
   panelDataArray,
   panelGroupElement,
   setLayout,
+  getPanelDataWithPercentConstraints,
 }: {
   eagerValuesRef: Ref<{
     panelDataArray: PanelData[]
@@ -26,10 +27,15 @@ export function useWindowSplitterPanelGroupBehavior({
   panelDataArray: PanelData[]
   panelGroupElement: Ref<ParentNode | null>
   setLayout: (sizes: number[]) => void
+  getPanelDataWithPercentConstraints: (groupSizeOverride?: number | null) => PanelData[] | null
 }): void {
   watchEffect((onCleanup) => {
     const _panelGroupElement = panelGroupElement.value
     if (!_panelGroupElement)
+      return
+
+    const panelDataArrayWithPercentConstraints = getPanelDataWithPercentConstraints()
+    if (!panelDataArrayWithPercentConstraints)
       return
 
     const resizeHandleElements = getResizeHandleElementsForGroup(
@@ -37,10 +43,10 @@ export function useWindowSplitterPanelGroupBehavior({
       _panelGroupElement,
     )
 
-    for (let index = 0; index < panelDataArray.length - 1; index++) {
+    for (let index = 0; index < panelDataArrayWithPercentConstraints.length - 1; index++) {
       const { valueMax, valueMin, valueNow } = calculateAriaValues({
         layout: layout.value,
-        panelsArray: panelDataArray,
+        panelsArray: panelDataArrayWithPercentConstraints,
         pivotIndices: [index, index + 1],
       })
 
@@ -50,7 +56,7 @@ export function useWindowSplitterPanelGroupBehavior({
           console.warn(`WARNING: Missing resize handle for PanelGroup "${groupId}"`)
       }
       else {
-        const panelData = panelDataArray[index]
+        const panelData = panelDataArrayWithPercentConstraints[index]
         assert(panelData)
 
         resizeHandleElement.setAttribute('aria-controls', panelData.id)
@@ -87,6 +93,10 @@ export function useWindowSplitterPanelGroupBehavior({
     const eagerValues = eagerValuesRef.value
     assert(eagerValues)
 
+    const panelDataArrayWithPercentConstraints = getPanelDataWithPercentConstraints()
+    if (!panelDataArrayWithPercentConstraints)
+      return
+
     const { panelDataArray } = eagerValues
     const groupElement = getPanelGroupElement(groupId, _panelGroupElement)
     assert(groupElement != null, `No group found for id "${groupId}"`)
@@ -115,11 +125,11 @@ export function useWindowSplitterPanelGroupBehavior({
           case 'Enter': {
             event.preventDefault()
 
-            const index = panelDataArray.findIndex(
+            const index = panelDataArrayWithPercentConstraints.findIndex(
               panelData => panelData.id === idBefore,
             )
             if (index >= 0) {
-              const panelData = panelDataArray[index]
+              const panelData = panelDataArrayWithPercentConstraints[index]
               assert(panelData)
 
               const size = layout.value[index]
@@ -136,7 +146,7 @@ export function useWindowSplitterPanelGroupBehavior({
                     ? minSize - collapsedSize
                     : collapsedSize - size,
                   layout: layout.value,
-                  panelConstraints: panelDataArray.map(
+                  panelConstraints: panelDataArrayWithPercentConstraints.map(
                     panelData => panelData.constraints,
                   ),
                   pivotIndices: determinePivotIndices(

--- a/packages/core/src/Splitter/utils/storage.ts
+++ b/packages/core/src/Splitter/utils/storage.ts
@@ -33,6 +33,9 @@ export type PanelConfigurationState = {
     [panelId: string]: number
   }
   layout: number[]
+  sizeUnits?: {
+    [panelIndex: number]: 'px' | '%'
+  }
 }
 
 export type SerializedPanelGroupState = {
@@ -102,9 +105,20 @@ export function savePanelGroupState(
   const panelGroupKey = getPanelGroupKey(autoSaveId)
   const panelKey = getPanelKey(panels)
   const state = loadSerializedPanelGroupState(autoSaveId, storage) ?? {}
+
+  // Store the size units for each panel so we can restore them correctly
+  const sizeUnits: { [panelIndex: number]: 'px' | '%' } = {}
+  panels.forEach((panel, index) => {
+    const unit = panel.constraints.sizeUnit ?? '%'
+    if (unit === 'px') {
+      sizeUnits[index] = 'px'
+    }
+  })
+
   state[panelKey] = {
     expandToSizes: Object.fromEntries(panelSizesBeforeCollapse.entries()),
     layout: sizes,
+    ...(Object.keys(sizeUnits).length > 0 && { sizeUnits }),
   }
 
   try {

--- a/packages/core/src/Splitter/utils/units.ts
+++ b/packages/core/src/Splitter/utils/units.ts
@@ -1,0 +1,161 @@
+import type { PanelConstraints, PanelData } from '../SplitterPanel.vue'
+
+export type SizeUnit = '%' | 'px'
+
+type ConvertConstraintsToPercentOptions = {
+  panelDataArray: PanelData[]
+  groupSizeInPixels: number | null
+}
+
+type ConvertValueOptions = {
+  sizeUnit: SizeUnit
+  groupSizeInPixels: number | null
+  value: number | undefined
+}
+
+function convertValueToPercent({ sizeUnit, groupSizeInPixels, value }: ConvertValueOptions): number | undefined {
+  if (value == null)
+    return value
+
+  if (sizeUnit === '%')
+    return value
+
+  if (groupSizeInPixels == null || groupSizeInPixels === 0)
+    return undefined
+
+  return (value / groupSizeInPixels) * 100
+}
+
+export function convertPanelConstraintsToPercent({
+  panelDataArray,
+  groupSizeInPixels,
+}: ConvertConstraintsToPercentOptions): PanelConstraints[] | null {
+  const requiresMeasurement = panelDataArray.some(
+    panelData => (panelData.constraints.sizeUnit ?? '%') === 'px',
+  )
+
+  if (requiresMeasurement && (!groupSizeInPixels || Number.isNaN(groupSizeInPixels)))
+    return null
+
+  return panelDataArray.map((panelData) => {
+    const constraints = panelData.constraints
+    const sizeUnit = constraints.sizeUnit ?? '%'
+
+    const collapsedSize = convertValueToPercent({
+      groupSizeInPixels,
+      sizeUnit,
+      value: constraints.collapsedSize,
+    })
+
+    const defaultSize = convertValueToPercent({
+      groupSizeInPixels,
+      sizeUnit,
+      value: constraints.defaultSize,
+    })
+
+    const maxSize = convertValueToPercent({
+      groupSizeInPixels,
+      sizeUnit,
+      value: constraints.maxSize,
+    })
+
+    const minSize = convertValueToPercent({
+      groupSizeInPixels,
+      sizeUnit,
+      value: constraints.minSize,
+    })
+
+    return {
+      ...constraints,
+      collapsedSize: collapsedSize ?? constraints.collapsedSize ?? 0,
+      defaultSize,
+      maxSize: maxSize ?? 100,
+      minSize: minSize ?? 0,
+      sizeUnit: '%',
+    }
+  })
+}
+
+type RecalculateLayoutOptions = {
+  layout: number[]
+  panelDataArray: PanelData[]
+  prevGroupSize: number | null
+  nextGroupSize: number | null
+}
+
+export function hasPixelSizedPanel(panelDataArray: PanelData[]): boolean {
+  return panelDataArray.some(panelData => (panelData.constraints.sizeUnit ?? '%') === 'px')
+}
+
+export function recalculateLayoutForPixelPanels({
+  layout,
+  panelDataArray,
+  prevGroupSize,
+  nextGroupSize,
+}: RecalculateLayoutOptions): number[] | null {
+  if (!hasPixelSizedPanel(panelDataArray)) {
+    return null
+  }
+
+  if (
+    prevGroupSize == null
+    || nextGroupSize == null
+    || prevGroupSize === 0
+    || nextGroupSize === 0
+    || Number.isNaN(prevGroupSize)
+    || Number.isNaN(nextGroupSize)
+  ) {
+    return null
+  }
+
+  const pixelPanelIndices = panelDataArray.reduce<number[]>((indices, panelData, index) => {
+    if ((panelData.constraints.sizeUnit ?? '%') === 'px')
+      indices.push(index)
+
+    return indices
+  }, [])
+
+  if (pixelPanelIndices.length === 0) {
+    return null
+  }
+
+  const pixelIndexSet = new Set(pixelPanelIndices)
+
+  const nextLayout = layout.map(size => size ?? 0)
+
+  const prevPercentForPixelPanels = pixelPanelIndices.reduce((sum, index) => sum + (layout[index] ?? 0), 0)
+
+  const nextPixelPercents = pixelPanelIndices.map((index) => {
+    const prevPercent = layout[index] ?? 0
+    const prevPixelSize = (prevPercent / 100) * prevGroupSize
+    return (prevPixelSize / nextGroupSize) * 100
+  })
+
+  const totalNextPixelPercent = nextPixelPercents.reduce((sum, value) => sum + value, 0)
+
+  const prevPercentForPercentPanels = layout.reduce((sum, size, index) => {
+    if (pixelIndexSet.has(index))
+      return sum
+
+    return sum + (size ?? 0)
+  }, 0)
+
+  const availableNextPercent = Math.max(0, 100 - totalNextPixelPercent)
+  const scaleFactor = prevPercentForPercentPanels > 0
+    ? availableNextPercent / prevPercentForPercentPanels
+    : 0
+
+  pixelPanelIndices.forEach((panelIndex, arrayIndex) => {
+    nextLayout[panelIndex] = nextPixelPercents[arrayIndex]
+  })
+
+  for (let index = 0; index < nextLayout.length; index++) {
+    if (pixelIndexSet.has(index))
+      continue
+
+    const prevSize = layout[index] ?? 0
+    nextLayout[index] = prevSize * scaleFactor
+  }
+
+  return nextLayout
+}

--- a/packages/core/src/Splitter/utils/validation.ts
+++ b/packages/core/src/Splitter/utils/validation.ts
@@ -112,11 +112,12 @@ export function validatePanelConstraints({
       defaultSize,
       maxSize = 100,
       minSize = 0,
+      sizeUnit = '%',
     } = panelConstraints
 
     if (minSize > maxSize) {
       warnings.push(
-        `min size (${minSize}%) should not be greater than max size (${maxSize}%)`,
+        `min size (${minSize}${sizeUnit}) should not be greater than max size (${maxSize}${sizeUnit})`,
       )
     }
 
@@ -131,7 +132,7 @@ export function validatePanelConstraints({
         warnings.push('default size should not be less than min size')
       }
 
-      if (defaultSize > 100)
+      if (sizeUnit === '%' && defaultSize > 100)
         warnings.push('default size should not be greater than 100')
       else if (defaultSize > maxSize)
         warnings.push('default size should not be greater than max size')


### PR DESCRIPTION
This pull request adds pixel-based sizing to the Splitter component, allowing panels to be sized in fixed pixels (`px`) alongside the existing percentage (`%`) support. The changes handle pixel sizing across layout calculations, persistence, collapse/expand operations, and panel constraints, with automatic conversion between units as needed.

**Changes:**

Added a new `sizeUnit` prop to `SplitterPanel` to specify whether a panel uses pixel or percent sizing, with corresponding support throughout the sizing logic. [[1]](diffhunk://#diff-d27523254fc04f582960419f0f159d8268a1f4f07b6064cb22f0e0203c835ea9L7-R22) [[2]](diffhunk://#diff-d27523254fc04f582960419f0f159d8268a1f4f07b6064cb22f0e0203c835ea9R54) [[3]](diffhunk://#diff-d27523254fc04f582960419f0f159d8268a1f4f07b6064cb22f0e0203c835ea9R113)

Updated layout calculation and persistence logic to convert between percent and pixel units, ensuring fixed-width panels maintain their size during resizing and when persisting state. [[1]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feR155-R193) [[2]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feR203-R229) [[3]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feR326-R343) [[4]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feR361-R403)

Refactored constraint validation to internally normalize all constraints to percent-based values and recalculate layouts when the container size changes. [[1]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feR155-R193) [[2]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feR361-R403) [[3]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feR326-R343)

Updated collapse and expand operations to store and restore panel sizes in their original unit, converting as needed between percent and pixel values. [[1]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feL514-R647) [[2]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feL532-R663) [[3]](diffhunk://#diff-f3c7f91b107254d9f2efd55fc54841479a74856cfb03fb861a5c5bb71f94d0feL570-R729)

Updated documentation with descriptions and examples of the new pixel sizing feature. [[1]](diffhunk://#diff-5335059a87385091c62857f8c69cb79b5f319f86dd0820c6df861361f6ba414fL25-R26) [[2]](diffhunk://#diff-5335059a87385091c62857f8c69cb79b5f319f86dd0820c6df861361f6ba414fR200-R224)

Closes #836, #2069 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pixel-based sizing support for panels with new `sizeUnit` prop, enabling fixed-size panels alongside fluid panels
  * Pixel sizing works seamlessly with panel persistence and collapse/expand functionality

* **Documentation**
  * Added "Pixel sizing" documentation section with practical examples and usage patterns
  * Enhanced feature list to highlight percent and pixel sizing capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->