### PR TITLE
fix(date): correct `getWeekNumber` for ISO 8601 locales

### DIFF
--- a/packages/core/src/date/calendar.test.ts
+++ b/packages/core/src/date/calendar.test.ts
@@ -1,0 +1,24 @@
+import { CalendarDate } from '@internationalized/date'
+import { describe, expect, it } from 'vitest'
+import { getWeekNumber } from './calendar'
+
+describe('getWeekNumber', () => {
+  it.each([
+  // ISO 8601 (de-DE)
+    ['de-DE', 2025, 12, 31, 1],
+    ['de-DE', 2025, 12, 29, 1],
+    ['de-DE', 2025, 12, 28, 52],
+    ['de-DE', 2024, 12, 31, 1],
+    ['de-DE', 2024, 1, 1, 1],
+    ['de-DE', 2023, 1, 1, 52],
+    ['de-DE', 2023, 1, 2, 1],
+    ['de-DE', 2021, 1, 4, 1],
+    ['de-DE', 2020, 12, 31, 53],
+    // US (en-US)
+    ['en-US', 2025, 12, 31, 53],
+    ['en-US', 2025, 1, 1, 1],
+    ['en-US', 2025, 1, 4, 1],
+  ])('%s %d-%d-%d → week %d', (locale, y, m, d, week) => {
+    expect(getWeekNumber(new CalendarDate(y, m, d), locale)).toBe(week)
+  })
+})

