### PR TITLE
feat(DatePicker, DateRangePicker): integrate locale handling with useLocale hook

### DIFF
--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { ConfigProvider } from '@/ConfigProvider'
 import { useTestKbd } from '@/shared'
 import DatePicker from './story/_DatePicker.vue'
 
@@ -285,5 +286,80 @@ describe('datePicker', async () => {
     const day = getByTestId('date-1-1')
     await user.click(day)
     expect(popoverContent).toBeVisible()
+  })
+
+  describe('locale integration with ConfigProvider', () => {
+    it('uses locale from ConfigProvider when no locale prop is provided', async () => {
+      const { getByTestId } = render({
+        components: { ConfigProvider, DatePicker },
+        template: `
+          <ConfigProvider locale="de">
+            <DatePicker :datePickerProps="{ modelValue: new CalendarDate(2024, 1, 15) }" />
+          </ConfigProvider>
+        `,
+        setup() {
+          return { CalendarDate }
+        },
+      })
+
+      const month = getByTestId('month')
+      // German locale should display month as single digit without leading zero
+      // The month input should be focused and have German locale formatting
+      expect(month).toBeInTheDocument()
+    })
+
+    it('locale prop overrides ConfigProvider locale', async () => {
+      const { getByTestId } = render({
+        components: { ConfigProvider, DatePicker },
+        template: `
+          <ConfigProvider locale="de">
+            <DatePicker :datePickerProps="{ modelValue: new CalendarDate(2024, 1, 15), locale: 'en' }" />
+          </ConfigProvider>
+        `,
+        setup() {
+          return { CalendarDate }
+        },
+      })
+
+      const month = getByTestId('month')
+      // Even though ConfigProvider sets 'de', explicit prop should use 'en'
+      expect(month).toBeInTheDocument()
+    })
+
+    it('updates when ConfigProvider locale changes', async () => {
+      const wrapper = render({
+        components: { ConfigProvider, DatePicker },
+        template: `
+          <ConfigProvider :locale="locale">
+            <DatePicker :datePickerProps="{ modelValue: new CalendarDate(2024, 1, 15) }" />
+          </ConfigProvider>
+        `,
+        setup() {
+          return {
+            CalendarDate,
+            locale: 'en',
+          }
+        },
+      })
+
+      const month = wrapper.getByTestId('month')
+      expect(month).toBeInTheDocument()
+
+      // Change locale
+      await wrapper.rerender({ locale: 'de' })
+
+      // Month segment should still be in the document
+      expect(month).toBeInTheDocument()
+    })
+
+    it('uses default locale when no ConfigProvider and no locale prop', async () => {
+      const { month } = setup({
+        datePickerProps: { modelValue: calendarDate },
+      })
+
+      // Should use browser default locale (typically 'en' in test environment)
+      expect(month).toBeInTheDocument()
+      expect(month).toHaveTextContent(String(calendarDate.month))
+    })
   })
 })

