### PR TITLE
fix(calendar): parity + docs regen

### DIFF
--- a/docs/content/meta/AccordionContent.md
+++ b/docs/content/meta/AccordionContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AccordionHeader.md
+++ b/docs/content/meta/AccordionHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AccordionItem.md
+++ b/docs/content/meta/AccordionItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AccordionRoot.md
+++ b/docs/content/meta/AccordionRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AccordionTrigger.md
+++ b/docs/content/meta/AccordionTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogAction.md
+++ b/docs/content/meta/AlertDialogAction.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogCancel.md
+++ b/docs/content/meta/AlertDialogCancel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogContent.md
+++ b/docs/content/meta/AlertDialogContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogDescription.md
+++ b/docs/content/meta/AlertDialogDescription.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogOverlay.md
+++ b/docs/content/meta/AlertDialogOverlay.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogPortal.md
+++ b/docs/content/meta/AlertDialogPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogRoot.md
+++ b/docs/content/meta/AlertDialogRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogTitle.md
+++ b/docs/content/meta/AlertDialogTitle.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AlertDialogTrigger.md
+++ b/docs/content/meta/AlertDialogTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AspectRatio.md
+++ b/docs/content/meta/AspectRatio.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AvatarFallback.md
+++ b/docs/content/meta/AvatarFallback.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AvatarImage.md
+++ b/docs/content/meta/AvatarImage.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/AvatarRoot.md
+++ b/docs/content/meta/AvatarRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarCell.md
+++ b/docs/content/meta/CalendarCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarCellTrigger.md
+++ b/docs/content/meta/CalendarCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarGrid.md
+++ b/docs/content/meta/CalendarGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarGridBody.md
+++ b/docs/content/meta/CalendarGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarGridHead.md
+++ b/docs/content/meta/CalendarGridHead.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarGridRow.md
+++ b/docs/content/meta/CalendarGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarHeadCell.md
+++ b/docs/content/meta/CalendarHeadCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarHeader.md
+++ b/docs/content/meta/CalendarHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarHeading.md
+++ b/docs/content/meta/CalendarHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarNext.md
+++ b/docs/content/meta/CalendarNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarPrev.md
+++ b/docs/content/meta/CalendarPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CalendarRoot.md
+++ b/docs/content/meta/CalendarRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -98,7 +98,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar</p>\n',
+    'description': '<p>The controlled selected date value of the calendar. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateValue | DateValue[]',
     'required': false
   },
@@ -166,8 +166,7 @@
     'name': 'weekStartsOn',
     'description': '<p>The day of the week to start the calendar on</p>\n',
     'type': '0 | 1 | 2 | 3 | 4 | 5 | 6',
-    'required': false,
-    'default': '0'
+    'required': false
   }
 ]" />
 

--- a/docs/content/meta/CheckboxGroupRoot.md
+++ b/docs/content/meta/CheckboxGroupRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CheckboxIndicator.md
+++ b/docs/content/meta/CheckboxIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CheckboxRoot.md
+++ b/docs/content/meta/CheckboxRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CollapsibleContent.md
+++ b/docs/content/meta/CollapsibleContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CollapsibleRoot.md
+++ b/docs/content/meta/CollapsibleRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/CollapsibleTrigger.md
+++ b/docs/content/meta/CollapsibleTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxAnchor.md
+++ b/docs/content/meta/ComboboxAnchor.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxArrow.md
+++ b/docs/content/meta/ComboboxArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxCancel.md
+++ b/docs/content/meta/ComboboxCancel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxContent.md
+++ b/docs/content/meta/ComboboxContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxEmpty.md
+++ b/docs/content/meta/ComboboxEmpty.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxGroup.md
+++ b/docs/content/meta/ComboboxGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxInput.md
+++ b/docs/content/meta/ComboboxInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxItem.md
+++ b/docs/content/meta/ComboboxItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxItemIndicator.md
+++ b/docs/content/meta/ComboboxItemIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxLabel.md
+++ b/docs/content/meta/ComboboxLabel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxPortal.md
+++ b/docs/content/meta/ComboboxPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxSeparator.md
+++ b/docs/content/meta/ComboboxSeparator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxTrigger.md
+++ b/docs/content/meta/ComboboxTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxViewport.md
+++ b/docs/content/meta/ComboboxViewport.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ComboboxVirtualizer.md
+++ b/docs/content/meta/ComboboxVirtualizer.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ConfigProvider.md
+++ b/docs/content/meta/ConfigProvider.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuArrow.md
+++ b/docs/content/meta/ContextMenuArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuCheckboxItem.md
+++ b/docs/content/meta/ContextMenuCheckboxItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuContent.md
+++ b/docs/content/meta/ContextMenuContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuGroup.md
+++ b/docs/content/meta/ContextMenuGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuItem.md
+++ b/docs/content/meta/ContextMenuItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuItemIndicator.md
+++ b/docs/content/meta/ContextMenuItemIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuLabel.md
+++ b/docs/content/meta/ContextMenuLabel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuPortal.md
+++ b/docs/content/meta/ContextMenuPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuRadioGroup.md
+++ b/docs/content/meta/ContextMenuRadioGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuRadioItem.md
+++ b/docs/content/meta/ContextMenuRadioItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuRoot.md
+++ b/docs/content/meta/ContextMenuRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuSeparator.md
+++ b/docs/content/meta/ContextMenuSeparator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuSub.md
+++ b/docs/content/meta/ContextMenuSub.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuSubContent.md
+++ b/docs/content/meta/ContextMenuSubContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuSubTrigger.md
+++ b/docs/content/meta/ContextMenuSubTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ContextMenuTrigger.md
+++ b/docs/content/meta/ContextMenuTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateFieldInput.md
+++ b/docs/content/meta/DateFieldInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateFieldRoot.md
+++ b/docs/content/meta/DateFieldRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -89,7 +89,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar. Can be bound as <code>v-model</code>.</p>\n',
+    'description': '<p>The controlled value of the field. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateValue | null',
     'required': false
   },

