### PR TITLE
fix(docs): escape angle brackets in autogen

### DIFF
--- a/docs/content/meta/CalendarNext.md
+++ b/docs/content/meta/CalendarNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/CalendarPrev.md
+++ b/docs/content/meta/CalendarPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/CalendarRoot.md
+++ b/docs/content/meta/CalendarRoot.md
@@ -112,7 +112,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the calendar. It receives the current placeholder as an argument inside the component.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -145,7 +145,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -193,7 +193,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of dates</p>\n',
-    'type': 'Grid<DateValue>[]'
+    'type': 'Grid&lt;DateValue&gt;[]'
   },
   {
     'name': 'weekDays',

--- a/docs/content/meta/ComboboxContent.md
+++ b/docs/content/meta/ComboboxContent.md
@@ -59,7 +59,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/ComboboxInput.md
+++ b/docs/content/meta/ComboboxInput.md
@@ -29,7 +29,7 @@
   {
     'name': 'displayValue',
     'description': '<p>The display value of input for selected item. Does not work with <code>multiple</code>.</p>\n',
-    'type': '((val: any) => string)',
+    'type': '((val: any) =&gt; string)',
     'required': false
   },
   {

--- a/docs/content/meta/ComboboxItem.md
+++ b/docs/content/meta/ComboboxItem.md
@@ -38,6 +38,6 @@
   {
     'name': 'select',
     'description': '<p>Event handler called when the selecting item. &lt;br&gt; It can be prevented by calling <code>event.preventDefault</code>.</p>\n',
-    'type': '[event: SelectEvent<AcceptableValue>]'
+    'type': '[event: SelectEvent&lt;AcceptableValue&gt;]'
   }
 ]" />

--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -17,7 +17,7 @@
   {
     'name': 'by',
     'description': '<p>Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared.</p>\n',
-    'type': 'string | ((a: AcceptableValue, b: AcceptableValue) => boolean)',
+    'type': 'string | ((a: AcceptableValue, b: AcceptableValue) =&gt; boolean)',
     'required': false
   },
   {

--- a/docs/content/meta/ComboboxVirtualizer.md
+++ b/docs/content/meta/ComboboxVirtualizer.md
@@ -4,7 +4,7 @@
   {
     'name': 'estimateSize',
     'description': '<p>Estimated size (in px) of each item</p>\n',
-    'type': 'number | ((index: number) => number)',
+    'type': 'number | ((index: number) =&gt; number)',
     'required': false
   },
   {
@@ -22,7 +22,7 @@
   {
     'name': 'textContent',
     'description': '<p>Text content for each item to achieve type-ahead feature</p>\n',
-    'type': '((option: AcceptableValue) => string)',
+    'type': '((option: AcceptableValue) =&gt; string)',
     'required': false
   }
 ]" />
@@ -31,12 +31,12 @@
   {
     'name': 'option',
     'description': '',
-    'type': 'null | string | number | bigint | Record<string, any>'
+    'type': 'null | string | number | bigint | Record&lt;string, any&gt;'
   },
   {
     'name': 'virtualizer',
     'description': '',
-    'type': 'Virtualizer<HTMLElement, Element>'
+    'type': 'Virtualizer&lt;HTMLElement, Element&gt;'
   },
   {
     'name': 'virtualItem',

--- a/docs/content/meta/ConfigProvider.md
+++ b/docs/content/meta/ConfigProvider.md
@@ -31,7 +31,7 @@
   {
     'name': 'useId',
     'description': '<p>The global <code>useId</code> injection as a workaround for preventing hydration issue.</p>\n',
-    'type': '(() => string)',
+    'type': '(() =&gt; string)',
     'required': false
   }
 ]" />
@@ -40,6 +40,6 @@
   {
     'name': 'useId',
     'description': '<p>The global <code>useId</code> injection as a workaround for preventing hydration issue.</p>\n',
-    'type': '() => string'
+    'type': '() =&gt; string'
   }
 ]" />

--- a/docs/content/meta/ContextMenuContent.md
+++ b/docs/content/meta/ContextMenuContent.md
@@ -44,7 +44,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false,
     'default': '0'
   },