--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -290,6 +290,7 @@ describe('datePicker', async () => {
 
   describe('locale integration with ConfigProvider', () => {
     it('uses locale from ConfigProvider when no locale prop is provided', async () => {
+      const user = userEvent.setup()
       const { getByTestId } = render({
         components: { ConfigProvider, DatePicker },
         template: `
@@ -302,18 +303,21 @@ describe('datePicker', async () => {
         },
       })
 
-      const month = getByTestId('month')
-      // German locale should display month as single digit without leading zero
-      // The month input should be focused and have German locale formatting
-      expect(month).toBeInTheDocument()
+      const trigger = getByTestId('trigger')
+      await user.click(trigger)
+
+      const heading = getByTestId('heading')
+      // German locale should display month name in German (e.g., "Januar" not "January")
+      expect(heading).toHaveTextContent('Januar')
     })
 
     it('locale prop overrides ConfigProvider locale', async () => {
+      const user = userEvent.setup()
       const { getByTestId } = render({
         components: { ConfigProvider, DatePicker },
         template: `
           <ConfigProvider locale="de">
-            <DatePicker :datePickerProps="{ modelValue: new CalendarDate(2024, 1, 15), locale: 'en' }" />
+            <DatePicker :datePickerProps="{ modelValue: new CalendarDate(2024, 1, 15), locale: 'en-US' }" />
           </ConfigProvider>
         `,
         setup() {
@@ -321,45 +325,26 @@ describe('datePicker', async () => {
         },
       })
 
-      const month = getByTestId('month')
-      // Even though ConfigProvider sets 'de', explicit prop should use 'en'
-      expect(month).toBeInTheDocument()
-    })
+      const trigger = getByTestId('trigger')
+      await user.click(trigger)
 
-    it('updates when ConfigProvider locale changes', async () => {
-      const wrapper = render({
-        components: { ConfigProvider, DatePicker },
-        template: `
-          <ConfigProvider :locale="locale">
-            <DatePicker :datePickerProps="{ modelValue: new CalendarDate(2024, 1, 15) }" />
-          </ConfigProvider>
-        `,
-        setup() {
-          return {
-            CalendarDate,
-            locale: 'en',
-          }
-        },
-      })
-
-      const month = wrapper.getByTestId('month')
-      expect(month).toBeInTheDocument()
-
-      // Change locale
-      await wrapper.rerender({ locale: 'de' })
-
-      // Month segment should still be in the document
-      expect(month).toBeInTheDocument()
+      const heading = getByTestId('heading')
+      // Even though ConfigProvider sets 'de', explicit prop should use 'en-US'
+      expect(heading).toHaveTextContent('January')
     })
 
     it('uses default locale when no ConfigProvider and no locale prop', async () => {
-      const { month } = setup({
+      const { user, trigger, getByTestId } = setup({
         datePickerProps: { modelValue: calendarDate },
       })
 
+      await user.click(trigger)
+
+      const heading = getByTestId('heading')
       // Should use browser default locale (typically 'en' in test environment)
-      expect(month).toBeInTheDocument()
-      expect(month).toHaveTextContent(String(calendarDate.month))
+      // January 1980 should be displayed
+      expect(heading).toHaveTextContent('January')
+      expect(heading).toHaveTextContent('1980')
     })
   })
 })

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -7,7 +7,7 @@ import type { Matcher, WeekDayFormat } from '@/date'
 import type { DateStep, Granularity, HourCycle } from '@/shared/date'
 import type { Direction } from '@/shared/types'
 import { computed, ref, toRefs, watch } from 'vue'
-import { createContext, useDirection } from '@/shared'
+import { createContext, useDirection, useLocale } from '@/shared'
 import { getDefaultDate } from '@/shared/date'
 import { PopoverRoot } from '..'
 
@@ -80,14 +80,13 @@ const props = withDefaults(defineProps<DatePickerRootProps>(), {
   disabled: false,
   readonly: false,
   placeholder: undefined,
-  locale: 'en',
   isDateDisabled: undefined,
   isDateUnavailable: undefined,
   closeOnSelect: false,
 })
 const emits = defineEmits<DatePickerRootEmits & PopoverRootEmits>()
 const {
-  locale,
+  locale: propLocale,
   disabled,
   readonly,
   pagedNavigation,
@@ -115,6 +114,7 @@ const {
 } = toRefs(props)
 
 const dir = useDirection(propDir)
+const locale = useLocale(propLocale)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: defaultValue.value,
@@ -125,7 +125,7 @@ const defaultDate = computed(() => getDefaultDate({
   defaultPlaceholder: props.placeholder,
   granularity: props.granularity,
   defaultValue: modelValue.value,
-  locale: props.locale,
+  locale: locale.value,
 }))
 
 const placeholder = useVModel(props, 'placeholder', emits, {

--- a/packages/core/src/DateRangePicker/DateRangePicker.test.ts
+++ b/packages/core/src/DateRangePicker/DateRangePicker.test.ts
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { ConfigProvider } from '@/ConfigProvider'
 import { useTestKbd } from '@/shared'
 import DateRangePicker from './story/_DateRangePicker.vue'
 
@@ -244,5 +245,95 @@ describe('dateRangePicker', async () => {
     await user.click(startDay)
     await user.click(endDay)
     expect(popoverContent).toBeVisible()
+  })
+
+  describe('locale integration with ConfigProvider', () => {
+    it('uses locale from ConfigProvider when no locale prop is provided', async () => {
+      const { getByTestId } = render({
+        components: { ConfigProvider, DateRangePicker },
+        template: `
+          <ConfigProvider locale="de">
+            <DateRangePicker :dateFieldProps="{
+              modelValue: {
+                start: new CalendarDate(2024, 1, 15),
+                end: new CalendarDate(2024, 1, 20)
+              }
+            }" />
+          </ConfigProvider>
+        `,
+        setup() {
+          return { CalendarDate }
+        },
+      })
+
+      const startMonth = getByTestId('start-month')
+      // German locale should display month properly
+      expect(startMonth).toBeInTheDocument()
+    })
+
+    it('locale prop overrides ConfigProvider locale', async () => {
+      const { getByTestId } = render({
+        components: { ConfigProvider, DateRangePicker },
+        template: `
+          <ConfigProvider locale="de">
+            <DateRangePicker :dateFieldProps="{
+              modelValue: {
+                start: new CalendarDate(2024, 1, 15),
+                end: new CalendarDate(2024, 1, 20)
+              },
+              locale: 'en'
+            }" />
+          </ConfigProvider>
+        `,
+        setup() {
+          return { CalendarDate }
+        },
+      })
+
+      const startMonth = getByTestId('start-month')
+      // Even though ConfigProvider sets 'de', explicit prop should use 'en'
+      expect(startMonth).toBeInTheDocument()
+    })
+
+    it('updates when ConfigProvider locale changes', async () => {
+      const wrapper = render({
+        components: { ConfigProvider, DateRangePicker },
+        template: `
+          <ConfigProvider :locale="locale">
+            <DateRangePicker :dateFieldProps="{
+              modelValue: {
+                start: new CalendarDate(2024, 1, 15),
+                end: new CalendarDate(2024, 1, 20)
+              }
+            }" />
+          </ConfigProvider>
+        `,
+        setup() {
+          return {
+            CalendarDate,
+            locale: 'en',
+          }
+        },
+      })
+
+      const startMonth = wrapper.getByTestId('start-month')
+      expect(startMonth).toBeInTheDocument()
+
+      // Change locale
+      await wrapper.rerender({ locale: 'de' })
+
+      // Month segment should still be in the document
+      expect(startMonth).toBeInTheDocument()
+    })
+
+    it('uses default locale when no ConfigProvider and no locale prop', async () => {
+      const { start } = setup({
+        dateFieldProps: { modelValue: calendarDate },
+      })
+
+      // Should use browser default locale (typically 'en' in test environment)
+      expect(start.month).toBeInTheDocument()
+      expect(start.month).toHaveTextContent(String(calendarDate.start.month))
+    })
   })
 })

--- a/packages/core/src/DateRangePicker/DateRangePicker.test.ts
+++ b/packages/core/src/DateRangePicker/DateRangePicker.test.ts
@@ -249,6 +249,7 @@ describe('dateRangePicker', async () => {
 
   describe('locale integration with ConfigProvider', () => {
     it('uses locale from ConfigProvider when no locale prop is provided', async () => {
+      const user = userEvent.setup()
       const { getByTestId } = render({
         components: { ConfigProvider, DateRangePicker },
         template: `
@@ -266,12 +267,16 @@ describe('dateRangePicker', async () => {
         },
       })
 
-      const startMonth = getByTestId('start-month')
-      // German locale should display month properly
-      expect(startMonth).toBeInTheDocument()
+      const trigger = getByTestId('trigger')
+      await user.click(trigger)
+
+      const heading = getByTestId('heading')
+      // German locale should display month name in German (e.g., "Januar" not "January")
+      expect(heading).toHaveTextContent('Januar')
     })
 
     it('locale prop overrides ConfigProvider locale', async () => {
+      const user = userEvent.setup()
       const { getByTestId } = render({
         components: { ConfigProvider, DateRangePicker },
         template: `
@@ -281,7 +286,7 @@ describe('dateRangePicker', async () => {
                 start: new CalendarDate(2024, 1, 15),
                 end: new CalendarDate(2024, 1, 20)
               },
-              locale: 'en'
+              locale: 'en-US'
             }" />
           </ConfigProvider>
         `,
@@ -290,50 +295,26 @@ describe('dateRangePicker', async () => {
         },
       })
 
-      const startMonth = getByTestId('start-month')
-      // Even though ConfigProvider sets 'de', explicit prop should use 'en'
-      expect(startMonth).toBeInTheDocument()
-    })
+      const trigger = getByTestId('trigger')
+      await user.click(trigger)
 
-    it('updates when ConfigProvider locale changes', async () => {
-      const wrapper = render({
-        components: { ConfigProvider, DateRangePicker },
-        template: `
-          <ConfigProvider :locale="locale">
-            <DateRangePicker :dateFieldProps="{
-              modelValue: {
-                start: new CalendarDate(2024, 1, 15),
-                end: new CalendarDate(2024, 1, 20)
-              }
-            }" />
-          </ConfigProvider>
-        `,
-        setup() {
-          return {
-            CalendarDate,
-            locale: 'en',
-          }
-        },
-      })
-
-      const startMonth = wrapper.getByTestId('start-month')
-      expect(startMonth).toBeInTheDocument()
-
-      // Change locale
-      await wrapper.rerender({ locale: 'de' })
-
-      // Month segment should still be in the document
-      expect(startMonth).toBeInTheDocument()
+      const heading = getByTestId('heading')
+      // Even though ConfigProvider sets 'de', explicit prop should use 'en-US'
+      expect(heading).toHaveTextContent('January')
     })
 
     it('uses default locale when no ConfigProvider and no locale prop', async () => {
-      const { start } = setup({
+      const { user, trigger, getByTestId } = setup({
         dateFieldProps: { modelValue: calendarDate },
       })
 
+      await user.click(trigger)
+
+      const heading = getByTestId('heading')
       // Should use browser default locale (typically 'en' in test environment)
-      expect(start.month).toBeInTheDocument()
-      expect(start.month).toHaveTextContent(String(calendarDate.start.month))
+      // January 2022 should be displayed
+      expect(heading).toHaveTextContent('January')
+      expect(heading).toHaveTextContent('2022')
     })
   })
 })

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -7,7 +7,7 @@ import type { Matcher, WeekDayFormat } from '@/date'
 import type { DateRange, DateStep, Granularity, HourCycle } from '@/shared/date'
 
 import type { Direction } from '@/shared/types'
-import { createContext, useDirection } from '@/shared'
+import { createContext, useDirection, useLocale } from '@/shared'
 import { getDefaultDate } from '@/shared/date'
 import { PopoverRoot } from '..'
 
@@ -88,7 +88,6 @@ const props = withDefaults(defineProps<DateRangePickerRootProps>(), {
   disabled: false,
   readonly: false,
   placeholder: undefined,
-  locale: 'en',
   isDateDisabled: undefined,
   isDateUnavailable: undefined,
   isDateHighlightable: undefined,
@@ -98,7 +97,7 @@ const props = withDefaults(defineProps<DateRangePickerRootProps>(), {
 })
 const emits = defineEmits<DateRangePickerRootEmits & PopoverRootEmits>()
 const {
-  locale,
+  locale: propLocale,
   disabled,
   readonly,
   pagedNavigation,
@@ -129,6 +128,7 @@ const {
 } = toRefs(props)
 
 const dir = useDirection(propsDir)
+const locale = useLocale(propLocale)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? { start: undefined, end: undefined },
@@ -139,7 +139,7 @@ const defaultDate = getDefaultDate({
   defaultPlaceholder: props.placeholder,
   granularity: props.granularity,
   defaultValue: modelValue.value?.start,
-  locale: props.locale,
+  locale: locale.value,
 })
 
 const placeholder = useVModel(props, 'placeholder', emits, {

--- a/typos.toml
+++ b/typos.toml
@@ -3,3 +3,7 @@ extend-ignore-re = [
   # Chalk.ist website
   "Chalk\\.ist",
 ]
+
+[default.extend-words]
+# Don't correct the german locale "January"
+Januar = "Januar"


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
#2416 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
Added usage of `useLocale` composable in `DateRangePicker` and `DatePicker`
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #2416

- added synchronization with global configuration (`ConfigProvider`) with usage of `useLocale` composable

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Date picker components now resolve locale consistently via the app configuration using an internal resolution mechanism.

* **Behavior**
  * DatePicker and DateRangePicker use ConfigProvider locale when no locale prop is provided; an explicit locale prop still overrides; ConfigProvider updates propagate; sensible default locale applies otherwise.

* **Tests**
  * Added integration tests covering locale resolution, override behavior, and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->