--- a/docs/content/meta/DatePickerAnchor.md
+++ b/docs/content/meta/DatePickerAnchor.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerArrow.md
+++ b/docs/content/meta/DatePickerArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerCalendar.md
+++ b/docs/content/meta/DatePickerCalendar.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <SlotsTable :data="[
   {

--- a/docs/content/meta/DatePickerCell.md
+++ b/docs/content/meta/DatePickerCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerCellTrigger.md
+++ b/docs/content/meta/DatePickerCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerClose.md
+++ b/docs/content/meta/DatePickerClose.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerContent.md
+++ b/docs/content/meta/DatePickerContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerField.md
+++ b/docs/content/meta/DatePickerField.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <SlotsTable :data="[
   {

--- a/docs/content/meta/DatePickerGrid.md
+++ b/docs/content/meta/DatePickerGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerGridBody.md
+++ b/docs/content/meta/DatePickerGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerGridHead.md
+++ b/docs/content/meta/DatePickerGridHead.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerGridRow.md
+++ b/docs/content/meta/DatePickerGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerHeadCell.md
+++ b/docs/content/meta/DatePickerHeadCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerHeader.md
+++ b/docs/content/meta/DatePickerHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerHeading.md
+++ b/docs/content/meta/DatePickerHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerInput.md
+++ b/docs/content/meta/DatePickerInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerNext.md
+++ b/docs/content/meta/DatePickerNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerPrev.md
+++ b/docs/content/meta/DatePickerPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DatePickerRoot.md
+++ b/docs/content/meta/DatePickerRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -110,7 +110,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar. Can be bound as <code>v-model</code>.</p>\n',
+    'description': '<p>The controlled value of the field. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateValue | null',
     'required': false
   },
@@ -183,8 +183,7 @@
     'name': 'weekStartsOn',
     'description': '<p>The day of the week to start the calendar on</p>\n',
     'type': '0 | 1 | 2 | 3 | 4 | 5 | 6',
-    'required': false,
-    'default': '0'
+    'required': false
   }
 ]" />
 

--- a/docs/content/meta/DatePickerTrigger.md
+++ b/docs/content/meta/DatePickerTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangeFieldInput.md
+++ b/docs/content/meta/DateRangeFieldInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangeFieldRoot.md
+++ b/docs/content/meta/DateRangeFieldRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -89,7 +89,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar. Can be bound as <code>v-model</code>.</p>\n',
+    'description': '<p>The controlled value of the field. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateRange | null',
     'required': false
   },

--- a/docs/content/meta/DateRangePickerAnchor.md
+++ b/docs/content/meta/DateRangePickerAnchor.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerArrow.md
+++ b/docs/content/meta/DateRangePickerArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerCalendar.md
+++ b/docs/content/meta/DateRangePickerCalendar.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <SlotsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerCell.md
+++ b/docs/content/meta/DateRangePickerCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerCellTrigger.md
+++ b/docs/content/meta/DateRangePickerCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerClose.md
+++ b/docs/content/meta/DateRangePickerClose.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerContent.md
+++ b/docs/content/meta/DateRangePickerContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerField.md
+++ b/docs/content/meta/DateRangePickerField.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <SlotsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerGrid.md
+++ b/docs/content/meta/DateRangePickerGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerGridBody.md
+++ b/docs/content/meta/DateRangePickerGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerGridHead.md
+++ b/docs/content/meta/DateRangePickerGridHead.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerGridRow.md
+++ b/docs/content/meta/DateRangePickerGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerHeadCell.md
+++ b/docs/content/meta/DateRangePickerHeadCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerHeader.md
+++ b/docs/content/meta/DateRangePickerHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerHeading.md
+++ b/docs/content/meta/DateRangePickerHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerInput.md
+++ b/docs/content/meta/DateRangePickerInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerNext.md
+++ b/docs/content/meta/DateRangePickerNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerPrev.md
+++ b/docs/content/meta/DateRangePickerPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DateRangePickerRoot.md
+++ b/docs/content/meta/DateRangePickerRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -136,7 +136,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar. Can be bound as <code>v-model</code>.</p>\n',
+    'description': '<p>The controlled value of the field. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateRange | null',
     'required': false
   },
@@ -209,8 +209,7 @@
     'name': 'weekStartsOn',
     'description': '<p>The day of the week to start the calendar on</p>\n',
     'type': '0 | 1 | 2 | 3 | 4 | 5 | 6',
-    'required': false,
-    'default': '0'
+    'required': false
   }
 ]" />
 