--- a/docs/content/meta/ContextMenuSubContent.md
+++ b/docs/content/meta/ContextMenuSubContent.md
@@ -47,7 +47,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/DateFieldRoot.md
+++ b/docs/content/meta/DateFieldRoot.md
@@ -166,6 +166,6 @@
   {
     'name': 'setFocusedElement',
     'description': '<p>Helper to set the focused element inside the DateField</p>\n',
-    'type': '(el: HTMLElement) => void'
+    'type': '(el: HTMLElement) =&gt; void'
   }
 ]" />

--- a/docs/content/meta/DatePickerCalendar.md
+++ b/docs/content/meta/DatePickerCalendar.md
@@ -9,7 +9,7 @@
   {
     'name': 'grid',
     'description': '',
-    'type': 'Grid<DateValue>[]'
+    'type': 'Grid&lt;DateValue&gt;[]'
   },
   {
     'name': 'weekDays',

--- a/docs/content/meta/DatePickerContent.md
+++ b/docs/content/meta/DatePickerContent.md
@@ -53,7 +53,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/DatePickerNext.md
+++ b/docs/content/meta/DatePickerNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/DatePickerPrev.md
+++ b/docs/content/meta/DatePickerPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>CalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/DateRangeFieldRoot.md
+++ b/docs/content/meta/DateRangeFieldRoot.md
@@ -166,6 +166,6 @@
   {
     'name': 'setFocusedElement',
     'description': '',
-    'type': '(el: HTMLElement) => void'
+    'type': '(el: HTMLElement) =&gt; void'
   }
 ]" />

--- a/docs/content/meta/DateRangePickerCalendar.md
+++ b/docs/content/meta/DateRangePickerCalendar.md
@@ -9,7 +9,7 @@
   {
     'name': 'grid',
     'description': '',
-    'type': 'Grid<DateValue>[]'
+    'type': 'Grid&lt;DateValue&gt;[]'
   },
   {
     'name': 'weekDays',

--- a/docs/content/meta/DateRangePickerContent.md
+++ b/docs/content/meta/DateRangePickerContent.md
@@ -53,7 +53,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/DateRangePickerNext.md
+++ b/docs/content/meta/DateRangePickerNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/DateRangePickerPrev.md
+++ b/docs/content/meta/DateRangePickerPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/DropdownMenuContent.md
+++ b/docs/content/meta/DropdownMenuContent.md
@@ -53,7 +53,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/DropdownMenuSubContent.md
+++ b/docs/content/meta/DropdownMenuSubContent.md
@@ -47,7 +47,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/EditableRoot.md
+++ b/docs/content/meta/EditableRoot.md
@@ -168,16 +168,16 @@
   {
     'name': 'submit',
     'description': '<p>Function to submit the value of the editable</p>\n',
-    'type': '() => void'
+    'type': '() =&gt; void'
   },
   {
     'name': 'cancel',
     'description': '<p>Function to cancel the value of the editable</p>\n',
-    'type': '() => void'
+    'type': '() =&gt; void'
   },
   {
     'name': 'edit',
     'description': '<p>Function to set the editable in edit mode</p>\n',
-    'type': '() => void'
+    'type': '() =&gt; void'
   }
 ]" />

--- a/docs/content/meta/HoverCardContent.md
+++ b/docs/content/meta/HoverCardContent.md
@@ -53,7 +53,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/ListboxItem.md
+++ b/docs/content/meta/ListboxItem.md
@@ -32,6 +32,6 @@
   {
     'name': 'select',
     'description': '<p>Event handler called when the selecting item. &lt;br&gt; It can be prevented by calling <code>event.preventDefault</code>.</p>\n',
-    'type': '[event: SelectEvent<AcceptableValue>]'
+    'type': '[event: SelectEvent&lt;AcceptableValue&gt;]'
   }
 ]" />

