### PR TITLE
feat(Checkbox/Switch): add support for custom true/false values

### DIFF
--- a/docs/content/docs/components/checkbox.md
+++ b/docs/content/docs/components/checkbox.md
@@ -112,6 +112,7 @@ Use the `trueValue` and `falseValue` props to specify custom values for the chec
 <script setup>
 import { Icon } from '@iconify/vue'
 import { CheckboxIndicator, CheckboxRoot } from 'reka-ui'
+import { ref } from 'vue'
 
 // With string values
 const acceptTerms = ref('no')

--- a/docs/content/docs/components/checkbox.md
+++ b/docs/content/docs/components/checkbox.md
@@ -21,6 +21,7 @@ A control that allows the user to toggle between checked and not checked.
     'Supports indeterminate state.',
     'Full keyboard navigation.',
     'Can be controlled or uncontrolled.',
+    'Supports custom true/false values.',
   ]"
 />
 
@@ -102,6 +103,41 @@ Wrapper around `CheckboxRoot` to support array of `modelValue`
 <!-- @include: @/meta/CheckboxGroupRoot.md -->
 
 ## Examples
+
+### Custom Values
+
+Use the `trueValue` and `falseValue` props to specify custom values for the checked and unchecked states instead of the default `true`/`false`.
+
+```vue line=5-6,11-12
+<script setup>
+import { Icon } from '@iconify/vue'
+import { CheckboxIndicator, CheckboxRoot } from 'reka-ui'
+
+// With string values
+const acceptTerms = ref('no')
+
+// With number values
+const permission = ref(0)
+</script>
+
+<template>
+  <!-- String values -->
+  <CheckboxRoot v-model="acceptTerms" true-value="yes" false-value="no">
+    <CheckboxIndicator>
+      <Icon icon="radix-icons:check" />
+    </CheckboxIndicator>
+  </CheckboxRoot>
+  <span>Value: {{ acceptTerms }}</span> <!-- "yes" or "no" -->
+
+  <!-- Number values -->
+  <CheckboxRoot v-model="permission" :true-value="1" :false-value="0">
+    <CheckboxIndicator>
+      <Icon icon="radix-icons:check" />
+    </CheckboxIndicator>
+  </CheckboxRoot>
+  <span>Value: {{ permission }}</span> <!-- 1 or 0 -->
+</template>
+```
 
 ### Indeterminate
 

--- a/docs/content/docs/components/switch.md
+++ b/docs/content/docs/components/switch.md
@@ -17,7 +17,11 @@ A control that allows the user to toggle between checked and not checked.
 ## Features
 
 <Highlights
-  :features="['Full keyboard navigation.', 'Can be controlled or uncontrolled.']"
+  :features="[
+    'Full keyboard navigation.',
+    'Can be controlled or uncontrolled.',
+    'Supports custom true/false values.',
+  ]"
 />
 
 ## Installation
@@ -81,6 +85,38 @@ The thumb that is used to visually indicate whether the switch is on or off.
     },
   ]"
 />
+
+## Examples
+
+### Custom Values
+
+Use the `trueValue` and `falseValue` props to specify custom values for the on and off states instead of the default `true`/`false`.
+
+```vue line=4-5,9-10
+<script setup>
+import { SwitchRoot, SwitchThumb } from 'reka-ui'
+
+// With string values
+const status = ref('inactive')
+
+// With number values
+const enabled = ref(0)
+</script>
+
+<template>
+  <!-- String values -->
+  <SwitchRoot v-model="status" true-value="active" false-value="inactive">
+    <SwitchThumb />
+  </SwitchRoot>
+  <span>Status: {{ status }}</span> <!-- "active" or "inactive" -->
+
+  <!-- Number values -->
+  <SwitchRoot v-model="enabled" :true-value="1" :false-value="0">
+    <SwitchThumb />
+  </SwitchRoot>
+  <span>Enabled: {{ enabled }}</span> <!-- 1 or 0 -->
+</template>
+```
 
 ## Accessibility
 