--- a/docs/content/meta/DateRangePickerTrigger.md
+++ b/docs/content/meta/DateRangePickerTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogClose.md
+++ b/docs/content/meta/DialogClose.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogContent.md
+++ b/docs/content/meta/DialogContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogDescription.md
+++ b/docs/content/meta/DialogDescription.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogOverlay.md
+++ b/docs/content/meta/DialogOverlay.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogPortal.md
+++ b/docs/content/meta/DialogPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogRoot.md
+++ b/docs/content/meta/DialogRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogTitle.md
+++ b/docs/content/meta/DialogTitle.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DialogTrigger.md
+++ b/docs/content/meta/DialogTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuArrow.md
+++ b/docs/content/meta/DropdownMenuArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuCheckboxItem.md
+++ b/docs/content/meta/DropdownMenuCheckboxItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuContent.md
+++ b/docs/content/meta/DropdownMenuContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuGroup.md
+++ b/docs/content/meta/DropdownMenuGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuItem.md
+++ b/docs/content/meta/DropdownMenuItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuItemIndicator.md
+++ b/docs/content/meta/DropdownMenuItemIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuLabel.md
+++ b/docs/content/meta/DropdownMenuLabel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuPortal.md
+++ b/docs/content/meta/DropdownMenuPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuRadioGroup.md
+++ b/docs/content/meta/DropdownMenuRadioGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuRadioItem.md
+++ b/docs/content/meta/DropdownMenuRadioItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuRoot.md
+++ b/docs/content/meta/DropdownMenuRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuSeparator.md
+++ b/docs/content/meta/DropdownMenuSeparator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuSub.md
+++ b/docs/content/meta/DropdownMenuSub.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuSubContent.md
+++ b/docs/content/meta/DropdownMenuSubContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuSubTrigger.md
+++ b/docs/content/meta/DropdownMenuSubTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/DropdownMenuTrigger.md
+++ b/docs/content/meta/DropdownMenuTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/EditableArea.md
+++ b/docs/content/meta/EditableArea.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/EditableCancelTrigger.md
+++ b/docs/content/meta/EditableCancelTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/EditableEditTrigger.md
+++ b/docs/content/meta/EditableEditTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/EditableInput.md
+++ b/docs/content/meta/EditableInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/EditablePreview.md
+++ b/docs/content/meta/EditablePreview.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/EditableRoot.md
+++ b/docs/content/meta/EditableRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/EditableSubmitTrigger.md
+++ b/docs/content/meta/EditableSubmitTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/FocusScope.md
+++ b/docs/content/meta/FocusScope.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/HoverCardArrow.md
+++ b/docs/content/meta/HoverCardArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/HoverCardContent.md
+++ b/docs/content/meta/HoverCardContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/HoverCardPortal.md
+++ b/docs/content/meta/HoverCardPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/HoverCardRoot.md
+++ b/docs/content/meta/HoverCardRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/HoverCardTrigger.md
+++ b/docs/content/meta/HoverCardTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/Label.md
+++ b/docs/content/meta/Label.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxContent.md
+++ b/docs/content/meta/ListboxContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxFilter.md
+++ b/docs/content/meta/ListboxFilter.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxGroup.md
+++ b/docs/content/meta/ListboxGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxGroupLabel.md
+++ b/docs/content/meta/ListboxGroupLabel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxItem.md
+++ b/docs/content/meta/ListboxItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxItemIndicator.md
+++ b/docs/content/meta/ListboxItemIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxRoot.md
+++ b/docs/content/meta/ListboxRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ListboxVirtualizer.md
+++ b/docs/content/meta/ListboxVirtualizer.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarArrow.md
+++ b/docs/content/meta/MenubarArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarCheckboxItem.md
+++ b/docs/content/meta/MenubarCheckboxItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarContent.md
+++ b/docs/content/meta/MenubarContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarGroup.md
+++ b/docs/content/meta/MenubarGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarItem.md
+++ b/docs/content/meta/MenubarItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarItemIndicator.md
+++ b/docs/content/meta/MenubarItemIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarLabel.md
+++ b/docs/content/meta/MenubarLabel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarMenu.md
+++ b/docs/content/meta/MenubarMenu.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarPortal.md
+++ b/docs/content/meta/MenubarPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarRadioGroup.md
+++ b/docs/content/meta/MenubarRadioGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarRadioItem.md
+++ b/docs/content/meta/MenubarRadioItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarRoot.md
+++ b/docs/content/meta/MenubarRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarSeparator.md
+++ b/docs/content/meta/MenubarSeparator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarSub.md
+++ b/docs/content/meta/MenubarSub.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarSubContent.md
+++ b/docs/content/meta/MenubarSubContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarSubTrigger.md
+++ b/docs/content/meta/MenubarSubTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MenubarTrigger.md
+++ b/docs/content/meta/MenubarTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerCell.md
+++ b/docs/content/meta/MonthPickerCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerCellTrigger.md
+++ b/docs/content/meta/MonthPickerCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerGrid.md
+++ b/docs/content/meta/MonthPickerGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerGridBody.md
+++ b/docs/content/meta/MonthPickerGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerGridRow.md
+++ b/docs/content/meta/MonthPickerGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerHeader.md
+++ b/docs/content/meta/MonthPickerHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerHeading.md
+++ b/docs/content/meta/MonthPickerHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthPickerNext.md
+++ b/docs/content/meta/MonthPickerNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>MonthPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthPickerNext.md
+++ b/docs/content/meta/MonthPickerNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>MonthPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthPickerPrev.md
+++ b/docs/content/meta/MonthPickerPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>MonthPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthPickerPrev.md
+++ b/docs/content/meta/MonthPickerPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>MonthPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthPickerRoot.md
+++ b/docs/content/meta/MonthPickerRoot.md
@@ -98,7 +98,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the month picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -117,7 +117,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the month picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -151,7 +151,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of months</p>\n',
-    'type': 'Grid<DateValue>'
+    'type': 'Grid&lt;DateValue&gt;'
   },
   {
     'name': 'locale',

--- a/docs/content/meta/MonthPickerRoot.md
+++ b/docs/content/meta/MonthPickerRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -84,7 +84,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the month picker</p>\n',
+    'description': '<p>The controlled selected month value of the month picker. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateValue | DateValue[]',
     'required': false
   },