--- a/docs/content/meta/ListboxRoot.md
+++ b/docs/content/meta/ListboxRoot.md
@@ -17,7 +17,7 @@
   {
     'name': 'by',
     'description': '<p>Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared.</p>\n',
-    'type': 'string | ((a: AcceptableValue, b: AcceptableValue) => boolean)',
+    'type': 'string | ((a: AcceptableValue, b: AcceptableValue) =&gt; boolean)',
     'required': false
   },
   {
@@ -88,7 +88,7 @@
   {
     'name': 'entryFocus',
     'description': '<p>Event handler called when container is being focused. Can be prevented.</p>\n',
-    'type': '[event: CustomEvent<any>]'
+    'type': '[event: CustomEvent&lt;any&gt;]'
   },
   {
     'name': 'highlight',

--- a/docs/content/meta/ListboxVirtualizer.md
+++ b/docs/content/meta/ListboxVirtualizer.md
@@ -4,7 +4,7 @@
   {
     'name': 'estimateSize',
     'description': '<p>Estimated size (in px) of each item</p>\n',
-    'type': 'number | ((index: number) => number)',
+    'type': 'number | ((index: number) =&gt; number)',
     'required': false
   },
   {
@@ -22,7 +22,7 @@
   {
     'name': 'textContent',
     'description': '<p>Text content for each item to achieve type-ahead feature</p>\n',
-    'type': '((option: AcceptableValue) => string)',
+    'type': '((option: AcceptableValue) =&gt; string)',
     'required': false
   }
 ]" />
@@ -31,12 +31,12 @@
   {
     'name': 'option',
     'description': '',
-    'type': 'null | string | number | bigint | Record<string, any>'
+    'type': 'null | string | number | bigint | Record&lt;string, any&gt;'
   },
   {
     'name': 'virtualizer',
     'description': '',
-    'type': 'Virtualizer<HTMLElement, Element>'
+    'type': 'Virtualizer&lt;HTMLElement, Element&gt;'
   },
   {
     'name': 'virtualItem',

--- a/docs/content/meta/MenubarContent.md
+++ b/docs/content/meta/MenubarContent.md
@@ -54,7 +54,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/MenubarSubContent.md
+++ b/docs/content/meta/MenubarSubContent.md
@@ -47,7 +47,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/NavigationMenuLink.md
+++ b/docs/content/meta/NavigationMenuLink.md
@@ -26,6 +26,6 @@
   {
     'name': 'select',
     'description': '<p>Event handler called when the user selects a link (via mouse or keyboard).</p>\n<p>Calling <code>event.preventDefault</code> in this handler will prevent the navigation menu from closing when selecting that link.</p>\n',
-    'type': '[payload: CustomEvent<{ originalEvent: Event; }>]'
+    'type': '[payload: CustomEvent&lt;{ originalEvent: Event; }&gt;]'
   }
 ]" />

--- a/docs/content/meta/PopoverContent.md
+++ b/docs/content/meta/PopoverContent.md
@@ -53,7 +53,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/ProgressRoot.md
+++ b/docs/content/meta/ProgressRoot.md
@@ -17,14 +17,14 @@
   {
     'name': 'getValueLabel',
     'description': '<p>A function to get the accessible label text in a human-readable format.</p>\n<p>If not provided, the value label will be read as the numeric value as a percentage of the max value.</p>\n',
-    'type': '((value: number | null, max: number) => string)',
+    'type': '((value: number | null, max: number) =&gt; string)',
     'required': false,
     'default': 'isNumber(value) ? `${Math.round((value / max) * DEFAULT_MAX)}%` : undefined'
   },
   {
     'name': 'getValueText',
     'description': '<p>A function to get the accessible value text representing the current value in a human-readable format.</p>\n',
-    'type': '((value: number | null, max: number) => string)',
+    'type': '((value: number | null, max: number) =&gt; string)',
     'required': false
   },
   {
@@ -67,6 +67,6 @@
   {
     'name': 'getValueLabel',
     'description': '<p>A function to get the accessible label text in a human-readable format.</p>\n<p>If not provided, the value label will be read as the numeric value as a percentage of the max value.</p>\n',
-    'type': '(value: number | null | undefined, max: number) => string | undefined'
+    'type': '(value: number | null | undefined, max: number) =&gt; string | undefined'
   }
 ]" />

--- a/docs/content/meta/RadioGroupRoot.md
+++ b/docs/content/meta/RadioGroupRoot.md
@@ -79,6 +79,6 @@
   {
     'name': 'modelValue',
     'description': '<p>Current input values</p>\n',
-    'type': 'null | string | number | bigint | Record<string, any>'
+    'type': 'null | string | number | bigint | Record&lt;string, any&gt;'
   }
 ]" />

--- a/docs/content/meta/RangeCalendarNext.md
+++ b/docs/content/meta/RangeCalendarNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/RangeCalendarPrev.md
+++ b/docs/content/meta/RangeCalendarPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>RangeCalendarRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/RangeCalendarRoot.md
+++ b/docs/content/meta/RangeCalendarRoot.md
@@ -131,7 +131,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the calendar. It receives the current placeholder as an argument inside the component.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -164,7 +164,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -222,7 +222,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of dates</p>\n',
-    'type': 'Grid<DateValue>[]'
+    'type': 'Grid&lt;DateValue&gt;[]'
   },
   {
     'name': 'weekDays',

--- a/docs/content/meta/RovingFocusGroup.md
+++ b/docs/content/meta/RovingFocusGroup.md
@@ -71,6 +71,6 @@
   {
     'name': 'getItems',
     'description': '',
-    'type': '(includeDisabledItem?: boolean) => { ref: HTMLElement; value?: any; }[]'
+    'type': '(includeDisabledItem?: boolean) =&gt; { ref: HTMLElement; value?: any; }[]'
   }
 ]" />

