### PR TITLE
fix: dayPeriod returning incorrect value due to missmatched format

### DIFF
--- a/packages/core/src/shared/useDateFormatter.ts
+++ b/packages/core/src/shared/useDateFormatter.ts
@@ -105,8 +105,8 @@ export function useDateFormatter(initialLocale: string, opts: DateFormatterOptio
       minute: 'numeric',
     }).formatToParts(date)
     const value = parts.find(p => p.type === 'dayPeriod')?.value
-    // Day period can be "AM"/"PM" or "a.m."/"p.m." in some locales
-    if (value === 'PM' || value === 'p.m.')
+    // Day period can be "AM"/"PM" or "am"/"pm" or "a.m."/"p.m." in some locales
+    if (value === 'PM' || value === 'pm' || value === 'p.m.')
       return 'PM'
 
     return 'AM'


### PR DESCRIPTION
This pull request fixes a bug in the `dayPeriod` function within `useDateFormatter` that causes it to only ever return "AM" for some locales e.g. "en-AU".

When `useDateFormatter` is passed the `en-AU` locale the resulting value of the `dayPeriod` part type is lowercase "pm". This causes the supported conditions to fail and the function to only ever return "AM" for locales where this is the case. This breaks the "AM/PM" day period selection functionality in any component where this is provided e.g. DateField.

I've added the lowercase "pm" to the conditions for now, but it may be better to force the value to either upper or lowercase to ensure the condition is not case-sensitive. Happy to update this PR if this is preferred.

Closes [#2381](https://github.com/unovue/reka-ui/issues/2381)