### PR TITLE
fix(Tabs): only render `aria-controls` when TabsContent exists

### DIFF
--- a/packages/core/src/Tabs/Tabs.test.ts
+++ b/packages/core/src/Tabs/Tabs.test.ts
@@ -1,7 +1,8 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '.'
 import Tabs from './story/_Tabs.vue'
 
 describe('given default Tabs', () => {
@@ -37,5 +38,46 @@ describe('given default Tabs', () => {
       expect(wrapper.find('[role=tabpanel]').exists()).toBeTruthy()
       expect(wrapper.html()).toContain('Change your password')
     })
+  })
+})
+
+describe('given Tabs without TabsContent', () => {
+  it('should not render aria-controls on TabsTrigger', async () => {
+    const wrapper = mount({
+      components: { TabsRoot, TabsList, TabsTrigger },
+      template: `
+        <TabsRoot default-value="tab1">
+          <TabsList>
+            <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+            <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+          </TabsList>
+        </TabsRoot>
+      `,
+    })
+    await flushPromises()
+
+    const triggers = wrapper.findAll('[role="tab"]')
+    expect(triggers[0].attributes('aria-controls')).toBeUndefined()
+    expect(triggers[1].attributes('aria-controls')).toBeUndefined()
+  })
+
+  it('should render aria-controls only for TabsTrigger with matching TabsContent', async () => {
+    const wrapper = mount({
+      components: { TabsRoot, TabsList, TabsTrigger, TabsContent },
+      template: `
+        <TabsRoot default-value="tab1">
+          <TabsList>
+            <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+            <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+          </TabsList>
+          <TabsContent value="tab1">Content 1</TabsContent>
+        </TabsRoot>
+      `,
+    })
+    await flushPromises()
+
+    const triggers = wrapper.findAll('[role="tab"]')
+    expect(triggers[0].attributes('aria-controls')).toBeDefined()
+    expect(triggers[1].attributes('aria-controls')).toBeUndefined()
   })
 })

--- a/packages/core/src/Tabs/TabsContent.vue
+++ b/packages/core/src/Tabs/TabsContent.vue
@@ -15,7 +15,7 @@ export interface TabsContentProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { Presence } from '@/Presence'
 import { Primitive } from '@/Primitive'
 import { injectTabsRootContext } from './TabsRoot.vue'
@@ -33,9 +33,14 @@ const isSelected = computed(() => props.value === rootContext.modelValue.value)
 const isMountAnimationPreventedRef = ref(isSelected.value)
 
 onMounted(() => {
+  rootContext.registerContent(props.value)
   requestAnimationFrame(() => {
     isMountAnimationPreventedRef.value = false
   })
+})
+
+onBeforeUnmount(() => {
+  rootContext.unregisterContent(props.value)
 })
 </script>
 

--- a/packages/core/src/Tabs/TabsRoot.vue
+++ b/packages/core/src/Tabs/TabsRoot.vue
@@ -14,6 +14,9 @@ export interface TabsRootContext {
   activationMode: 'automatic' | 'manual'
   baseId: string
   tabsList: Ref<HTMLElement | undefined>
+  contentIds: Ref<Set<StringOrNumber>>
+  registerContent: (value: StringOrNumber) => void
+  unregisterContent: (value: StringOrNumber) => void
 }
 
 export interface TabsRootProps<T extends StringOrNumber = StringOrNumber> extends PrimitiveProps {
@@ -55,7 +58,7 @@ export const [injectTabsRootContext, provideTabsRootContext]
 </script>
 
 <script setup lang="ts" generic="T extends StringOrNumber = StringOrNumber">
-import { ref, toRefs } from 'vue'
+import { ref, shallowRef, toRefs } from 'vue'
 import { Primitive } from '@/Primitive'
 
 const props = withDefaults(defineProps<TabsRootProps<T>>(), {
@@ -82,6 +85,7 @@ const modelValue = useVModel<TabsRootProps<T>, 'modelValue', 'update:modelValue'
 })
 
 const tabsList = ref<HTMLElement>()
+const contentIds = shallowRef<Set<StringOrNumber>>(new Set())
 
 provideTabsRootContext({
   modelValue,
@@ -94,6 +98,15 @@ provideTabsRootContext({
   activationMode: props.activationMode,
   baseId: useId(undefined, 'reka-tabs'),
   tabsList,
+  contentIds,
+  registerContent: (value: StringOrNumber) => {
+    contentIds.value = new Set([...contentIds.value, value])
+  },
+  unregisterContent: (value: StringOrNumber) => {
+    const newSet = new Set(contentIds.value)
+    newSet.delete(value)
+    contentIds.value = newSet
+  },
 })
 </script>
 

--- a/packages/core/src/Tabs/TabsTrigger.vue
+++ b/packages/core/src/Tabs/TabsTrigger.vue
@@ -27,7 +27,7 @@ const { forwardRef } = useForwardExpose()
 const rootContext = injectTabsRootContext()
 
 const triggerId = computed(() => makeTriggerId(rootContext.baseId, props.value))
-const contentId = computed(() => makeContentId(rootContext.baseId, props.value))
+const contentId = computed(() => rootContext.contentIds.value.has(props.value) ? makeContentId(rootContext.baseId, props.value) : undefined)
 
 const isSelected = computed(() => props.value === rootContext.modelValue.value)
 </script>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR adds content registration tracking to `TabsRoot`, so `TabsTrigger` only renders `aria-controls` when a matching `TabsContent` is actually mounted which results in invalid ARIA references otherwise.

> I'm making this change because I encountered a11y issues in Nuxt UI when using it this way: https://ui.nuxt.com/docs/components/tabs#content

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by ensuring the aria-controls attribute on tab triggers only appears when corresponding tab content is present.

* **Tests**
  * Added test coverage for aria-controls behavior to verify correct attribute binding based on content availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->