### PR TITLE
fix(tabs): remove unintended focus from TabsContent

### DIFF
--- a/packages/core/src/Tabs/TabsContent.vue
+++ b/packages/core/src/Tabs/TabsContent.vue
@@ -60,7 +60,6 @@ onBeforeUnmount(() => {
       :data-orientation="rootContext.orientation.value"
       :aria-labelledby="triggerId"
       :hidden="!present"
-      tabindex="0"
       :style="{
         animationDuration: isMountAnimationPreventedRef ? '0s' : undefined,
       }"


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2430 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes an accessibility issue where the TabsContent Component was focusable by default.

The issue was caused by an unnecessary tabindex on the Primitive element.

By removing the tabindex, focus now correctly skips the tab panel itself and only moves to interactive elements inside it, aligning with expected keyboard navigation and accessibility behavior.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted keyboard focus behavior for tab panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->