--- a/docs/content/docs/components/switch.md
+++ b/docs/content/docs/components/switch.md
@@ -95,6 +95,7 @@ Use the `trueValue` and `falseValue` props to specify custom values for the on a
 ```vue line=4-5,9-10
 <script setup>
 import { SwitchRoot, SwitchThumb } from 'reka-ui'
+import { ref } from 'vue'
 
 // With string values
 const status = ref('inactive')

--- a/packages/core/src/Checkbox/CheckboxRoot.vue
+++ b/packages/core/src/Checkbox/CheckboxRoot.vue
@@ -86,7 +86,7 @@ const modelValue = useVModel(props as any, 'modelValue', emits as any, {
 
 const disabled = computed(() => checkboxGroupContext?.disabled.value || props.disabled)
 
-const isChecked = computed(() => modelValue.value === props.trueValue)
+const isChecked = computed(() => isEqual(modelValue.value, props.trueValue))
 
 const checkboxState = computed<CheckedState>(() => {
   if (!isNullish(checkboxGroupContext?.modelValue.value)) {

--- a/packages/core/src/Checkbox/CheckboxRoot.vue
+++ b/packages/core/src/Checkbox/CheckboxRoot.vue
@@ -7,11 +7,11 @@ import { useVModel } from '@vueuse/core'
 import { createContext, isNullish, isValueEqualOrExist, useFormControl, useForwardExpose } from '@/shared'
 import { injectCheckboxGroupRootContext } from './CheckboxGroupRoot.vue'
 
-export interface CheckboxRootProps extends PrimitiveProps, FormFieldProps {
+export interface CheckboxRootProps<T = boolean> extends PrimitiveProps, FormFieldProps {
   /** The value of the checkbox when it is initially rendered. Use when you do not need to control its value. */
-  defaultValue?: boolean | 'indeterminate'
+  defaultValue?: T | 'indeterminate'
   /** The controlled value of the checkbox. Can be binded with v-model. */
-  modelValue?: boolean | 'indeterminate' | null
+  modelValue?: T | 'indeterminate' | null
   /** When `true`, prevents the user from interacting with the checkbox */
   disabled?: boolean
   /**
@@ -21,11 +21,19 @@ export interface CheckboxRootProps extends PrimitiveProps, FormFieldProps {
   value?: AcceptableValue
   /** Id of the element */
   id?: string
+  /**
+   * The value used when the checkbox is checked. Defaults to `true`.
+   */
+  trueValue?: T
+  /**
+   * The value used when the checkbox is unchecked. Defaults to `false`.
+   */
+  falseValue?: T
 }
 
-export type CheckboxRootEmits = {
+export type CheckboxRootEmits<T = boolean> = {
   /** Event handler called when the value of the checkbox changes. */
-  'update:modelValue': [value: boolean | 'indeterminate']
+  'update:modelValue': [value: T | 'indeterminate']
 }
 
 interface CheckboxRootContext {
@@ -37,7 +45,7 @@ export const [injectCheckboxRootContext, provideCheckboxRootContext]
   = createContext<CheckboxRootContext>('CheckboxRoot')
 </script>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T = boolean">
 import { isEqual } from 'ohash'
 import { computed } from 'vue'
 import { Primitive } from '@/Primitive'
@@ -49,12 +57,14 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(defineProps<CheckboxRootProps>(), {
+const props = withDefaults(defineProps<CheckboxRootProps<T>>(), {
   modelValue: undefined,
   value: 'on',
   as: 'button',
+  trueValue: (() => true) as unknown as undefined,
+  falseValue: (() => false) as unknown as undefined,
 })
-const emits = defineEmits<CheckboxRootEmits>()
+const emits = defineEmits<CheckboxRootEmits<T>>()
 
 defineSlots<{
   default?: (props: {
@@ -69,19 +79,23 @@ const { forwardRef, currentElement } = useForwardExpose()
 
 const checkboxGroupContext = injectCheckboxGroupRootContext(null)
 
-const modelValue = useVModel(props, 'modelValue', emits, {
-  defaultValue: props.defaultValue,
+const modelValue = useVModel(props as any, 'modelValue', emits as any, {
+  defaultValue: props.defaultValue ?? props.falseValue,
   passive: (props.modelValue === undefined) as false,
-}) as Ref<CheckedState>
+}) as Ref<T | 'indeterminate'>
 
 const disabled = computed(() => checkboxGroupContext?.disabled.value || props.disabled)
+
+const isChecked = computed(() => modelValue.value === props.trueValue)
 
 const checkboxState = computed<CheckedState>(() => {
   if (!isNullish(checkboxGroupContext?.modelValue.value)) {
     return isValueEqualOrExist(checkboxGroupContext.modelValue.value, props.value)
   }
   else {
-    return modelValue.value === 'indeterminate' ? 'indeterminate' : modelValue.value
+    if (modelValue.value === 'indeterminate')
+      return 'indeterminate'
+    return isChecked.value
   }
 })
 
@@ -98,7 +112,12 @@ function handleClick() {
     checkboxGroupContext.modelValue.value = modelValueArray
   }
   else {
-    modelValue.value = isIndeterminate(modelValue.value) ? true : !modelValue.value
+    if (modelValue.value === 'indeterminate') {
+      modelValue.value = props.trueValue as T
+    }
+    else {
+      modelValue.value = isChecked.value ? props.falseValue as T : props.trueValue as T
+    }
   }
 }
 

--- a/packages/core/src/Checkbox/story/Checkbox.story.vue
+++ b/packages/core/src/Checkbox/story/Checkbox.story.vue
@@ -5,6 +5,8 @@ import { CheckboxIndicator, CheckboxRoot } from '..'
 
 const checkboxOne = ref<boolean | 'indeterminate'>('indeterminate')
 const checkboxThree = ref(false)
+const customStringState = ref<'yes' | 'no'>('no')
+const customNumberState = ref<1 | 0>(0)
 </script>
 
 <template>
@@ -75,6 +77,58 @@ const checkboxThree = ref(false)
           </CheckboxRoot>
           <span class="select-none">Required Checkbox</span>
         </label>
+      </div>
+    </Variant>
+
+    <Variant title="Custom string values">
+      <div class="flex flex-col gap-4">
+        <label
+          class="flex flex-row gap-4 items-center"
+        >
+          <CheckboxRoot
+            v-model="customStringState"
+            true-value="yes"
+            false-value="no"
+            class="shadow-blackA7 hover:bg-violet3 flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white shadow-[0_2px_10px] outline-none focus-within:shadow-[0_0_0_2px_black]"
+          >
+            <CheckboxIndicator
+              class="bg-white h-full w-full rounded flex items-center justify-center"
+            >
+              <Icon
+                icon="radix-icons:check"
+                class="h-4 w-4 text-black"
+              />
+            </CheckboxIndicator>
+          </CheckboxRoot>
+          <span class="select-none">Accept terms</span>
+        </label>
+        <span class="text-sm">v-model value: "{{ customStringState }}"</span>
+      </div>
+    </Variant>
+
+    <Variant title="Custom number values">
+      <div class="flex flex-col gap-4">
+        <label
+          class="flex flex-row gap-4 items-center"
+        >
+          <CheckboxRoot
+            v-model="customNumberState"
+            :true-value="1"
+            :false-value="0"
+            class="shadow-blackA7 hover:bg-violet3 flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white shadow-[0_2px_10px] outline-none focus-within:shadow-[0_0_0_2px_black]"
+          >
+            <CheckboxIndicator
+              class="bg-white h-full w-full rounded flex items-center justify-center"
+            >
+              <Icon
+                icon="radix-icons:check"
+                class="h-4 w-4 text-black"
+              />
+            </CheckboxIndicator>
+          </CheckboxRoot>
+          <span class="select-none">Enable feature</span>
+        </label>
+        <span class="text-sm">v-model value: {{ customNumberState }}</span>
       </div>
     </Variant>
   </Story>

--- a/packages/core/src/Switch/Switch.story.vue
+++ b/packages/core/src/Switch/Switch.story.vue
@@ -3,6 +3,8 @@ import { ref } from 'vue'
 import { SwitchRoot, SwitchThumb } from '.'
 
 const switchState = ref(true)
+const customStringState = ref<'on' | 'off'>('off')
+const customNumberState = ref<1 | 0>(0)
 </script>
 
 <template>
@@ -27,6 +29,56 @@ const switchState = ref(true)
             class="block w-[21px] h-[21px] my-auto bg-white shadow-sm rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[19px]"
           />
         </SwitchRoot>
+      </div>
+    </Variant>
+
+    <Variant title="Custom string values">
+      <div class="flex flex-col gap-4">
+        <div class="flex gap-2 items-center">
+          <label
+            class="text-white text-[15px] leading-none pr-[15px]"
+            for="custom-string"
+          >
+            Status
+          </label>
+          <SwitchRoot
+            id="custom-string"
+            v-model="customStringState"
+            true-value="on"
+            false-value="off"
+            class="w-[42px] h-[25px] focus-within:outline focus-within:outline-black flex bg-black/50 shadow-sm rounded-full relative data-[state=checked]:bg-black cursor-default"
+          >
+            <SwitchThumb
+              class="block w-[21px] h-[21px] my-auto bg-white shadow-sm rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[19px]"
+            />
+          </SwitchRoot>
+        </div>
+        <span class="text-white text-sm">v-model value: "{{ customStringState }}"</span>
+      </div>
+    </Variant>
+
+    <Variant title="Custom number values">
+      <div class="flex flex-col gap-4">
+        <div class="flex gap-2 items-center">
+          <label
+            class="text-white text-[15px] leading-none pr-[15px]"
+            for="custom-number"
+          >
+            Permission
+          </label>
+          <SwitchRoot
+            id="custom-number"
+            v-model="customNumberState"
+            :true-value="1"
+            :false-value="0"
+            class="w-[42px] h-[25px] focus-within:outline focus-within:outline-black flex bg-black/50 shadow-sm rounded-full relative data-[state=checked]:bg-black cursor-default"
+          >
+            <SwitchThumb
+              class="block w-[21px] h-[21px] my-auto bg-white shadow-sm rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[19px]"
+            />
+          </SwitchRoot>
+        </div>
+        <span class="text-white text-sm">v-model value: {{ customNumberState }}</span>
       </div>
     </Variant>
   </Story>

--- a/packages/core/src/Switch/SwitchRoot.vue
+++ b/packages/core/src/Switch/SwitchRoot.vue
@@ -1,28 +1,36 @@
 <script lang="ts">
-import type { Ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
 import type { FormFieldProps } from '@/shared/types'
 import { createContext, useFormControl, useForwardExpose } from '@/shared'
 
-export interface SwitchRootProps extends PrimitiveProps, FormFieldProps {
+export interface SwitchRootProps<T = boolean> extends PrimitiveProps, FormFieldProps {
   /** The state of the switch when it is initially rendered. Use when you do not need to control its state. */
-  defaultValue?: boolean
+  defaultValue?: T
   /** The controlled state of the switch. Can be bind as `v-model`. */
-  modelValue?: boolean | null
+  modelValue?: T | null
   /** When `true`, prevents the user from interacting with the switch. */
   disabled?: boolean
   id?: string
   /** The value given as data when submitted with a `name`. */
   value?: string
+  /**
+   * The value used when the switch is on. Defaults to `true`.
+   */
+  trueValue?: T
+  /**
+   * The value used when the switch is off. Defaults to `false`.
+   */
+  falseValue?: T
 }
 
-export type SwitchRootEmits = {
+export type SwitchRootEmits<T = boolean> = {
   /** Event handler called when the value of the switch changes. */
-  'update:modelValue': [payload: boolean]
+  'update:modelValue': [payload: T]
 }
 
 export interface SwitchRootContext {
-  modelValue?: Ref<boolean>
+  checked: ComputedRef<boolean>
   toggleCheck: () => void
   disabled: Ref<boolean>
 }
@@ -31,38 +39,44 @@ export const [injectSwitchRootContext, provideSwitchRootContext]
   = createContext<SwitchRootContext>('SwitchRoot')
 </script>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T = boolean">
 import { useVModel } from '@vueuse/core'
 import { computed, toRefs } from 'vue'
 import { Primitive } from '@/Primitive'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
 
-const props = withDefaults(defineProps<SwitchRootProps>(), {
+const props = withDefaults(defineProps<SwitchRootProps<T>>(), {
   as: 'button',
   modelValue: undefined,
   value: 'on',
+  trueValue: (() => true) as unknown as undefined,
+  falseValue: (() => false) as unknown as undefined,
 })
-const emit = defineEmits<SwitchRootEmits>()
+const emit = defineEmits<SwitchRootEmits<T>>()
 
 defineSlots<{
   default?: (props: {
     /** Current value */
     modelValue: typeof modelValue.value
+    /** Whether the switch is checked */
+    checked: typeof checked.value
   }) => any
 }>()
 
 const { disabled } = toRefs(props)
 
-const modelValue = useVModel(props, 'modelValue', emit, {
-  defaultValue: props.defaultValue,
+const modelValue = useVModel(props as any, 'modelValue', emit as any, {
+  defaultValue: props.defaultValue ?? props.falseValue,
   passive: (props.modelValue === undefined) as false,
-}) as Ref<boolean>
+}) as Ref<T>
+
+const checked = computed(() => modelValue.value === props.trueValue)
 
 function toggleCheck() {
   if (disabled.value)
     return
 
-  modelValue.value = !modelValue.value
+  modelValue.value = checked.value ? props.falseValue as T : props.trueValue as T
 }
 
 const { forwardRef, currentElement } = useForwardExpose()
@@ -70,7 +84,7 @@ const isFormControl = useFormControl(currentElement)
 const ariaLabel = computed(() => props.id && currentElement.value ? (document.querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText : undefined)
 
 provideSwitchRootContext({
-  modelValue,
+  checked,
   toggleCheck,
   disabled,
 })
@@ -85,9 +99,9 @@ provideSwitchRootContext({
     :type="as === 'button' ? 'button' : undefined"
     :value="value"
     :aria-label="$attrs['aria-label'] || ariaLabel"
-    :aria-checked="modelValue"
+    :aria-checked="checked"
     :aria-required="required"
-    :data-state="modelValue ? 'checked' : 'unchecked'"
+    :data-state="checked ? 'checked' : 'unchecked'"
     :data-disabled="disabled ? '' : undefined"
     :as-child="asChild"
     :as="as"
@@ -95,7 +109,10 @@ provideSwitchRootContext({
     @click="toggleCheck"
     @keydown.enter.prevent="toggleCheck"
   >
-    <slot :model-value="modelValue" />
+    <slot
+      :model-value="modelValue"
+      :checked="checked"
+    />
 
     <VisuallyHiddenInput
       v-if="isFormControl && name"
@@ -104,7 +121,7 @@ provideSwitchRootContext({
       :disabled="disabled"
       :required="required"
       :value="value"
-      :checked="!!modelValue"
+      :checked="checked"
     />
   </Primitive>
 </template>

--- a/packages/core/src/Switch/SwitchThumb.vue
+++ b/packages/core/src/Switch/SwitchThumb.vue
@@ -18,7 +18,7 @@ useForwardExpose()
 
 <template>
   <Primitive
-    :data-state="rootContext.modelValue?.value ? 'checked' : 'unchecked'"
+    :data-state="rootContext.checked.value ? 'checked' : 'unchecked'"
     :data-disabled="rootContext.disabled.value ? '' : undefined"
     :as-child="asChild"
     :as="as"


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unovue/reka-ui/issues/2409

### ❓ Type of change

Add ability to pass optional `:true-value` and `:false-value` to both Checkbox and Switch components.

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Like native Vue behavior, this helps binding to custom values instead `true`or `false`, like `1`and `0`.
Useful for bind data to DB responses that use `1` for `true` and `0` for `false`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checkbox and Switch now support custom true/false values (string, numeric, and other types) for v-model bindings.

* **Documentation**
  * Added "Custom Values" examples showing string and numeric mappings and live v-model displays.
  * Updated feature lists to reflect custom value support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->