@@ -98,7 +98,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the month picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -117,7 +117,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the month picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -133,7 +133,7 @@
   {
     'name': 'update:modelValue',
     'description': '<p>Event handler called whenever the model value changes</p>\n',
-    'type': '[date: DateValue]'
+    'type': '[date: DateValue | DateValue[]]'
   },
   {
     'name': 'update:placeholder',
@@ -151,7 +151,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of months</p>\n',
-    'type': 'Grid&lt;DateValue&gt;'
+    'type': 'Grid<DateValue>'
   },
   {
     'name': 'locale',

--- a/docs/content/meta/MonthRangePickerCell.md
+++ b/docs/content/meta/MonthRangePickerCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthRangePickerCellTrigger.md
+++ b/docs/content/meta/MonthRangePickerCellTrigger.md
@@ -40,7 +40,7 @@
   },
   {
     'name': 'today',
-    'description': '<p>Current month is today's month state</p>\n',
+    'description': '<p>Current month is today\'s month state</p>\n',
     'type': 'boolean'
   },
   {

--- a/docs/content/meta/MonthRangePickerCellTrigger.md
+++ b/docs/content/meta/MonthRangePickerCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -40,7 +40,7 @@
   },
   {
     'name': 'today',
-    'description': '<p>Current month is today\'s month state</p>\n',
+    'description': '<p>Current month is today's month state</p>\n',
     'type': 'boolean'
   },
   {

--- a/docs/content/meta/MonthRangePickerGrid.md
+++ b/docs/content/meta/MonthRangePickerGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthRangePickerGridBody.md
+++ b/docs/content/meta/MonthRangePickerGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthRangePickerGridRow.md
+++ b/docs/content/meta/MonthRangePickerGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthRangePickerHeader.md
+++ b/docs/content/meta/MonthRangePickerHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthRangePickerHeading.md
+++ b/docs/content/meta/MonthRangePickerHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/MonthRangePickerNext.md
+++ b/docs/content/meta/MonthRangePickerNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthRangePickerNext.md
+++ b/docs/content/meta/MonthRangePickerNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthRangePickerPrev.md
+++ b/docs/content/meta/MonthRangePickerPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthRangePickerPrev.md
+++ b/docs/content/meta/MonthRangePickerPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/MonthRangePickerRoot.md
+++ b/docs/content/meta/MonthRangePickerRoot.md
@@ -111,7 +111,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -130,7 +130,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -169,7 +169,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of months</p>\n',
-    'type': 'Grid<DateValue>'
+    'type': 'Grid&lt;DateValue&gt;'
   },
   {
     'name': 'locale',

--- a/docs/content/meta/MonthRangePickerRoot.md
+++ b/docs/content/meta/MonthRangePickerRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -104,14 +104,14 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar. Can be bound as <code>v-model</code>.</p>\n',
+    'description': '<p>The controlled selected month range of the month range picker. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateRange | null',
     'required': false
   },
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -130,7 +130,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -169,7 +169,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of months</p>\n',
-    'type': 'Grid&lt;DateValue&gt;'
+    'type': 'Grid<DateValue>'
   },
   {
     'name': 'locale',

--- a/docs/content/meta/NavigationMenuContent.md
+++ b/docs/content/meta/NavigationMenuContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuIndicator.md
+++ b/docs/content/meta/NavigationMenuIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuItem.md
+++ b/docs/content/meta/NavigationMenuItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuLink.md
+++ b/docs/content/meta/NavigationMenuLink.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuList.md
+++ b/docs/content/meta/NavigationMenuList.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuRoot.md
+++ b/docs/content/meta/NavigationMenuRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuSub.md
+++ b/docs/content/meta/NavigationMenuSub.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuTrigger.md
+++ b/docs/content/meta/NavigationMenuTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NavigationMenuViewport.md
+++ b/docs/content/meta/NavigationMenuViewport.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NumberFieldDecrement.md
+++ b/docs/content/meta/NumberFieldDecrement.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NumberFieldIncrement.md
+++ b/docs/content/meta/NumberFieldIncrement.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NumberFieldInput.md
+++ b/docs/content/meta/NumberFieldInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/NumberFieldRoot.md
+++ b/docs/content/meta/NumberFieldRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationEllipsis.md
+++ b/docs/content/meta/PaginationEllipsis.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationFirst.md
+++ b/docs/content/meta/PaginationFirst.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationLast.md
+++ b/docs/content/meta/PaginationLast.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationList.md
+++ b/docs/content/meta/PaginationList.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationListItem.md
+++ b/docs/content/meta/PaginationListItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationNext.md
+++ b/docs/content/meta/PaginationNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationPrev.md
+++ b/docs/content/meta/PaginationPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PaginationRoot.md
+++ b/docs/content/meta/PaginationRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PinInputInput.md
+++ b/docs/content/meta/PinInputInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PinInputRoot.md
+++ b/docs/content/meta/PinInputRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PopoverAnchor.md
+++ b/docs/content/meta/PopoverAnchor.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PopoverArrow.md
+++ b/docs/content/meta/PopoverArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PopoverClose.md
+++ b/docs/content/meta/PopoverClose.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PopoverContent.md
+++ b/docs/content/meta/PopoverContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PopoverPortal.md
+++ b/docs/content/meta/PopoverPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PopoverRoot.md
+++ b/docs/content/meta/PopoverRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/PopoverTrigger.md
+++ b/docs/content/meta/PopoverTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ProgressIndicator.md
+++ b/docs/content/meta/ProgressIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ProgressRoot.md
+++ b/docs/content/meta/ProgressRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RadioGroupIndicator.md
+++ b/docs/content/meta/RadioGroupIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RadioGroupItem.md
+++ b/docs/content/meta/RadioGroupItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RadioGroupRoot.md
+++ b/docs/content/meta/RadioGroupRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarCell.md
+++ b/docs/content/meta/RangeCalendarCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarCellTrigger.md
+++ b/docs/content/meta/RangeCalendarCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarGrid.md
+++ b/docs/content/meta/RangeCalendarGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarGridBody.md
+++ b/docs/content/meta/RangeCalendarGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarGridHead.md
+++ b/docs/content/meta/RangeCalendarGridHead.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarGridRow.md
+++ b/docs/content/meta/RangeCalendarGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarHeadCell.md
+++ b/docs/content/meta/RangeCalendarHeadCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarHeader.md
+++ b/docs/content/meta/RangeCalendarHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarHeading.md
+++ b/docs/content/meta/RangeCalendarHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarNext.md
+++ b/docs/content/meta/RangeCalendarNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarPrev.md
+++ b/docs/content/meta/RangeCalendarPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RangeCalendarRoot.md
+++ b/docs/content/meta/RangeCalendarRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -124,7 +124,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar. Can be bound as <code>v-model</code>.</p>\n',
+    'description': '<p>The controlled selected date range of the calendar. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateRange | null',
     'required': false
   },
@@ -185,8 +185,7 @@
     'name': 'weekStartsOn',
     'description': '<p>The day of the week to start the calendar on</p>\n',
     'type': '0 | 1 | 2 | 3 | 4 | 5 | 6',
-    'required': false,
-    'default': '0'
+    'required': false
   }
 ]" />
 

