### PR TITLE
fix(Calendar/RangeCalendar): when the selected date or today is outside the range of allowed dates, cannot use the tab to select selectable date

### DIFF
--- a/packages/core/src/Calendar/Calendar.test.ts
+++ b/packages/core/src/Calendar/Calendar.test.ts
@@ -960,4 +960,29 @@ describe('calendar - tabindex states', () => {
     expect(outsideVisibleDay).toHaveAttribute('data-outside-visible-view')
     expect(outsideVisibleDay).not.toHaveAttribute('tabindex')
   })
+
+  it('sets tabindex to 0 for first can tab selected date when has modelValue', async () => {
+    const { getByTestId } = setup({
+      calendarProps: {
+        modelValue: calendarDate,
+        minValue: new CalendarDate(1980, 1, 15),
+        maxValue: new CalendarDate(1980, 1, 19),
+      },
+    })
+
+    const firstCanTabSelectedDate = getByTestId('date-1-15')
+    expect(firstCanTabSelectedDate).toHaveAttribute('tabindex', '0')
+  })
+
+  it('sets tabindex to 0 for first can tab selected date', async () => {
+    const { getByTestId } = setup({
+      calendarProps: {
+        placeholder: calendarDate,
+        maxValue: new CalendarDate(1980, 1, 19),
+      },
+    })
+
+    const firstCanTabSelectedDate = getByTestId('date-1-1')
+    expect(firstCanTabSelectedDate).toHaveAttribute('tabindex', '0')
+  })
 })

--- a/packages/core/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/core/src/Calendar/CalendarCellTrigger.vue
@@ -86,7 +86,7 @@ const isFocusedDate = computed(() => {
     return false
   if (!rootContext.disabled.value && rootContext.isPlaceholderFocusable.value && isSameDay(props.day, rootContext.placeholder.value))
     return true
-  if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDateDisabled) && !rootContext.isPlaceholderFocusable.value)
+  if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDateDisabled.value) && !rootContext.isPlaceholderFocusable.value)
     return rootContext.firstFocusableDate.value && isSameDay(props.day, rootContext.firstFocusableDate.value)
   return false
 })

--- a/packages/core/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/core/src/Calendar/CalendarCellTrigger.vue
@@ -35,6 +35,8 @@ export interface CalendarCellTriggerSlot {
     outsideVisibleView: boolean
     /** Current unavailable state */
     unavailable: boolean
+    /** Current can be selected using the tab */
+    isTabbable: boolean
   }) => any
 }
 </script>
@@ -85,6 +87,16 @@ const isFocusedDate = computed(() => {
   return !rootContext.disabled.value && isSameDay(props.day, rootContext.placeholder.value)
 })
 const isSelectedDate = computed(() => rootContext.isDateSelected(props.day))
