### PR TITLE
fix(NavigationMenu): allow `aria-label` override by fixing CollectionSlot attrs forwarding

### DIFF
--- a/packages/core/src/Collection/Collection.ts
+++ b/packages/core/src/Collection/Collection.ts
@@ -46,12 +46,13 @@ export function useCollection<ItemData = {}>(options: { key?: string, isProvider
 
   const CollectionSlot = defineComponent({
     name: 'CollectionSlot',
-    setup(_, { slots }) {
+    inheritAttrs: false,
+    setup(_, { slots, attrs }) {
       const { primitiveElement, currentElement } = usePrimitiveElement()
       watch(currentElement, () => {
         context.collectionRef.value = currentElement.value
       })
-      return () => h(Slot, { ref: primitiveElement }, slots)
+      return () => h(Slot, { ref: primitiveElement, ...attrs }, slots)
     },
   })
 

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -214,7 +214,6 @@ provideNavigationMenuContext({
   <CollectionSlot>
     <Primitive
       :ref="forwardRef"
-      aria-label="Main"
       :as="as"
       :as-child="asChild"
       :data-orientation="orientation"


### PR DESCRIPTION
Related to nuxt/ui#5141

The `NavigationMenuRoot` component had a hardcoded `aria-label="Main"` that couldn't be overridden because `CollectionSlot` wasn't forwarding attributes.

### Changes
- Removed hardcoded `aria-label="Main"` from `NavigationMenuRoot`
- Fixed `CollectionSlot` to forward `attrs` to the underlying `Slot` component

### Usage

Users should now provide their own accessible label based on the navigation's purpose, avoiding misleading defaults when used for footer/sidebar navigation:

```vue
<template>
  <NavigationMenuRoot aria-label="Header" />
  <NavigationMenuRoot aria-label="Footer" />
</template>
```