### PR TITLE
fix(EditableInput): prevent submission during IME composition

### DIFF
--- a/packages/core/src/Editable/EditableInput.vue
+++ b/packages/core/src/Editable/EditableInput.vue
@@ -45,7 +45,7 @@ watch(context.isEditing, (value) => {
 })
 
 function handleSubmitKeyDown(event: KeyboardEvent) {
-  if ((context.submitMode.value === 'enter' || context.submitMode.value === 'both') && event.key === kbd.ENTER && !event.shiftKey && !event.metaKey)
+  if ((context.submitMode.value === 'enter' || context.submitMode.value === 'both') && event.key === kbd.ENTER && !event.shiftKey && !event.metaKey && !event.isComposing)
     context.submit()
 }
 </script>


### PR DESCRIPTION
## Summary

Fixed an issue where pressing Enter to confirm IME (Input Method Editor) composition during Japanese, Chinese, or other language input would unintentionally submit the form.

related: https://github.com/unovue/reka-ui/issues/1441
ref: https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/isComposing
ref: https://heistak.github.io/your-code-displays-japanese-wrong/otherthings.html#messaging-apps-do-not-directly-hook-to-the-enter-key-to-submit-messages-by-default

## Before

https://github.com/user-attachments/assets/618e4d38-9cf0-4068-b180-228fb8eebe73

## After

https://github.com/user-attachments/assets/b2f623d5-b805-4538-bc66-3745c489867e