--- a/docs/content/meta/RovingFocusGroup.md
+++ b/docs/content/meta/RovingFocusGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/RovingFocusItem.md
+++ b/docs/content/meta/RovingFocusItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ScrollAreaCorner.md
+++ b/docs/content/meta/ScrollAreaCorner.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ScrollAreaRoot.md
+++ b/docs/content/meta/ScrollAreaRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ScrollAreaScrollbar.md
+++ b/docs/content/meta/ScrollAreaScrollbar.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ScrollAreaThumb.md
+++ b/docs/content/meta/ScrollAreaThumb.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ScrollAreaViewport.md
+++ b/docs/content/meta/ScrollAreaViewport.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectArrow.md
+++ b/docs/content/meta/SelectArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectContent.md
+++ b/docs/content/meta/SelectContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectGroup.md
+++ b/docs/content/meta/SelectGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectIcon.md
+++ b/docs/content/meta/SelectIcon.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectItem.md
+++ b/docs/content/meta/SelectItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectItemIndicator.md
+++ b/docs/content/meta/SelectItemIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectItemText.md
+++ b/docs/content/meta/SelectItemText.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectLabel.md
+++ b/docs/content/meta/SelectLabel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectPortal.md
+++ b/docs/content/meta/SelectPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectRoot.md
+++ b/docs/content/meta/SelectRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectScrollDownButton.md
+++ b/docs/content/meta/SelectScrollDownButton.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectScrollUpButton.md
+++ b/docs/content/meta/SelectScrollUpButton.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectSeparator.md
+++ b/docs/content/meta/SelectSeparator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectTrigger.md
+++ b/docs/content/meta/SelectTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectValue.md
+++ b/docs/content/meta/SelectValue.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SelectViewport.md
+++ b/docs/content/meta/SelectViewport.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/Separator.md
+++ b/docs/content/meta/Separator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SliderRange.md
+++ b/docs/content/meta/SliderRange.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SliderRoot.md
+++ b/docs/content/meta/SliderRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SliderThumb.md
+++ b/docs/content/meta/SliderThumb.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SliderTrack.md
+++ b/docs/content/meta/SliderTrack.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SplitterGroup.md
+++ b/docs/content/meta/SplitterGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SplitterPanel.md
+++ b/docs/content/meta/SplitterPanel.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SplitterResizeHandle.md
+++ b/docs/content/meta/SplitterResizeHandle.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/StepperDescription.md
+++ b/docs/content/meta/StepperDescription.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/StepperIndicator.md
+++ b/docs/content/meta/StepperIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/StepperItem.md
+++ b/docs/content/meta/StepperItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/StepperRoot.md
+++ b/docs/content/meta/StepperRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/StepperSeparator.md
+++ b/docs/content/meta/StepperSeparator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/StepperTitle.md
+++ b/docs/content/meta/StepperTitle.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/StepperTrigger.md
+++ b/docs/content/meta/StepperTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SwitchRoot.md
+++ b/docs/content/meta/SwitchRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/SwitchThumb.md
+++ b/docs/content/meta/SwitchThumb.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TabsContent.md
+++ b/docs/content/meta/TabsContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TabsIndicator.md
+++ b/docs/content/meta/TabsIndicator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TabsList.md
+++ b/docs/content/meta/TabsList.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TabsRoot.md
+++ b/docs/content/meta/TabsRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TabsTrigger.md
+++ b/docs/content/meta/TabsTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TagsInputClear.md
+++ b/docs/content/meta/TagsInputClear.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TagsInputInput.md
+++ b/docs/content/meta/TagsInputInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TagsInputItem.md
+++ b/docs/content/meta/TagsInputItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TagsInputItemDelete.md
+++ b/docs/content/meta/TagsInputItemDelete.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TagsInputItemText.md
+++ b/docs/content/meta/TagsInputItemText.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TagsInputRoot.md
+++ b/docs/content/meta/TagsInputRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TimeFieldInput.md
+++ b/docs/content/meta/TimeFieldInput.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TimeFieldRoot.md
+++ b/docs/content/meta/TimeFieldRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastAction.md
+++ b/docs/content/meta/ToastAction.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastClose.md
+++ b/docs/content/meta/ToastClose.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastDescription.md
+++ b/docs/content/meta/ToastDescription.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastPortal.md
+++ b/docs/content/meta/ToastPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastProvider.md
+++ b/docs/content/meta/ToastProvider.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastRoot.md
+++ b/docs/content/meta/ToastRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastTitle.md
+++ b/docs/content/meta/ToastTitle.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToastViewport.md
+++ b/docs/content/meta/ToastViewport.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/Toggle.md
+++ b/docs/content/meta/Toggle.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToggleGroupItem.md
+++ b/docs/content/meta/ToggleGroupItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToggleGroupRoot.md
+++ b/docs/content/meta/ToggleGroupRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToolbarButton.md
+++ b/docs/content/meta/ToolbarButton.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToolbarLink.md
+++ b/docs/content/meta/ToolbarLink.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToolbarRoot.md
+++ b/docs/content/meta/ToolbarRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToolbarSeparator.md
+++ b/docs/content/meta/ToolbarSeparator.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToolbarToggleGroup.md
+++ b/docs/content/meta/ToolbarToggleGroup.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/ToolbarToggleItem.md
+++ b/docs/content/meta/ToolbarToggleItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TooltipArrow.md
+++ b/docs/content/meta/TooltipArrow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TooltipContent.md
+++ b/docs/content/meta/TooltipContent.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TooltipPortal.md
+++ b/docs/content/meta/TooltipPortal.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TooltipProvider.md
+++ b/docs/content/meta/TooltipProvider.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TooltipRoot.md
+++ b/docs/content/meta/TooltipRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TooltipTrigger.md
+++ b/docs/content/meta/TooltipTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TreeItem.md
+++ b/docs/content/meta/TreeItem.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TreeRoot.md
+++ b/docs/content/meta/TreeRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/TreeVirtualizer.md
+++ b/docs/content/meta/TreeVirtualizer.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/Viewport.md
+++ b/docs/content/meta/Viewport.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/VisuallyHidden.md
+++ b/docs/content/meta/VisuallyHidden.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerCell.md
+++ b/docs/content/meta/YearPickerCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerCellTrigger.md
+++ b/docs/content/meta/YearPickerCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerGrid.md
+++ b/docs/content/meta/YearPickerGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerGridBody.md
+++ b/docs/content/meta/YearPickerGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerGridRow.md
+++ b/docs/content/meta/YearPickerGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerHeader.md
+++ b/docs/content/meta/YearPickerHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerHeading.md
+++ b/docs/content/meta/YearPickerHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearPickerNext.md
+++ b/docs/content/meta/YearPickerNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>YearPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearPickerNext.md
+++ b/docs/content/meta/YearPickerNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the <code>YearPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearPickerPrev.md
+++ b/docs/content/meta/YearPickerPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>YearPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearPickerPrev.md
+++ b/docs/content/meta/YearPickerPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the <code>YearPickerRoot</code>.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearPickerRoot.md
+++ b/docs/content/meta/YearPickerRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -84,7 +84,7 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the year picker</p>\n',
+    'description': '<p>The controlled selected year value of the year picker. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateValue | DateValue[]',
     'required': false
   },
