### PR TITLE
fix(Menu): support text input elements inside menu content

### DIFF
--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -162,6 +162,15 @@ async function handleMountAutoFocus(event: Event) {
   })
 }
 
+function isTextInputElement(element: HTMLElement): boolean {
+  if (element instanceof HTMLTextAreaElement)
+    return true
+  if (element instanceof HTMLInputElement) {
+    return !['button', 'checkbox', 'radio', 'submit', 'reset', 'image', 'file', 'hidden', 'range', 'color'].includes(element.type)
+  }
+  return element.isContentEditable
+}
+
 function handleKeyDown(event: KeyboardEvent) {
   if (event.defaultPrevented)
     return
@@ -171,6 +180,20 @@ function handleKeyDown(event: KeyboardEvent) {
     = target.closest('[data-reka-menu-content]') === event.currentTarget
   const isModifierKey = event.ctrlKey || event.altKey || event.metaKey
   const isCharacterKey = event.key.length === 1
+
+  const isFromTextInput = isTextInputElement(target)
+
+  if (isFromTextInput && ['ArrowDown', 'ArrowUp'].includes(event.key)) {
+    event.preventDefault()
+    const items = Array.from(
+      contentElement.value!.querySelectorAll<HTMLElement>('[data-reka-collection-item]:not([data-disabled])'),
+    )
+    if (items.length) {
+      const el = event.key === 'ArrowDown' ? items[0] : items[items.length - 1]
+      el?.focus()
+    }
+    return
+  }
 
   const el = useArrowNavigation(
     event,
@@ -197,7 +220,7 @@ function handleKeyDown(event: KeyboardEvent) {
     // menus should not be navigated using tab key so we prevent it
     if (event.key === 'Tab')
       event.preventDefault()
-    if (!isModifierKey && isCharacterKey)
+    if (!isModifierKey && isCharacterKey && !isFromTextInput)
       handleTypeaheadSearch(event.key, collectionItems)
   }
 

--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -183,17 +183,8 @@ function handleKeyDown(event: KeyboardEvent) {
 
   const isFromTextInput = isTextInputElement(target)
 
-  if (isFromTextInput && ['ArrowDown', 'ArrowUp'].includes(event.key)) {
-    event.preventDefault()
-    const items = Array.from(
-      contentElement.value!.querySelectorAll<HTMLElement>('[data-reka-collection-item]:not([data-disabled])'),
-    )
-    if (items.length) {
-      const el = event.key === 'ArrowDown' ? items[0] : items[items.length - 1]
-      el?.focus()
-    }
+  if (isFromTextInput && ['ArrowDown', 'ArrowUp'].includes(event.key))
     return
-  }
 
   const el = useArrowNavigation(
     event,


### PR DESCRIPTION
### 🔗 Linked issue

#2246 (supersedes #2247)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Text inputs inside `MenuContent` were basically unusable: typeahead stole keystrokes and arrow keys hit a `-1` index bug in `useArrowNavigation`.

This fixes both by detecting text input elements (`<input>`, `<textarea>`, `contenteditable`) and:
1. Skipping typeahead when typing comes from one
2. Manually focusing first/last menu item on ArrowDown/ArrowUp instead of going through `useArrowNavigation`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.