--- a/docs/content/meta/ScrollAreaRoot.md
+++ b/docs/content/meta/ScrollAreaRoot.md
@@ -40,11 +40,11 @@
   {
     'name': 'scrollTop',
     'description': '<p>Scroll viewport to top</p>\n',
-    'type': '() => void'
+    'type': '() =&gt; void'
   },
   {
     'name': 'scrollTopLeft',
     'description': '<p>Scroll viewport to top-left</p>\n',
-    'type': '() => void'
+    'type': '() =&gt; void'
   }
 ]" />

--- a/docs/content/meta/SelectContent.md
+++ b/docs/content/meta/SelectContent.md
@@ -59,7 +59,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/SelectItem.md
+++ b/docs/content/meta/SelectItem.md
@@ -38,6 +38,6 @@
   {
     'name': 'select',
     'description': '<p>Event handler called when the selecting item. &lt;br&gt; It can be prevented by calling <code>event.preventDefault</code>.</p>\n',
-    'type': '[event: SelectEvent<AcceptableValue>]'
+    'type': '[event: SelectEvent&lt;AcceptableValue&gt;]'
   }
 ]" />

--- a/docs/content/meta/SelectRoot.md
+++ b/docs/content/meta/SelectRoot.md
@@ -10,7 +10,7 @@
   {
     'name': 'by',
     'description': '<p>Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared.</p>\n',
-    'type': 'string | ((a: AcceptableValue, b: AcceptableValue) => boolean)',
+    'type': 'string | ((a: AcceptableValue, b: AcceptableValue) =&gt; boolean)',
     'required': false
   },
   {

--- a/docs/content/meta/SplitterPanel.md
+++ b/docs/content/meta/SplitterPanel.md
@@ -108,21 +108,21 @@
   {
     'name': 'collapse',
     'description': '<p>If panel is <code>collapsible</code>, collapse it fully.</p>\n',
-    'type': '() => void'
+    'type': '() =&gt; void'
   },
   {
     'name': 'expand',
     'description': '<p>If panel is currently collapsed, expand it to its most recent size.</p>\n',
-    'type': '() => void'
+    'type': '() =&gt; void'
   },
   {
     'name': 'getSize',
     'description': '<p>Gets the current size of the panel as a percentage (1 - 100).</p>\n',
-    'type': '() => number'
+    'type': '() =&gt; number'
   },
   {
     'name': 'resize',
     'description': '<p>Resize panel to the specified percentage (1 - 100).</p>\n',
-    'type': '(size: number) => void'
+    'type': '(size: number) =&gt; void'
   }
 ]" />

--- a/docs/content/meta/StepperRoot.md
+++ b/docs/content/meta/StepperRoot.md
@@ -119,26 +119,26 @@
   {
     'name': 'goToStep',
     'description': '',
-    'type': '(step: number) => void'
+    'type': '(step: number) =&gt; void'
   },
   {
     'name': 'nextStep',
     'description': '',
-    'type': '() => void'
+    'type': '() =&gt; void'
   },
   {
     'name': 'prevStep',
     'description': '',
-    'type': '() => void'
+    'type': '() =&gt; void'
   },
   {
     'name': 'hasNext',
     'description': '',
-    'type': '() => boolean'
+    'type': '() =&gt; boolean'
   },
   {
     'name': 'hasPrev',
     'description': '',
-    'type': '() => boolean'
+    'type': '() =&gt; boolean'
   }
 ]" />