+
+const isTabbable = computed(() => {
+  if (isOutsideView.value || isDisabled.value)
+    return false
+  if (isFocusedDate.value && rootContext.isPlaceholderFocusable.value)
+    return true
+  if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDateDisabled) && !rootContext.isPlaceholderFocusable.value)
+    return rootContext.firstFocusableDate.value && isSameDay(props.day, rootContext.firstFocusableDate.value)
+  return false
+})
 
 function changeDate(date: DateValue) {
   if (rootContext.readonly.value)
@@ -177,7 +189,7 @@ function handleArrowKey(e: KeyboardEvent) {
     :data-outside-view="isOutsideView ? '' : undefined"
     :data-outside-visible-view="isOutsideVisibleView ? '' : undefined"
     :data-focused="isFocusedDate ? '' : undefined"
-    :tabindex="isFocusedDate ? 0 : isOutsideView || isDisabled ? undefined : -1"
+    :tabindex="isTabbable ? 0 : isOutsideView || isDisabled ? undefined : -1"
     @click="handleClick"
     @keydown.up.down.left.right.space.enter="handleArrowKey"
     @keydown.enter.prevent
@@ -190,6 +202,7 @@ function handleArrowKey(e: KeyboardEvent) {
       :outside-view="isOutsideView"
       :outside-visible-view="isOutsideVisibleView"
       :unavailable="isUnavailable"
+      :is-tabbable="!!isTabbable"
     >
       {{ dayValue }}
     </slot>

--- a/packages/core/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/core/src/Calendar/CalendarCellTrigger.vue
@@ -35,8 +35,6 @@ export interface CalendarCellTriggerSlot {
     outsideVisibleView: boolean
     /** Current unavailable state */
     unavailable: boolean
-    /** Current can be selected using the tab */
-    isTabbable: boolean
   }) => any
 }
 </script>

--- a/packages/core/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/core/src/Calendar/CalendarCellTrigger.vue
@@ -82,19 +82,16 @@ const isOutsideVisibleView = computed(() =>
 const isDisabled = computed(() => rootContext.isDateDisabled(props.day) || (rootContext.disableDaysOutsideCurrentView.value && isOutsideView.value))
 
 const isFocusedDate = computed(() => {
-  return !rootContext.disabled.value && isSameDay(props.day, rootContext.placeholder.value)
-})
-const isSelectedDate = computed(() => rootContext.isDateSelected(props.day))
-
-const isTabbable = computed(() => {
   if (isOutsideView.value || isDisabled.value)
     return false
-  if (isFocusedDate.value && rootContext.isPlaceholderFocusable.value)
+  if (!rootContext.disabled.value && rootContext.isPlaceholderFocusable.value && isSameDay(props.day, rootContext.placeholder.value))
     return true
   if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDateDisabled) && !rootContext.isPlaceholderFocusable.value)
     return rootContext.firstFocusableDate.value && isSameDay(props.day, rootContext.firstFocusableDate.value)
   return false
 })