--- a/packages/core/src/date/calendar.test.ts
+++ b/packages/core/src/date/calendar.test.ts
@@ -3,22 +3,56 @@ import { describe, expect, it } from 'vitest'
 import { getWeekNumber } from './calendar'
 
 describe('getWeekNumber', () => {
-  it.each([
-  // ISO 8601 (de-DE)
-    ['de-DE', 2025, 12, 31, 1],
-    ['de-DE', 2025, 12, 29, 1],
-    ['de-DE', 2025, 12, 28, 52],
-    ['de-DE', 2024, 12, 31, 1],
-    ['de-DE', 2024, 1, 1, 1],
-    ['de-DE', 2023, 1, 1, 52],
-    ['de-DE', 2023, 1, 2, 1],
-    ['de-DE', 2021, 1, 4, 1],
-    ['de-DE', 2020, 12, 31, 53],
-    // US (en-US)
-    ['en-US', 2025, 12, 31, 53],
-    ['en-US', 2025, 1, 1, 1],
-    ['en-US', 2025, 1, 4, 1],
-  ])('%s %d-%d-%d → week %d', (locale, y, m, d, week) => {
-    expect(getWeekNumber(new CalendarDate(y, m, d), locale)).toBe(week)
+  describe('iSO week (de-DE locale)', () => {
+    it.each([
+      [[2025, 12, 31], 1],
+      [[2025, 12, 29], 1],
+      [[2025, 12, 28], 52],
+      [[2024, 12, 31], 1],
+      [[2024, 1, 1], 1],
+      [[2023, 1, 1], 52],
+      [[2023, 1, 2], 1],
+      [[2021, 1, 4], 1],
+      [[2020, 12, 31], 53],
+      [[2005, 1, 2], 53],
+      [[2008, 12, 29], 1],
+      [[2016, 1, 1], 53],
+      [[2016, 5, 1], 17],
+      [[2016, 5, 2], 18],
+      [[2016, 5, 31], 22],
+      [[2014, 7, 14], 29],
+    ] as const)('%j → week %d', ([y, m, d], week) => {
+      expect(getWeekNumber(new CalendarDate(y, m, d), 'de-DE')).toBe(week)
+    })
+  })
+
+  describe('non-ISO week (en-US locale)', () => {
+    it.each([
+      [[2025, 12, 31], 1],
+      [[2025, 1, 1], 1],
+      [[2025, 1, 4], 1],
+      [[2005, 1, 2], 2],
+      [[2005, 1, 4], 2],
+      [[2008, 12, 29], 1],
+    ] as const)('%j → week %d', ([y, m, d], week) => {
+      expect(getWeekNumber(new CalendarDate(y, m, d), 'en-US')).toBe(week)
+    })
+  })
+
+  describe('firstDayOfWeek override', () => {
+    it('should use locale for ISO detection, not firstDayOfWeek override', () => {
+      // en-US with Monday override should still use non-ISO week numbering (Jan 1 in week 1)
+      // Jan 1, 2023 is a Sunday. In non-ISO (en-US style), it's week 1.
+      // In ISO 8601, Jan 1, 2023 would be week 52 of 2022.
+      expect(getWeekNumber(new CalendarDate(2023, 1, 1), 'en-US', 'mon')).toBe(1)
+    })
+
+    it('should respect firstDayOfWeek for week boundaries', () => {
+      // de-DE with Sunday override: week boundaries shift to Sunday
+      // Jan 2, 2005 (Sunday) with Sunday start → week is Jan 2-8, contains Jan 4 → week 1
+      // Without override (Monday start) → week is Dec 27-Jan 2, no Jan 4 → week 53
+      expect(getWeekNumber(new CalendarDate(2005, 1, 2), 'de-DE', 'sun')).toBe(1)
+      expect(getWeekNumber(new CalendarDate(2005, 1, 2), 'de-DE')).toBe(53)
+    })
   })
 })

--- a/packages/core/src/date/calendar.ts
+++ b/packages/core/src/date/calendar.ts
@@ -223,6 +223,23 @@ export function createDateRange({ start, end }: DateRange): DateValue[] {
  * Returns the locale-specific week number
  */
 export function getWeekNumber(date: DateValue, locale: string = 'en-US', firstDayOfWeek?: DayOfWeek): number {
+  // Detect ISO locale by comparing JS day of week with locale day of week
+  const jan1 = new CalendarDate(date.year, 1, 1)
+  const jan1JsDay = jan1.toDate('UTC').getUTCDay()
+  const jan1LocaleDay = getDayOfWeek(jan1, locale, firstDayOfWeek)
+  const usesISOWeek = jan1JsDay !== jan1LocaleDay
+
+  // ISO locales (de-DE, etc.), #2422
+  if (usesISOWeek) {
+    // @see https://weeknumber.com/how-to/javascript
+    const d = date.toDate('UTC')
+    d.setUTCHours(0, 0, 0, 0)
+    d.setUTCDate(d.getUTCDate() + 3 - (d.getUTCDay() + 6) % 7)
+    const week1 = new Date(Date.UTC(d.getUTCFullYear(), 0, 4))
+    return 1 + Math.round(((d.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getUTCDay() + 6) % 7) / 7)
+  }
+
+  // Non-ISO locales (en-US, etc.)
   const firstDayOfYear = new CalendarDate(date.year, 1, 1)
 
   const firstDayOfYearWeekday = getDayOfWeek(firstDayOfYear, locale, firstDayOfWeek)

--- a/packages/core/src/date/calendar.ts
+++ b/packages/core/src/date/calendar.ts
@@ -5,7 +5,7 @@
 import type { DateValue, DayOfWeek } from '@internationalized/date'
 import type { Grid } from './types'
 import type { DateRange } from '@/shared'
-import { CalendarDate, endOfMonth, endOfYear, getDayOfWeek, startOfMonth, startOfYear } from '@internationalized/date'
+import { CalendarDate, endOfMonth, endOfYear, getDayOfWeek, startOfMonth, startOfWeek, startOfYear } from '@internationalized/date'
 import { getDaysInMonth, getLastFirstDayOfWeek, getNextLastDayOfWeek } from './comparators'
 import { chunk } from './utils'
 
@@ -223,37 +223,27 @@ export function createDateRange({ start, end }: DateRange): DateValue[] {
  * Returns the locale-specific week number
  */
 export function getWeekNumber(date: DateValue, locale: string = 'en-US', firstDayOfWeek?: DayOfWeek): number {
-  // Detect ISO locale by comparing JS day of week with locale day of week
   const jan1 = new CalendarDate(date.year, 1, 1)
-  const jan1JsDay = jan1.toDate('UTC').getUTCDay()
-  const jan1LocaleDay = getDayOfWeek(jan1, locale, firstDayOfWeek)
-  const usesISOWeek = jan1JsDay !== jan1LocaleDay
 
-  // ISO locales (de-DE, etc.), #2422
-  if (usesISOWeek) {
-    // @see https://weeknumber.com/how-to/javascript
-    const d = date.toDate('UTC')
-    d.setUTCHours(0, 0, 0, 0)
-    d.setUTCDate(d.getUTCDate() + 3 - (d.getUTCDay() + 6) % 7)
-    const week1 = new Date(Date.UTC(d.getUTCFullYear(), 0, 4))
-    return 1 + Math.round(((d.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getUTCDay() + 6) % 7) / 7)
-  }
+  // Detect ISO locale by comparing JS day of week with locale day of week
+  const usesISOWeek = jan1.toDate('UTC').getUTCDay() !== getDayOfWeek(jan1, locale)
+  const weekStartsOn = firstDayOfWeek ?? (usesISOWeek ? 'mon' : 'sun')
+  const firstWeekContainsDate = usesISOWeek ? 4 : 1
 
-  // Non-ISO locales (en-US, etc.)
-  const firstDayOfYear = new CalendarDate(date.year, 1, 1)
+  // Find the "deciding day" - its year determines which year's week numbering to use
+  const dayOfWeek = getDayOfWeek(date, locale, weekStartsOn)
+  const decidingDay = date.add({ days: 7 - firstWeekContainsDate - dayOfWeek })
+  const weekYear = decidingDay.year
 
-  const firstDayOfYearWeekday = getDayOfWeek(firstDayOfYear, locale, firstDayOfWeek)
+  // Calculate week number from week 1 start
+  const week1Ref = new CalendarDate(weekYear, 1, firstWeekContainsDate)
+  const week1Start = startOfWeek(week1Ref, locale, weekStartsOn)
+  const currentWeekStart = startOfWeek(date, locale, weekStartsOn)
 
-  const firstWeekStart = firstDayOfYear.subtract({ days: firstDayOfYearWeekday })
-
-  // If date is before the first week start It belongs to the last week of the previous year
-  if (date.compare(firstWeekStart) < 0) {
-    const prevYearDate = new CalendarDate(date.year - 1, 12, 31)
-    return getWeekNumber(prevYearDate, locale, firstDayOfWeek)
-  }
-
-  const days = getDaysBetween(firstWeekStart, date)
-
-  // Week number is days divided by 7 plus 1
-  return Math.floor(days.length / 7) + 1
+  const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
+  const daysDiff = Math.round(
+    (currentWeekStart.toDate('UTC').getTime() - week1Start.toDate('UTC').getTime())
+    / MS_PER_WEEK,
+  )
+  return daysDiff + 1
 }


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue 

resolves https://github.com/unovue/reka-ui/issues/2422

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved week-numbering logic to accurately handle ISO 8601 and locale-specific week rules (e.g., de-DE and en-US), including correct week-year determination.

* **Tests**
  * Added comprehensive, parameterized tests covering many dates, locales, and first-day-of-week overrides to validate week-number behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->