--- a/docs/content/meta/TabsIndicator.md
+++ b/docs/content/meta/TabsIndicator.md
@@ -20,6 +20,6 @@
   {
     'name': 'updateIndicatorStyle',
     'description': '',
-    'type': '() => void'
+    'type': '() =&gt; void'
   }
 ]" />

--- a/docs/content/meta/TagsInputItem.md
+++ b/docs/content/meta/TagsInputItem.md
@@ -23,7 +23,7 @@
   {
     'name': 'value',
     'description': '<p>Value associated with the tags</p>\n',
-    'type': 'string | number | bigint | Record<string, any>',
+    'type': 'string | number | bigint | Record&lt;string, any&gt;',
     'required': true
   }
 ]" />

--- a/docs/content/meta/TagsInputRoot.md
+++ b/docs/content/meta/TagsInputRoot.md
@@ -35,7 +35,7 @@
   {
     'name': 'convertValue',
     'description': '<p>Convert the input value to the desired type. Mandatory when using objects as values and using <code>TagsInputInput</code></p>\n',
-    'type': '((value: string) => AcceptableInputValue)',
+    'type': '((value: string) =&gt; AcceptableInputValue)',
     'required': false
   },
   {
@@ -67,7 +67,7 @@
   {
     'name': 'displayValue',
     'description': '<p>Display the value of the tag. Useful when you want to apply modifications to the value like adding a suffix or when using object as values</p>\n',
-    'type': '((value: AcceptableInputValue) => string)',
+    'type': '((value: AcceptableInputValue) =&gt; string)',
     'required': false,
     'default': 'value.toString()'
   },
@@ -137,6 +137,6 @@
   {
     'name': 'modelValue',
     'description': '<p>Current input values</p>\n',
-    'type': 'string | number | bigint | Record<string, any>'
+    'type': 'string | number | bigint | Record&lt;string, any&gt;'
   }
 ]" />

--- a/docs/content/meta/TimeFieldRoot.md
+++ b/docs/content/meta/TimeFieldRoot.md
@@ -162,6 +162,6 @@
   {
     'name': 'setFocusedElement',
     'description': '<p>Helper to set the focused element inside the DateField</p>\n',
-    'type': '(el: HTMLElement) => void'
+    'type': '(el: HTMLElement) =&gt; void'
   }
 ]" />

--- a/docs/content/meta/ToastViewport.md
+++ b/docs/content/meta/ToastViewport.md
@@ -24,7 +24,7 @@
   {
     'name': 'label',
     'description': '<p>An author-localized label for the toast viewport to provide context for screen reader users\nwhen navigating page landmarks. The available <code>{hotkey}</code> placeholder will be replaced for you.\nAlternatively, you can pass in a custom function to generate the label.</p>\n',
-    'type': 'string | ((hotkey: string) => string)',
+    'type': 'string | ((hotkey: string) =&gt; string)',
     'required': false,
     'default': '\'Notifications ({hotkey})\''
   }

--- a/docs/content/meta/TooltipContent.md
+++ b/docs/content/meta/TooltipContent.md
@@ -53,7 +53,7 @@
   {
     'name': 'collisionPadding',
     'description': '<p>The distance in pixels from the boundary edges where collision\ndetection should occur. Accepts a number (same for all sides),\nor a partial padding object, for example: { top: 20, left: 20 }.</p>\n',
-    'type': 'number | Partial<Record<\'top\' | \'right\' | \'bottom\' | \'left\', number>>',
+    'type': 'number | Partial&lt;Record&lt;\'top\' | \'right\' | \'bottom\' | \'left\', number&gt;&gt;',
     'required': false
   },
   {

--- a/docs/content/meta/TreeItem.md
+++ b/docs/content/meta/TreeItem.md
@@ -23,7 +23,7 @@
   {
     'name': 'value',
     'description': '<p>Value given to this item</p>\n',
-    'type': 'Record<string, any>',
+    'type': 'Record&lt;string, any&gt;',
     'required': true
   }
 ]" />
