### PR TITLE
fix(DatePicker/DateRangePicker/Calendar/RangeCalendar): default `weekStartsOn` based on locale

### DIFF
--- a/packages/core/src/Calendar/CalendarRoot.vue
+++ b/packages/core/src/Calendar/CalendarRoot.vue
@@ -2,12 +2,13 @@
 import type { DateValue } from '@internationalized/date'
 
 import type { Ref } from 'vue'
-import type { Grid, Matcher, WeekDayFormat } from '@/date'
+import type { Grid, Matcher, WeekDayFormat, WeekStartsOn } from '@/date'
 import type { PrimitiveProps } from '@/Primitive'
 
 import type { Formatter } from '@/shared'
 import type { Direction } from '@/shared/types'
 import { isEqualDay, isSameDay } from '@internationalized/date'
+import { getWeekStartsOn } from '@/date'
 import { createContext, useDirection, useLocale } from '@/shared'
 import { getDefaultDate, handleCalendarInitialFocus } from '@/shared/date'
 import { useCalendar, useCalendarState } from './useCalendar'
@@ -20,7 +21,7 @@ type CalendarRootContext = {
   preventDeselect: Ref<boolean>
   grid: Ref<Grid<DateValue>[]>
   weekDays: Ref<string[]>
-  weekStartsOn: Ref<0 | 1 | 2 | 3 | 4 | 5 | 6>
+  weekStartsOn: Ref<WeekStartsOn>
   weekdayFormat: Ref<WeekDayFormat>
   fixedWeeks: Ref<boolean>
   multiple: Ref<boolean>
@@ -61,7 +62,7 @@ export interface CalendarRootProps extends PrimitiveProps {
   /** Whether or not to prevent the user from deselecting a date without selecting another date first */
   preventDeselect?: boolean
   /** The day of the week to start the calendar on */
-  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+  weekStartsOn?: WeekStartsOn
   /** The format to use for the weekday strings provided via the weekdays slot prop */
   weekdayFormat?: WeekDayFormat
   /** The accessible label for the calendar */
@@ -113,7 +114,7 @@ export const [injectCalendarRootContext, provideCalendarRootContext]
 
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
-import { onMounted, toRefs, watch } from 'vue'
+import { computed, onMounted, toRefs, watch } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<CalendarRootProps>(), {
@@ -121,7 +122,6 @@ const props = withDefaults(defineProps<CalendarRootProps>(), {
   as: 'div',
   pagedNavigation: false,
   preventDeselect: false,
-  weekStartsOn: 0,
   weekdayFormat: 'narrow',
   fixedWeeks: false,
   multiple: false,
@@ -144,7 +144,7 @@ defineSlots<{
     /** The days of the week */
     weekDays: string[]
     /** The start of the week */
-    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
+    weekStartsOn: WeekStartsOn
     /** The calendar locale */
     locale: string
     /** Whether or not to always display 6 weeks in the calendar */
@@ -159,7 +159,6 @@ const {
   readonly,
   initialFocus,
   pagedNavigation,
-  weekStartsOn,
   weekdayFormat,
   fixedWeeks,
   multiple,
@@ -182,6 +181,7 @@ const { primitiveElement, currentElement: parentElement }
   = usePrimitiveElement()
 const locale = useLocale(propLocale)
 const dir = useDirection(propDir)
+const weekStartsOn = computed(() => props.weekStartsOn ?? getWeekStartsOn(locale.value))
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: defaultValue.value,

--- a/packages/core/src/Calendar/useCalendar.ts
+++ b/packages/core/src/Calendar/useCalendar.ts
@@ -4,7 +4,7 @@
 
 import type { DateFields, DateValue } from '@internationalized/date'
 import type { Ref } from 'vue'
-import type { Grid, Matcher, WeekDayFormat } from '@/date'
+import type { Grid, Matcher, WeekDayFormat, WeekStartsOn } from '@/date'
 import type { DateFormatterOptions } from '@/shared/useDateFormatter'
 import { isEqualMonth, isSameDay } from '@internationalized/date'
 import { computed, ref, watch } from 'vue'
@@ -14,7 +14,7 @@ import { useDateFormatter } from '@/shared'
 export type UseCalendarProps = {
   locale: Ref<string>
   placeholder: Ref<DateValue>
-  weekStartsOn: Ref<0 | 1 | 2 | 3 | 4 | 5 | 6>
+  weekStartsOn: Ref<WeekStartsOn>
   fixedWeeks: Ref<boolean>
   numberOfMonths: Ref<number>
   minValue: Ref<DateValue | undefined>

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -3,10 +3,11 @@ import type { DateValue } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { CalendarRootProps, DateFieldRoot, DateFieldRootProps, PopoverRootEmits, PopoverRootProps } from '..'
-import type { Matcher, WeekDayFormat } from '@/date'
+import type { Matcher, WeekDayFormat, WeekStartsOn } from '@/date'
 import type { DateStep, Granularity, HourCycle } from '@/shared/date'
 import type { Direction } from '@/shared/types'
 import { computed, ref, toRefs, watch } from 'vue'
+import { getWeekStartsOn } from '@/date'
 import { createContext, useDirection, useLocale } from '@/shared'
 import { getDefaultDate } from '@/shared/date'
 import { PopoverRoot } from '..'
@@ -26,7 +27,7 @@ type DatePickerRootContext = {
   placeholder: Ref<DateValue>
   pagedNavigation: Ref<boolean>
   preventDeselect: Ref<boolean>
-  weekStartsOn: Ref<0 | 1 | 2 | 3 | 4 | 5 | 6>
+  weekStartsOn: Ref<WeekStartsOn>
   weekdayFormat: Ref<WeekDayFormat>
   fixedWeeks: Ref<boolean>
   numberOfMonths: Ref<number>
@@ -73,7 +74,6 @@ const props = withDefaults(defineProps<DatePickerRootProps>(), {
   modal: false,
   pagedNavigation: false,
   preventDeselect: false,
-  weekStartsOn: 0,
   weekdayFormat: 'narrow',
   fixedWeeks: false,
   numberOfMonths: 1,
@@ -90,7 +90,6 @@ const {
   disabled,
   readonly,
   pagedNavigation,
-  weekStartsOn,
   weekdayFormat,
   fixedWeeks,
   numberOfMonths,
@@ -115,6 +114,7 @@ const {
 
 const dir = useDirection(propDir)
 const locale = useLocale(propLocale)
+const weekStartsOn = computed(() => props.weekStartsOn ?? getWeekStartsOn(locale.value))
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: defaultValue.value,

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -3,10 +3,11 @@ import type { DateValue } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { DateRangeFieldRoot, DateRangeFieldRootProps, PopoverRootEmits, PopoverRootProps, RangeCalendarRootProps } from '..'
-import type { Matcher, WeekDayFormat } from '@/date'
+import type { Matcher, WeekDayFormat, WeekStartsOn } from '@/date'
 import type { DateRange, DateStep, Granularity, HourCycle } from '@/shared/date'
 
 import type { Direction } from '@/shared/types'
+import { getWeekStartsOn } from '@/date'
 import { createContext, useDirection, useLocale } from '@/shared'
 import { getDefaultDate } from '@/shared/date'
 import { PopoverRoot } from '..'
@@ -26,7 +27,7 @@ type DateRangePickerRootContext = {
   placeholder: Ref<DateValue>
   pagedNavigation: Ref<boolean>
   preventDeselect: Ref<boolean>
-  weekStartsOn: Ref<0 | 1 | 2 | 3 | 4 | 5 | 6>
+  weekStartsOn: Ref<WeekStartsOn>
   weekdayFormat: Ref<WeekDayFormat>
   fixedWeeks: Ref<boolean>
   numberOfMonths: Ref<number>
@@ -69,7 +70,7 @@ export const [injectDateRangePickerRootContext, provideDateRangePickerRootContex
 
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
-import { ref, toRefs, watch } from 'vue'
+import { computed, ref, toRefs, watch } from 'vue'
 
 defineOptions({
   inheritAttrs: false,
@@ -81,7 +82,6 @@ const props = withDefaults(defineProps<DateRangePickerRootProps>(), {
   modal: false,
   pagedNavigation: false,
   preventDeselect: false,
-  weekStartsOn: 0,
   weekdayFormat: 'narrow',
   fixedWeeks: false,
   numberOfMonths: 1,
@@ -101,7 +101,6 @@ const {
   disabled,
   readonly,
   pagedNavigation,
-  weekStartsOn,
   weekdayFormat,
   fixedWeeks,
   numberOfMonths,
@@ -129,6 +128,7 @@ const {
 
 const dir = useDirection(propsDir)
 const locale = useLocale(propLocale)
+const weekStartsOn = computed(() => props.weekStartsOn ?? getWeekStartsOn(locale.value))
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? { start: undefined, end: undefined },

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -1,14 +1,14 @@
 <script lang="ts">
 import type { DateValue } from '@internationalized/date'
 import type { Ref } from 'vue'
-import type { Grid, Matcher, WeekDayFormat } from '@/date'
+import type { Grid, Matcher, WeekDayFormat, WeekStartsOn } from '@/date'
 import type { PrimitiveProps } from '@/Primitive'
 import type { Formatter } from '@/shared'
 import type { DateRange } from '@/shared/date'
 import type { Direction } from '@/shared/types'
 import { isEqualDay } from '@internationalized/date'
 import { useCalendar } from '@/Calendar/useCalendar'
-import { isBefore } from '@/date'
+import { getWeekStartsOn, isBefore } from '@/date'
 import {
   createContext,
   useDirection,
@@ -28,7 +28,7 @@ type RangeCalendarRootContext = {
   preventDeselect: Ref<boolean>
   grid: Ref<Grid<DateValue>[]>
   weekDays: Ref<string[]>
-  weekStartsOn: Ref<0 | 1 | 2 | 3 | 4 | 5 | 6>
+  weekStartsOn: Ref<WeekStartsOn>
   weekdayFormat: Ref<WeekDayFormat>
   fixedWeeks: Ref<boolean>
   numberOfMonths: Ref<number>
@@ -88,7 +88,7 @@ export interface RangeCalendarRootProps extends PrimitiveProps {
   /** The maximum number of days that can be selected in a range */
   maximumDays?: number
   /** The day of the week to start the calendar on */
-  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+  weekStartsOn?: WeekStartsOn
   /** The format to use for the weekday strings provided via the weekdays slot prop */
   weekdayFormat?: WeekDayFormat
   /** The accessible label for the calendar */
@@ -145,7 +145,7 @@ export const [injectRangeCalendarRootContext, provideRangeCalendarRootContext]
 
 <script setup lang="ts">
 import { useEventListener, useVModel } from '@vueuse/core'
-import { onMounted, ref, toRefs, watch } from 'vue'
+import { computed, onMounted, ref, toRefs, watch } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<RangeCalendarRootProps>(), {
@@ -153,7 +153,6 @@ const props = withDefaults(defineProps<RangeCalendarRootProps>(), {
   as: 'div',
   pagedNavigation: false,
   preventDeselect: false,
-  weekStartsOn: 0,
   weekdayFormat: 'narrow',
   fixedWeeks: false,
   numberOfMonths: 1,
@@ -179,7 +178,7 @@ defineSlots<{
     /** The days of the week */
     weekDays: string[]
     /** The start of the week */
-    weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
+    weekStartsOn: WeekStartsOn
     /** The calendar locale */
     locale: string
     /** Whether or not to always display 6 weeks in the calendar */
@@ -194,7 +193,6 @@ const {
   readonly,
   initialFocus,
   pagedNavigation,
-  weekStartsOn,
   weekdayFormat,
   fixedWeeks,
   numberOfMonths,
@@ -219,6 +217,7 @@ const { primitiveElement, currentElement: parentElement }
   = usePrimitiveElement()
 const dir = useDirection(propDir)
 const locale = useLocale(propLocale)
+const weekStartsOn = computed(() => props.weekStartsOn ?? getWeekStartsOn(locale.value))
 
 const lastPressedDateValue = ref() as Ref<DateValue | undefined>
 const focusedValue = ref() as Ref<DateValue | undefined>

--- a/packages/core/src/date/calendar.ts
+++ b/packages/core/src/date/calendar.ts
@@ -11,6 +11,8 @@ import { chunk } from './utils'
 
 export type WeekDayFormat = 'narrow' | 'short' | 'long'
 
+export type WeekStartsOn = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
 export type CreateSelectProps = {
   /**
    * The date object representing the date (usually the first day of the month/year).
@@ -27,7 +29,7 @@ export type CreateMonthProps = {
   /**
    * The day of the week to start the calendar on (0 for Sunday, 1 for Monday, etc.).
    */
-  weekStartsOn: number
+  weekStartsOn: WeekStartsOn
 
   /**
    * Whether to always render 6 weeks in the calendar, even if the month doesn't
@@ -217,6 +219,21 @@ export function createDateRange({ start, end }: DateRange): DateValue[] {
   }
 
   return dates
+}
+
+/**
+ * It's better to use `getWeekStart` from `@internationalized/date`,
+ * but sadly it is not yet exported from the package.
+ * And the `Intl.Locale` API is not supported well enough yet.
+ */
+export function getWeekStartsOn(locale: string): WeekStartsOn {
+  // Jan 6, 2025 is a Monday (ISO day = 1)
+  const monday = new CalendarDate(2025, 1, 6)
+  const dayOfWeek = getDayOfWeek(monday, locale)
+  // dayOfWeek tells us Monday's position in the locale's week (0-indexed)
+  // If Monday is position 0 → week starts Monday (1)
+  // If Monday is position 1 → week starts Sunday (0)
+  return (1 - dayOfWeek + 7) % 7 as WeekStartsOn
 }
 
 /**


### PR DESCRIPTION

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

resolves https://github.com/unovue/reka-ui/issues/2435
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This follows up on https://github.com/unovue/reka-ui/pull/2359. Now that `weekStartsOn` is a fixed range, we should automatically set its default based on the locale.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar and date picker components now intelligently determine the week start day based on user locale, ensuring culturally appropriate calendar layouts without manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->