### PR TITLE
chore: change default value hint from 'top' to 'bottom'

### DIFF
--- a/packages/core/src/Popper/PopperContent.vue
+++ b/packages/core/src/Popper/PopperContent.vue
@@ -37,7 +37,7 @@ export interface PopperContentProps extends PrimitiveProps {
    * Will be reversed when collisions occur and avoidCollisions
    * is enabled.
    *
-   * @defaultValue "top"
+   * @defaultValue "bottom"
    */
   side?: Side
 


### PR DESCRIPTION
The default value is actually set to `bottom` but the ide hint shows as `top`