@@ -32,12 +32,12 @@
   {
     'name': 'select',
     'description': '<p>Event handler called when the selecting item. &lt;br&gt; It can be prevented by calling <code>event.preventDefault</code>.</p>\n',
-    'type': '[event: SelectEvent<Record<string, any>>]'
+    'type': '[event: SelectEvent&lt;Record&lt;string, any&gt;&gt;]'
   },
   {
     'name': 'toggle',
     'description': '<p>Event handler called when the selecting item. &lt;br&gt; It can be prevented by calling <code>event.preventDefault</code>.</p>\n',
-    'type': '[event: ToggleEvent<Record<string, any>>]'
+    'type': '[event: ToggleEvent&lt;Record&lt;string, any&gt;&gt;]'
   }
 ]" />
 

--- a/docs/content/meta/TreeRoot.md
+++ b/docs/content/meta/TreeRoot.md
@@ -29,7 +29,7 @@
   {
     'name': 'defaultValue',
     'description': '<p>The value of the tree when initially rendered. Use when you do not need to control the state of the tree</p>\n',
-    'type': 'Record<string, any> | Record<string, any>[]',
+    'type': 'Record&lt;string, any&gt; | Record&lt;string, any&gt;[]',
     'required': false
   },
   {
@@ -53,26 +53,26 @@
   {
     'name': 'getChildren',
     'description': '<p>This function is passed the index of each item and should return a list of children for that item</p>\n',
-    'type': '((val: Record<string, any>) => Record<string, any>[])',
+    'type': '((val: Record&lt;string, any&gt;) =&gt; Record&lt;string, any&gt;[])',
     'required': false,
     'default': 'val.children'
   },
   {
     'name': 'getKey',
     'description': '<p>This function is passed the index of each item and should return a unique key for that item</p>\n',
-    'type': '(val: Record<string, any>): string',
+    'type': '(val: Record&lt;string, any&gt;): string',
     'required': true
   },
   {
     'name': 'items',
     'description': '<p>List of items</p>\n',
-    'type': 'Record<string, any>[]',
+    'type': 'Record&lt;string, any&gt;[]',
     'required': false
   },
   {
     'name': 'modelValue',
     'description': '<p>The controlled value of the tree. Can be binded with <code>v-model</code>.</p>\n',
-    'type': 'Record<string, any> | Record<string, any>[]',
+    'type': 'Record&lt;string, any&gt; | Record&lt;string, any&gt;[]',
     'required': false
   },
   {
@@ -105,7 +105,7 @@
   {
     'name': 'update:modelValue',
     'description': '<p>Event handler called when the value of the toggle changes.</p>\n',
-    'type': '[val: Record<string, any> | Record<string, any>[]]'
+    'type': '[val: Record&lt;string, any&gt; | Record&lt;string, any&gt;[]]'
   }
 ]" />
 
@@ -113,12 +113,12 @@
   {
     'name': 'flattenItems',
     'description': '',
-    'type': 'FlattenedItem<Record<string, any>>[]'
+    'type': 'FlattenedItem&lt;Record&lt;string, any&gt;&gt;[]'
   },
   {
     'name': 'modelValue',
     'description': '',
-    'type': 'Record<string, any> | Record<string, any>[]'
+    'type': 'Record&lt;string, any&gt; | Record&lt;string, any&gt;[]'
   },
   {
     'name': 'expanded',

--- a/docs/content/meta/TreeVirtualizer.md
+++ b/docs/content/meta/TreeVirtualizer.md
@@ -4,7 +4,7 @@
   {
     'name': 'estimateSize',
     'description': '<p>Estimated size (in px) of each item</p>\n',
-    'type': 'number | ((index: number) => number)',
+    'type': 'number | ((index: number) =&gt; number)',
     'required': false
   },
   {
@@ -16,7 +16,7 @@
   {
     'name': 'textContent',
     'description': '<p>Text content for each item to achieve type-ahead feature</p>\n',
-    'type': '((item: Record<string, any>) => string)',
+    'type': '((item: Record&lt;string, any&gt;) =&gt; string)',
     'required': false
   }
 ]" />
@@ -25,12 +25,12 @@
   {
     'name': 'item',
     'description': '',
-    'type': 'FlattenedItem<Record<string, any>>'
+    'type': 'FlattenedItem&lt;Record&lt;string, any&gt;&gt;'
   },
   {
     'name': 'virtualizer',
     'description': '',
-    'type': 'Virtualizer<Element | Window, Element>'
+    'type': 'Virtualizer&lt;Element | Window, Element&gt;'
   },
   {
     'name': 'virtualItem',

--- a/docs/scripts/autogen.ts
+++ b/docs/scripts/autogen.ts
@@ -67,18 +67,25 @@ primitiveComponents.forEach((componentPath) => {
 
   const metaMdFilePath = join(metaDirPath, `${componentName}.md`)
 
+  // Convert JSON to single-quoted format safely by escaping existing single quotes first
+  function toSingleQuotedJson(obj: unknown): string {
+    return JSON.stringify(obj, null, 2)
+      .replace(/'/g, '\\\'') // Escape existing single quotes
+      .replace(/"/g, '\'') // Then convert double quotes to single
+  }
+
   let parsedString = '<!-- This file was automatic generated. Do not edit it manually -->\n\n'
   if (meta.props.length)
-    parsedString += `<PropsTable :data="${JSON.stringify(meta.props, null, 2).replace(/"/g, '\'')}" />\n`
+    parsedString += `<PropsTable :data="${toSingleQuotedJson(meta.props)}" />\n`
 
   if (meta.events.length)
-    parsedString += `\n<EmitsTable :data="${JSON.stringify(meta.events, null, 2).replace(/"/g, '\'')}" />\n`
+    parsedString += `\n<EmitsTable :data="${toSingleQuotedJson(meta.events)}" />\n`
 
   if (meta.slots.length)
-    parsedString += `\n<SlotsTable :data="${JSON.stringify(meta.slots, null, 2).replace(/"/g, '\'')}" />\n`
+    parsedString += `\n<SlotsTable :data="${toSingleQuotedJson(meta.slots)}" />\n`
 
   if (meta.methods.length)
-    parsedString += `\n<MethodsTable :data="${JSON.stringify(meta.methods, null, 2).replace(/"/g, '\'')}" />\n`
+    parsedString += `\n<MethodsTable :data="${toSingleQuotedJson(meta.methods)}" />\n`
 
   writeFileSync(metaMdFilePath, parsedString)
 })
@@ -128,7 +135,7 @@ function parseMeta(meta: ComponentMeta) {
       return ({
         name,
         description: md.render(description),
-        type: type.replace(/\s*\|\s*undefined/g, ''),
+        type: type.replace(/\s*\|\s*undefined/g, '').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
         required,
         default: defaultValue ?? undefined,
       })
@@ -141,7 +148,7 @@ function parseMeta(meta: ComponentMeta) {
       return ({
         name,
         description: md.render((eventDescriptionMap.get(name) ?? '').replace(/^[ \t]+/gm, '')),
-        type: type.replace(/\s*\|\s*undefined/g, ''),
+        type: type.replace(/\s*\|\s*undefined/g, '').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
       })
     })
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -156,7 +163,7 @@ function parseMeta(meta: ComponentMeta) {
         slots.push({
           name: childMeta.name,
           description: md.render(childMeta.description),
-          type: parseTypeFromSchema(childMeta.schema),
+          type: parseTypeFromSchema(childMeta.schema).replace(/</g, '&lt;').replace(/>/g, '&gt;'),
         })
       })
     }
@@ -168,7 +175,7 @@ function parseMeta(meta: ComponentMeta) {
     .map(expose => ({
       name: expose.name,
       description: md.render(expose.description),
-      type: expose.type,
+      type: expose.type.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
     }))
 
   return {


### PR DESCRIPTION
Type strings with `<` and `>` were breaking template parsing in meta files.

Escapes angle brackets to `&lt;` and `&gt;` in autogen output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Improved type annotation rendering across all component documentation by adding proper HTML entity escaping for generic brackets and arrows in TypeScript type signatures. This ensures correct display of complex types in auto-generated reference docs without impact to any functional APIs or code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->