@@ -98,7 +98,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the year picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -117,7 +117,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the year picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -140,7 +140,7 @@
   {
     'name': 'update:modelValue',
     'description': '<p>Event handler called whenever the model value changes</p>\n',
-    'type': '[date: DateValue]'
+    'type': '[date: DateValue | DateValue[]]'
   },
   {
     'name': 'update:placeholder',
@@ -158,7 +158,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of years</p>\n',
-    'type': 'Grid&lt;DateValue&gt;'
+    'type': 'Grid<DateValue>'
   },
   {
     'name': 'locale',

--- a/docs/content/meta/YearPickerRoot.md
+++ b/docs/content/meta/YearPickerRoot.md
@@ -98,7 +98,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the year picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -117,7 +117,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the year picker. Receives the current placeholder as an argument.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -158,7 +158,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of years</p>\n',
-    'type': 'Grid<DateValue>'
+    'type': 'Grid&lt;DateValue&gt;'
   },
   {
     'name': 'locale',

--- a/docs/content/meta/YearRangePickerCell.md
+++ b/docs/content/meta/YearRangePickerCell.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearRangePickerCellTrigger.md
+++ b/docs/content/meta/YearRangePickerCellTrigger.md
@@ -40,7 +40,7 @@
   },
   {
     'name': 'today',
-    'description': '<p>Current year is today's year state</p>\n',
+    'description': '<p>Current year is today\'s year state</p>\n',
     'type': 'boolean'
   },
   {

--- a/docs/content/meta/YearRangePickerCellTrigger.md
+++ b/docs/content/meta/YearRangePickerCellTrigger.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -40,7 +40,7 @@
   },
   {
     'name': 'today',
-    'description': '<p>Current year is today\'s year state</p>\n',
+    'description': '<p>Current year is today's year state</p>\n',
     'type': 'boolean'
   },
   {

--- a/docs/content/meta/YearRangePickerGrid.md
+++ b/docs/content/meta/YearRangePickerGrid.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearRangePickerGridBody.md
+++ b/docs/content/meta/YearRangePickerGridBody.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearRangePickerGridRow.md
+++ b/docs/content/meta/YearRangePickerGridRow.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearRangePickerHeader.md
+++ b/docs/content/meta/YearRangePickerHeader.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearRangePickerHeading.md
+++ b/docs/content/meta/YearRangePickerHeading.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {

--- a/docs/content/meta/YearRangePickerNext.md
+++ b/docs/content/meta/YearRangePickerNext.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearRangePickerNext.md
+++ b/docs/content/meta/YearRangePickerNext.md
@@ -17,7 +17,7 @@
   {
     'name': 'nextPage',
     'description': '<p>The function to be used for the next page. Overwrites the <code>nextPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearRangePickerPrev.md
+++ b/docs/content/meta/YearRangePickerPrev.md
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearRangePickerPrev.md
+++ b/docs/content/meta/YearRangePickerPrev.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -17,7 +17,7 @@
   {
     'name': 'prevPage',
     'description': '<p>The function to be used for the prev page. Overwrites the <code>prevPage</code> function set on the Root.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   }
 ]" />

--- a/docs/content/meta/YearRangePickerRoot.md
+++ b/docs/content/meta/YearRangePickerRoot.md
@@ -111,7 +111,7 @@
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -130,7 +130,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) => DateValue)',
+    'type': '((placeholder: DateValue) =&gt; DateValue)',
     'required': false
   },
   {
@@ -176,7 +176,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of years</p>\n',
-    'type': 'Grid<DateValue>'
+    'type': 'Grid&lt;DateValue&gt;'
   },
   {
     'name': 'locale',

--- a/docs/content/meta/YearRangePickerRoot.md
+++ b/docs/content/meta/YearRangePickerRoot.md
@@ -1,4 +1,4 @@
-<!-- This file was automatic generated. Do not edit it manually -->
+<!-- This file was automatically generated. Do not edit it manually -->
 
 <PropsTable :data="[
   {
@@ -104,14 +104,14 @@
   },
   {
     'name': 'modelValue',
-    'description': '<p>The controlled checked state of the calendar. Can be bound as <code>v-model</code>.</p>\n',
+    'description': '<p>The controlled selected year range of the year range picker. Can be bound as <code>v-model</code>.</p>\n',
     'type': 'DateRange | null',
     'required': false
   },
   {
     'name': 'nextPage',
     'description': '<p>A function that returns the next page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -130,7 +130,7 @@
   {
     'name': 'prevPage',
     'description': '<p>A function that returns the previous page of the calendar.</p>\n',
-    'type': '((placeholder: DateValue) =&gt; DateValue)',
+    'type': '((placeholder: DateValue) => DateValue)',
     'required': false
   },
   {
@@ -176,7 +176,7 @@
   {
     'name': 'grid',
     'description': '<p>The grid of years</p>\n',
-    'type': 'Grid&lt;DateValue&gt;'
+    'type': 'Grid<DateValue>'
   },
   {
     'name': 'locale',

--- a/docs/scripts/autogen.ts
+++ b/docs/scripts/autogen.ts
@@ -67,9 +67,9 @@ primitiveComponents.forEach((componentPath) => {
 
   const metaMdFilePath = join(metaDirPath, `${componentName}.md`)
 
-  let parsedString = '<!-- This file was automatic generated. Do not edit it manually -->\n\n'
+  let parsedString = '<!-- This file was automatically generated. Do not edit it manually -->\n'
   if (meta.props.length)
-    parsedString += `<PropsTable :data="${JSON.stringify(meta.props, null, 2).replace(/"/g, '\'')}" />\n`
+    parsedString += `\n<PropsTable :data="${JSON.stringify(meta.props, null, 2).replace(/"/g, '\'')}" />\n`
 
   if (meta.events.length)
     parsedString += `\n<EmitsTable :data="${JSON.stringify(meta.events, null, 2).replace(/"/g, '\'')}" />\n`

--- a/packages/core/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/core/src/Calendar/CalendarCellTrigger.vue
@@ -164,7 +164,8 @@ function handleArrowKey(e: KeyboardEvent) {
 <template>
   <Primitive
     ref="primitiveElement"
-    v-bind="props"
+    :as="props.as"
+    :as-child="props.asChild"
     role="button"
     :aria-label="labelText"
     data-reka-calendar-cell-trigger

--- a/packages/core/src/Calendar/CalendarNext.vue
+++ b/packages/core/src/Calendar/CalendarNext.vue
@@ -26,6 +26,12 @@ defineSlots<CalendarNextSlot>()
 const disabled = computed(() => rootContext.disabled.value || rootContext.isNextButtonDisabled(props.nextPage))
 
 const rootContext = injectCalendarRootContext()
+
+function handleClick() {
+  if (disabled.value)
+    return
+  rootContext.nextPage(props.nextPage)
+}
 </script>
 
 <template>
@@ -33,11 +39,11 @@ const rootContext = injectCalendarRootContext()
     :as="props.as"
     :as-child="props.asChild"
     aria-label="Next page"
-    :type="as === 'button' ? 'button' : undefined"
+    :type="props.as === 'button' ? 'button' : undefined"
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled || undefined"
     :disabled="disabled"
-    @click="rootContext.nextPage(props.nextPage)"
+    @click="handleClick"
   >
     <slot :disabled>
       Next page

--- a/packages/core/src/Calendar/CalendarPrev.vue
+++ b/packages/core/src/Calendar/CalendarPrev.vue
@@ -26,6 +26,12 @@ defineSlots<CalendarPrevSlot>()
 const disabled = computed(() => rootContext.disabled.value || rootContext.isPrevButtonDisabled(props.prevPage))
 
 const rootContext = injectCalendarRootContext()
+
+function handleClick() {
+  if (disabled.value)
+    return
+  rootContext.prevPage(props.prevPage)
+}
 </script>
 
 <template>
@@ -33,11 +39,11 @@ const rootContext = injectCalendarRootContext()
     aria-label="Previous page"
     :as="props.as"
     :as-child="props.asChild"
-    :type="as === 'button' ? 'button' : undefined"
+    :type="props.as === 'button' ? 'button' : undefined"
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled || undefined"
     :disabled="disabled"
-    @click="rootContext.prevPage(props.prevPage)"
+    @click="handleClick"
   >
     <slot :disabled>
       Prev page

--- a/packages/core/src/Calendar/CalendarRoot.vue
+++ b/packages/core/src/Calendar/CalendarRoot.vue
@@ -93,7 +93,7 @@ export interface CalendarRootProps extends PrimitiveProps {
   nextPage?: (placeholder: DateValue) => DateValue
   /** A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component. */
   prevPage?: (placeholder: DateValue) => DateValue
-  /** The controlled checked state of the calendar */
+  /** The controlled selected date value of the calendar. Can be bound as `v-model`. */
   modelValue?: DateValue | DateValue[] | undefined
   /** Whether multiple dates can be selected */
   multiple?: boolean

--- a/packages/core/src/DateField/DateFieldRoot.vue
+++ b/packages/core/src/DateField/DateFieldRoot.vue
@@ -44,7 +44,7 @@ export interface DateFieldRootProps extends PrimitiveProps, FormFieldProps {
   defaultPlaceholder?: DateValue
   /** The placeholder date, which is used to determine what month to display when no date is selected. This updates as the user navigates the calendar and can be used to programmatically control the calendar view */
   placeholder?: DateValue
-  /** The controlled checked state of the calendar. Can be bound as `v-model`. */
+  /** The controlled value of the field. Can be bound as `v-model`. */
   modelValue?: DateValue | null
   /** The hour cycle used for formatting times. Defaults to the local preference */
   hourCycle?: HourCycle

--- a/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
@@ -57,7 +57,7 @@ export interface DateRangeFieldRootProps extends PrimitiveProps, FormFieldProps 
   defaultPlaceholder?: DateValue
   /** The placeholder date, which is used to determine what month to display when no date is selected. This updates as the user navigates the calendar and can be used to programmatically control the calendar view */
   placeholder?: DateValue
-  /** The controlled checked state of the calendar. Can be bound as `v-model`. */
+  /** The controlled value of the field. Can be bound as `v-model`. */
   modelValue?: DateRange | null
   /** The hour cycle used for formatting times. Defaults to the local preference */
   hourCycle?: HourCycle

--- a/packages/core/src/MonthPicker/MonthPickerRoot.vue
+++ b/packages/core/src/MonthPicker/MonthPickerRoot.vue
@@ -73,7 +73,7 @@ export interface MonthPickerRootProps extends PrimitiveProps {
   nextPage?: (placeholder: DateValue) => DateValue
   /** A function that returns the previous page of the month picker. Receives the current placeholder as an argument. */
   prevPage?: (placeholder: DateValue) => DateValue
-  /** The controlled checked state of the month picker */
+  /** The controlled selected month value of the month picker. Can be bound as `v-model`. */
   modelValue?: DateValue | DateValue[] | undefined
   /** Whether multiple months can be selected */
   multiple?: boolean

--- a/packages/core/src/MonthRangePicker/MonthRangePickerRoot.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerRoot.vue
@@ -57,7 +57,7 @@ export interface MonthRangePickerRootProps extends PrimitiveProps {
   defaultPlaceholder?: DateValue
   /** The default value for the calendar */
   defaultValue?: DateRange
-  /** The controlled checked state of the calendar. Can be bound as `v-model`. */
+  /** The controlled selected month range of the month range picker. Can be bound as `v-model`. */
   modelValue?: DateRange | null
   /** The placeholder date, which is used to determine what year to display when no date is selected. */
   placeholder?: DateValue

--- a/packages/core/src/RangeCalendar/RangeCalendar.test.ts
+++ b/packages/core/src/RangeCalendar/RangeCalendar.test.ts
@@ -7,6 +7,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { useTestKbd } from '@/shared'
+import { RangeCalendarHeader, RangeCalendarHeading, RangeCalendarNext, RangeCalendarPrev, RangeCalendarRoot } from '..'
 import RangeCalendar from './story/_RangeCalendar.vue'
 
 it('should pass axe accessibility tests', async () => {
@@ -235,6 +236,42 @@ describe('rangeCalendar', () => {
       await user.click(prevBtn)
     }
     expect(heading).toHaveTextContent('January 1979')
+  })
+
+  it('does not navigate when prev is disabled and rendered as div', async () => {
+    const user = userEvent.setup()
+
+    const Test = {
+      components: {
+        RangeCalendarRoot,
+        RangeCalendarHeader,
+        RangeCalendarPrev,
+        RangeCalendarHeading,
+        RangeCalendarNext,
+      },
+      setup() {
+        const placeholder = new CalendarDate(1980, 1, 15)
+        const minValue = new CalendarDate(1980, 1, 1)
+        return { placeholder, minValue }
+      },
+      template: `
+        <RangeCalendarRoot
+          :placeholder="placeholder"
+          :min-value="minValue"
+        >
+          <RangeCalendarHeader>
+            <RangeCalendarPrev as="div" data-testid="prev-button" />
+            <RangeCalendarHeading data-testid="heading" />
+            <RangeCalendarNext as="div" data-testid="next-button" />
+          </RangeCalendarHeader>
+        </RangeCalendarRoot>
+      `,
+    }
+
+    const { getByTestId } = render(Test)
+    expect(getByTestId('heading')).toHaveTextContent('January 1980')
+    await user.click(getByTestId('prev-button'))
+    expect(getByTestId('heading')).toHaveTextContent('January 1980')
   })
 
   it('should navigate one year in the past (prev year button)', async () => {
@@ -851,6 +888,27 @@ describe('handles maximumDays', () => {
     expect(maximumDay).toHaveAttribute('data-highlighted-end')
     expect(maximumDay).toHaveAttribute('data-highlighted')
     expect(beyondMaximumDay).not.toHaveAttribute('data-highlighted')
+  })
+
+  it('highlights backwards within maximumDays without inverting', async () => {
+    const { getByTestId, user } = setup({
+      calendarProps: {
+        placeholder: new CalendarDate(1980, 1, 10),
+        maximumDays: 3,
+      },
+    })
+
+    const startDay = getByTestId('date-1-10')
+    await user.click(startDay)
+    expect(startDay).toHaveAttribute('data-selection-start')
+
+    const day8 = getByTestId('date-1-8')
+    await user.hover(day8)
+
+    expect(day8).toHaveAttribute('data-highlighted-start')
+    expect(getByTestId('date-1-9')).toHaveAttribute('data-highlighted')
+    expect(startDay).toHaveAttribute('data-highlighted-end')
+    expect(getByTestId('date-1-7')).not.toHaveAttribute('data-highlighted')
   })
 
   describe('a11y', async () => {

--- a/packages/core/src/RangeCalendar/RangeCalendarNext.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarNext.vue
@@ -26,18 +26,24 @@ defineSlots<RangeCalendarNextSlot>()
 const disabled = computed(() => rootContext.disabled.value || rootContext.isNextButtonDisabled(props.nextPage))
 
 const rootContext = injectRangeCalendarRootContext()
+
+function handleClick() {
+  if (disabled.value)
+    return
+  rootContext.nextPage(props.nextPage)
+}
 </script>
 
 <template>
   <Primitive
-    :as="as"
-    :as-child="asChild"
+    :as="props.as"
+    :as-child="props.asChild"
     aria-label="Next page"
-    :type="as === 'button' ? 'button' : undefined"
+    :type="props.as === 'button' ? 'button' : undefined"
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled || undefined"
     :disabled="disabled"
-    @click="rootContext.nextPage(props.nextPage)"
+    @click="handleClick"
   >
     <slot :disabled>
       Next page

--- a/packages/core/src/RangeCalendar/RangeCalendarPrev.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarPrev.vue
@@ -26,18 +26,24 @@ defineSlots<RangeCalendarPrevSlot>()
 const disabled = computed(() => rootContext.disabled.value || rootContext.isPrevButtonDisabled(props.prevPage))
 
 const rootContext = injectRangeCalendarRootContext()
+
+function handleClick() {
+  if (disabled.value)
+    return
+  rootContext.prevPage(props.prevPage)
+}
 </script>
 
 <template>
   <Primitive
-    :as="as"
-    :as-child="asChild"
+    :as="props.as"
+    :as-child="props.asChild"
     aria-label="Previous page"
-    :type="as === 'button' ? 'button' : undefined"
+    :type="props.as === 'button' ? 'button' : undefined"
     :aria-disabled="disabled || undefined"
     :data-disabled="disabled || undefined"
     :disabled="disabled"
-    @click="rootContext.prevPage(props.prevPage)"
+    @click="handleClick"
   >
     <slot :disabled>
       Prev page

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -75,7 +75,7 @@ export interface RangeCalendarRootProps extends PrimitiveProps {
   defaultPlaceholder?: DateValue
   /** The default value for the calendar */
   defaultValue?: DateRange
-  /** The controlled checked state of the calendar. Can be bound as `v-model`. */
+  /** The controlled selected date range of the calendar. Can be bound as `v-model`. */
   modelValue?: DateRange | null
   /** The placeholder date, which is used to determine what month to display when no date is selected. This updates as the user navigates the calendar and can be used to programmatically control the calendar view */
   placeholder?: DateValue
@@ -372,7 +372,7 @@ watch([startValue, endValue], ([_startValue, _endValue]) => {
 })
 
 const kbd = useKbd()
-useEventListener('keydown', (ev) => {
+useEventListener(parentElement, 'keydown', (ev) => {
   if (ev.key === kbd.ESCAPE && isEditing.value) {
     // Abort start and end selection
     startValue.value = validModelValue.value.start?.copy()

--- a/packages/core/src/RangeCalendar/useRangeCalendar.ts
+++ b/packages/core/src/RangeCalendar/useRangeCalendar.ts
@@ -41,7 +41,7 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
   const isInvalid = computed(
     () => {
       if (isStartInvalid.value || isEndInvalid.value)
-        return false
+        return true
       if (props.start.value && props.end.value && isBefore(props.end.value, props.start.value))
         return true
       return false
@@ -97,9 +97,6 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
       }
     }
 
-    if (!props.start.value || props.end.value || isSameDay(props.start.value, date))
-      return false
-
     return false
   }
 
@@ -129,15 +126,16 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
     // If maximum days is set and the range exceeds it, limit the highlight
     // We only apply this when we're in the middle of a selection (no end date yet)
     if (props.maximumDays?.value && !props.end.value) {
-      // Determine the direction of selection and limit to maximum days
-      const cappedEnd = isStartBeforeFocused
-        ? start.add({ days: props.maximumDays.value - 1 })
-        : start.subtract({ days: props.maximumDays.value })
+      const maximumDays = props.maximumDays.value
+      const anchor = props.start.value
+      const focused = props.focusedValue.value
 
-      return {
-        start,
-        end: cappedEnd,
-      }
+      // Keep the highlight in sync with the maximum selectable range.
+      // Existing behavior highlights the full allowed window while selecting.
+      if (!isBefore(focused, anchor))
+        return { start: anchor, end: anchor.add({ days: maximumDays - 1 }) }
+
+      return { start: anchor.subtract({ days: maximumDays - 1 }), end: anchor }
     }
 
     const isValid = areAllDaysBetweenValid(start, end, props.allowNonContiguousRanges.value ? () => false : props.isDateUnavailable, rangeIsDateDisabled, props.isDateHighlightable)

--- a/packages/core/src/YearPicker/YearPickerRoot.vue
+++ b/packages/core/src/YearPicker/YearPickerRoot.vue
@@ -74,7 +74,7 @@ export interface YearPickerRootProps extends PrimitiveProps {
   nextPage?: (placeholder: DateValue) => DateValue
   /** A function that returns the previous page of the year picker. Receives the current placeholder as an argument. */
   prevPage?: (placeholder: DateValue) => DateValue
-  /** The controlled checked state of the year picker */
+  /** The controlled selected year value of the year picker. Can be bound as `v-model`. */
   modelValue?: DateValue | DateValue[] | undefined
   /** Whether multiple years can be selected */
   multiple?: boolean

--- a/packages/core/src/YearRangePicker/YearRangePickerRoot.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerRoot.vue
@@ -58,7 +58,7 @@ export interface YearRangePickerRootProps extends PrimitiveProps {
   defaultPlaceholder?: DateValue
   /** The default value for the calendar */
   defaultValue?: DateRange
-  /** The controlled checked state of the calendar. Can be bound as `v-model`. */
+  /** The controlled selected year range of the year range picker. Can be bound as `v-model`. */
   modelValue?: DateRange | null
   /** The placeholder date, which is used to determine what year range to display when no date is selected. */
   placeholder?: DateValue


### PR DESCRIPTION
Stacked on #2434.
- Guard Calendar/RangeCalendar prev/next clicks when disabled (asChild-safe)
- Scope RangeCalendar ESC handling to the component
- Fix range invalid state + maximumDays backwards highlight
- Remove CalendarCellTrigger prop spread to avoid "[object Object]" DOM attrs\n- Fix date-related modelValue JSDoc wording ("checked" -> "selected")
- Update docs autogen header + regenerate meta docs