+
+const isSelectedDate = computed(() => rootContext.isDateSelected(props.day))
 
 function changeDate(date: DateValue) {
   if (rootContext.readonly.value)
@@ -187,7 +184,7 @@ function handleArrowKey(e: KeyboardEvent) {
     :data-outside-view="isOutsideView ? '' : undefined"
     :data-outside-visible-view="isOutsideVisibleView ? '' : undefined"
     :data-focused="isFocusedDate ? '' : undefined"
-    :tabindex="isTabbable ? 0 : isOutsideView || isDisabled ? undefined : -1"
+    :tabindex="isFocusedDate ? 0 : isOutsideView || isDisabled ? undefined : -1"
     @click="handleClick"
     @keydown.up.down.left.right.space.enter="handleArrowKey"
     @keydown.enter.prevent
@@ -200,7 +197,6 @@ function handleArrowKey(e: KeyboardEvent) {
       :outside-view="isOutsideView"
       :outside-visible-view="isOutsideVisibleView"
       :unavailable="isUnavailable"
-      :is-tabbable="!!isTabbable"
     >
       {{ dayValue }}
     </slot>

--- a/packages/core/src/Calendar/CalendarRoot.vue
+++ b/packages/core/src/Calendar/CalendarRoot.vue
@@ -47,6 +47,10 @@ type CalendarRootContext = {
   disableDaysOutsideCurrentView: Ref<boolean>
   minValue: Ref<DateValue | undefined>
   maxValue: Ref<DateValue | undefined>
+  isPlaceholderFocusable: Ref<boolean>
+  firstFocusableDate: Ref<DateValue | undefined>
+  hasSelectedDate: Ref<boolean>
+  isSelectedDateDisabled: Ref<boolean>
 }
 
 export interface CalendarRootProps extends PrimitiveProps {
@@ -216,6 +220,8 @@ const {
   prevPage,
   formatter,
   grid,
+  isPlaceholderFocusable,
+  firstFocusableDate,
 } = useCalendar({
   locale,
   placeholder,
@@ -237,6 +243,8 @@ const {
 const {
   isInvalid,
   isDateSelected,
+  hasSelectedDate,
+  isSelectedDateDisabled,
 } = useCalendarState({
   date: modelValue,
   isDateDisabled,
@@ -327,6 +335,10 @@ provideCalendarRootContext({
   disableDaysOutsideCurrentView,
   minValue,
   maxValue,
+  isPlaceholderFocusable,
+  firstFocusableDate,
+  hasSelectedDate,
+  isSelectedDateDisabled,
 })
 </script>
 

--- a/packages/core/src/Calendar/useCalendar.ts
+++ b/packages/core/src/Calendar/useCalendar.ts
@@ -359,15 +359,19 @@ export function useCalendar(props: UseCalendarProps) {
 
   const firstFocusableDate = computed(() => {
     for (const month of grid.value) {
-      for (const row of month.rows) {
-        for (const date of row) {
-          if (!isSameMonth(date, month.value) || isDateDisabled(date) || isDateUnavailable(date))
-            continue
-          return date
-        }
+      if (props.minValue.value && isBefore(month.value, props.minValue.value))
+        continue
+
+      const daysInMonth = getDaysInMonth(month.value)
+      const startDay = props.minValue.value && isSameMonth(props.minValue.value, month.value) ? props.minValue.value.day : 1
+
+      for (let day = startDay; day <= daysInMonth; day++) {
+        const date = month.value.set({ day })
+        if (isDateDisabled(date) || isDateUnavailable(date))
+          continue
+        return date
       }
     }
-    return undefined
   })
 
   return {

--- a/packages/core/src/Calendar/useCalendar.ts
+++ b/packages/core/src/Calendar/useCalendar.ts
@@ -6,7 +6,7 @@ import type { DateFields, DateValue } from '@internationalized/date'
 import type { Ref } from 'vue'
 import type { Grid, Matcher, WeekDayFormat } from '@/date'
 import type { DateFormatterOptions } from '@/shared/useDateFormatter'
-import { isEqualMonth, isSameDay } from '@internationalized/date'
+import { isEqualMonth, isSameDay, isSameMonth } from '@internationalized/date'
 import { computed, ref, watch } from 'vue'
 import { createMonths, getDaysInMonth, isAfter, isBefore, toDate } from '@/date'
 import { useDateFormatter } from '@/shared'
@@ -71,9 +71,26 @@ export function useCalendarState(props: UseCalendarStateProps) {
     },
   )
 
+  const hasSelectedDate = computed(() => {
+    return Array.isArray(props.date.value) ? props.date.value.length > 0 : !!props.date.value
+  })
+
+  const isSelectedDateDisabled = computed(() => {
+    if (Array.isArray(props.date.value)) {
+      if (!props.date.value.length)
+        return false
+      return props.date.value.some(dateObj => props.isDateDisabled?.(dateObj))
+    }
+    if (!props.date.value)
+      return false
+    return !!props.isDateDisabled?.(props.date.value)
+  })
+
   return {
     isDateSelected,
     isInvalid,
+    hasSelectedDate,
+    isSelectedDateDisabled,
   }
 }
 
@@ -336,6 +353,23 @@ export function useCalendar(props: UseCalendarProps) {
 
   const fullCalendarLabel = computed(() => `${props.calendarLabel.value ?? 'Event Date'}, ${headingValue.value}`)
 
+  const isPlaceholderFocusable = computed(() => {
+    return !(isDateDisabled(props.placeholder.value) || isDateUnavailable(props.placeholder.value) || isOutsideVisibleView(props.placeholder.value))
+  })
+
+  const firstFocusableDate = computed(() => {
+    for (const month of grid.value) {
+      for (const row of month.rows) {
+        for (const date of row) {
+          if (!isSameMonth(date, month.value) || isDateDisabled(date) || isDateUnavailable(date))
+            continue
+          return date
+        }
+      }
+    }
+    return undefined
+  })
+
   return {
     isDateDisabled,
     isDateUnavailable,
@@ -350,5 +384,7 @@ export function useCalendar(props: UseCalendarProps) {
     prevPage,
     headingValue,
     fullCalendarLabel,
+    isPlaceholderFocusable,
+    firstFocusableDate,
   }
 }

--- a/packages/core/src/RangeCalendar/RangeCalendar.test.ts
+++ b/packages/core/src/RangeCalendar/RangeCalendar.test.ts
@@ -862,3 +862,56 @@ describe('handles maximumDays', () => {
     })
   })
 })
+
+describe('range calendar - tabindex states', () => {
+  it('sets tabindex to 0 for first can tab selected date when has modelValue', async () => {
+    const { getByTestId } = setup({
+      calendarProps: {
+        modelValue: calendarDateRange,
+        minValue: new CalendarDate(1980, 1, 15),
+        maxValue: new CalendarDate(1980, 1, 18),
+      },
+    })
+
+    const firstCanTabSelectedDate = getByTestId('date-1-15')
+    expect(firstCanTabSelectedDate).toHaveAttribute('tabindex', '0')
+  })
+
+  it('sets tabindex to 0 for focused date when start within the allowed time range', async () => {
+    const { getByTestId } = setup({
+      calendarProps: {
+        modelValue: calendarDateRange,
+        minValue: new CalendarDate(1980, 1, 15),
+        maxValue: new CalendarDate(1980, 1, 21),
+      },
+    })
+
+    const focusedDay = getByTestId('date-1-20')
+    expect(focusedDay).toHaveAttribute('tabindex', '0')
+  })
+
+  it('sets tabindex to 0 for focused date when end within the allowed time range', async () => {
+    const { getByTestId } = setup({
+      calendarProps: {
+        modelValue: calendarDateRange,
+        minValue: new CalendarDate(1980, 1, 21),
+        maxValue: new CalendarDate(1980, 1, 26),
+      },
+    })
+
+    const focusedDay = getByTestId('date-1-25')
+    expect(focusedDay).toHaveAttribute('tabindex', '0')
+  })
+
+  it('sets tabindex to 0 for first can tab selected date', async () => {
+    const { getByTestId } = setup({
+      calendarProps: {
+        placeholder: new CalendarDate(1980, 1, 20),
+        maxValue: new CalendarDate(1980, 1, 19),
+      },
+    })
+
+    const firstCanTabSelectedDate = getByTestId('date-1-1')
+    expect(firstCanTabSelectedDate).toHaveAttribute('tabindex', '0')
+  })
+})

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -97,6 +97,22 @@ const isFocusedDate = computed(() => {
   return !rootContext.disabled.value && isSameDay(props.day, rootContext.placeholder.value)
 })
 
+const isTabbable = computed(() => {
+  if (isOutsideView.value || isDisabled.value)
+    return false
+  if (isFocusedDate.value && rootContext.isPlaceholderFocusable.value)
+    return true
+  if (rootContext.selectedFocusableDate.value && !rootContext.isPlaceholderFocusable.value) {
+    return isSameDay(props.day, rootContext.selectedFocusableDate.value)
+  }
+
+  if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDisabled) && !rootContext.isPlaceholderFocusable.value)
+    return rootContext.firstFocusableDate.value && isSameDay(props.day, rootContext.firstFocusableDate.value)
+  return false
+})
+
+const tabindex = computed(() => isTabbable.value ? 0 : isOutsideView.value || isDisabled.value ? undefined : -1)
+
 function changeDate(e: MouseEvent | KeyboardEvent, date: DateValue) {
   if (rootContext.readonly.value)
     return
@@ -257,7 +273,7 @@ function handleArrowKey(e: KeyboardEvent) {
     :data-today="isDateToday ? '' : undefined"
     :data-outside-view="isOutsideView ? '' : undefined"
     :data-focused="isFocusedDate ? '' : undefined"
-    :tabindex="isFocusedDate ? 0 : isOutsideView || isDisabled ? undefined : -1"
+    :tabindex="tabindex"
     @click="handleClick"
     @focusin="handleFocus"
     @mouseenter="handleFocus"

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -100,7 +100,7 @@ const isFocusedDate = computed(() => {
     return true
   if (rootContext.selectedFocusableDate.value && !rootContext.isPlaceholderFocusable.value)
     return isSameDay(props.day, rootContext.selectedFocusableDate.value)
-  if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDisabled) && !rootContext.isPlaceholderFocusable.value)
+  if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDisabled.value) && !rootContext.isPlaceholderFocusable.value)
     return rootContext.firstFocusableDate.value && isSameDay(props.day, rootContext.firstFocusableDate.value)
   return false
 })

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -98,9 +98,9 @@ const isFocusedDate = computed(() => {
     return false
   if (!rootContext.disabled.value && rootContext.isPlaceholderFocusable.value && isSameDay(props.day, rootContext.placeholder.value))
     return true
-  if (rootContext.selectedFocusableDate.value && !rootContext.isPlaceholderFocusable.value)
+  if (!rootContext.disabled.value && rootContext.selectedFocusableDate.value && !rootContext.isPlaceholderFocusable.value)
     return isSameDay(props.day, rootContext.selectedFocusableDate.value)
-  if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDisabled.value) && !rootContext.isPlaceholderFocusable.value)
+  if (!rootContext.disabled.value && (!rootContext.hasSelectedDate.value || rootContext.isSelectedDisabled.value) && !rootContext.isPlaceholderFocusable.value)
     return rootContext.firstFocusableDate.value && isSameDay(props.day, rootContext.firstFocusableDate.value)
   return false
 })

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -98,10 +98,8 @@ const isFocusedDate = computed(() => {
     return false
   if (!rootContext.disabled.value && rootContext.isPlaceholderFocusable.value && isSameDay(props.day, rootContext.placeholder.value))
     return true
-  if (rootContext.selectedFocusableDate.value && !rootContext.isPlaceholderFocusable.value) {
+  if (rootContext.selectedFocusableDate.value && !rootContext.isPlaceholderFocusable.value)
     return isSameDay(props.day, rootContext.selectedFocusableDate.value)
-  }
-
   if ((!rootContext.hasSelectedDate.value || rootContext.isSelectedDisabled) && !rootContext.isPlaceholderFocusable.value)
     return rootContext.firstFocusableDate.value && isSameDay(props.day, rootContext.firstFocusableDate.value)
   return false

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -111,8 +111,6 @@ const isTabbable = computed(() => {
   return false
 })
 
-const tabindex = computed(() => isTabbable.value ? 0 : isOutsideView.value || isDisabled.value ? undefined : -1)
-
 function changeDate(e: MouseEvent | KeyboardEvent, date: DateValue) {
   if (rootContext.readonly.value)
     return
@@ -273,7 +271,7 @@ function handleArrowKey(e: KeyboardEvent) {
     :data-today="isDateToday ? '' : undefined"
     :data-outside-view="isOutsideView ? '' : undefined"
     :data-focused="isFocusedDate ? '' : undefined"
-    :tabindex="tabindex"
+    :tabindex="isTabbable ? 0 : isOutsideView || isDisabled ? undefined : -1"
     @click="handleClick"
     @focusin="handleFocus"
     @mouseenter="handleFocus"

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -94,13 +94,9 @@ const isDisabled = computed(() => rootContext.isDateDisabled(props.day) || (root
 const dayValue = computed(() => props.day.day.toLocaleString(rootContext.locale.value))
 
 const isFocusedDate = computed(() => {
-  return !rootContext.disabled.value && isSameDay(props.day, rootContext.placeholder.value)
-})
-
-const isTabbable = computed(() => {
   if (isOutsideView.value || isDisabled.value)
     return false
-  if (isFocusedDate.value && rootContext.isPlaceholderFocusable.value)
+  if (!rootContext.disabled.value && rootContext.isPlaceholderFocusable.value && isSameDay(props.day, rootContext.placeholder.value))
     return true
   if (rootContext.selectedFocusableDate.value && !rootContext.isPlaceholderFocusable.value) {
     return isSameDay(props.day, rootContext.selectedFocusableDate.value)
@@ -271,7 +267,7 @@ function handleArrowKey(e: KeyboardEvent) {
     :data-today="isDateToday ? '' : undefined"
     :data-outside-view="isOutsideView ? '' : undefined"
     :data-focused="isFocusedDate ? '' : undefined"
-    :tabindex="isTabbable ? 0 : isOutsideView || isDisabled ? undefined : -1"
+    :tabindex="isFocusedDate ? 0 : isOutsideView || isDisabled ? undefined : -1"
     @click="handleClick"
     @focusin="handleFocus"
     @mouseenter="handleFocus"

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -68,6 +68,11 @@ type RangeCalendarRootContext = {
   maximumDays: Ref<number | undefined>
   minValue: Ref<DateValue | undefined>
   maxValue: Ref<DateValue | undefined>
+  isPlaceholderFocusable: Ref<boolean>
+  firstFocusableDate: Ref<DateValue | undefined>
+  hasSelectedDate: Ref<boolean>
+  isSelectedDisabled: Ref<boolean>
+  selectedFocusableDate: Ref<DateValue | undefined>
 }
 
 export interface RangeCalendarRootProps extends PrimitiveProps {
@@ -167,6 +172,7 @@ const props = withDefaults(defineProps<RangeCalendarRootProps>(), {
   allowNonContiguousRanges: false,
   maximumDays: undefined,
   disableDaysOutsideCurrentView: false,
+
 })
 const emits = defineEmits<RangeCalendarRootEmits>()
 
@@ -268,6 +274,8 @@ const {
   nextPage,
   prevPage,
   formatter,
+  isPlaceholderFocusable,
+  firstFocusableDate,
 } = useCalendar({
   locale,
   placeholder,
@@ -296,6 +304,9 @@ const {
   isHighlightedStart,
   isHighlightedEnd,
   isDateDisabled: rangeIsDateDisabled,
+  hasSelectedDate,
+  isSelectedDisabled,
+  selectedFocusableDate,
 } = useRangeCalendarState({
   start: startValue,
   end: endValue,
@@ -422,6 +433,11 @@ provideRangeCalendarRootContext({
   maximumDays,
   minValue,
   maxValue,
+  isPlaceholderFocusable,
+  firstFocusableDate,
+  hasSelectedDate,
+  isSelectedDisabled,
+  selectedFocusableDate,
 })
 
 onMounted(() => {

--- a/packages/core/src/RangeCalendar/useRangeCalendar.ts
+++ b/packages/core/src/RangeCalendar/useRangeCalendar.ts
@@ -162,6 +162,30 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
     return isSameDay(highlightedRange.value.end, date)
   }
 
+  const hasSelectedDate = computed(() => {
+    return !!(props.start.value || props.end.value)
+  })
+
+  const isStartDateDisabled = computed(() => {
+    return !!(props.start.value && props.isDateDisabled(props.start.value))
+  })
+
+  const isEndDateDisabled = computed(() => {
+    return !!(props.end.value && props.isDateDisabled(props.end.value))
+  })
+
+  const isSelectedDisabled = computed(() => {
+    return hasSelectedDate.value && isStartDateDisabled.value && isEndDateDisabled.value
+  })
+
+  const selectedFocusableDate = computed(() => {
+    if (props.start.value && !isStartDateDisabled.value)
+      return props.start.value
+    if (props.end.value && !isEndDateDisabled.value)
+      return props.end.value
+    return undefined
+  })
+
   return {
     isInvalid,
     isSelected,
@@ -172,5 +196,8 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
     isHighlightedStart,
     isHighlightedEnd,
     isDateDisabled: rangeIsDateDisabled,
+    hasSelectedDate,
+    isSelectedDisabled,
+    selectedFocusableDate,
   }
 }

--- a/packages/core/src/RangeCalendar/useRangeCalendar.ts
+++ b/packages/core/src/RangeCalendar/useRangeCalendar.ts
@@ -175,7 +175,13 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
   })
 
   const isSelectedDisabled = computed(() => {
-    return hasSelectedDate.value && isStartDateDisabled.value && isEndDateDisabled.value
+    const hasStart = !!props.start.value
+    const hasEnd = !!props.end.value
+    if (!hasStart && !hasEnd)
+      return false
+    if (hasStart && hasEnd)
+      return isStartDateDisabled.value && isEndDateDisabled.value
+    return (hasStart && isStartDateDisabled.value) || (hasEnd && isEndDateDisabled.value)
   })
 
   const selectedFocusableDate = computed(() => {


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

* Describe your changes in detail:
When the selected date or today is outside the allowed selection range, tabindex="0" will be set on the trigger of the first selectable date.   
For example, if the selected date is 2026-01-29, and the allowed selection range for Calendar or RangeCalendar is from 2026-01-26 to 2026-01-27, then setting tabindex="0" will trigger the date 2026-01-26.

* Why is this change required? What problem does it solve?   
When the selected date or today is outside the allowed range of dates, tabindex="0" is still on the trigger of the selected date or today, which will cause the date to be unselectable using tab.
For example:
    * Calendar: https://codesandbox.io/p/devbox/f2h23m   
    * RangeCalendar: https://codesandbox.io/p/devbox/psrpxj

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation and tabindex/focus selection across single and range calendars, including placeholder and disabled-date scenarios and min/max bounds.
  * More reliable identification of the first focusable date within month views.

* **Tests**
  * Added tests covering tabindex and focus behavior for single and range calendar scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->