### PR TITLE
fix(TimeField): prioritize hourCycle prop over locale for 12/24h detection

### DIFF
--- a/packages/core/src/TimeField/TimeField.test.ts
+++ b/packages/core/src/TimeField/TimeField.test.ts
@@ -336,6 +336,31 @@ describe('timeField', async () => {
     expect(hour).toHaveTextContent('13')
   })
 
+  it('allows typing two-digit hours (e.g. 14) in 24h mode regardless of locale', async () => {
+    const { hour, user, value, rerender } = setup({
+      timeFieldProps: {
+        modelValue: new Time(0, 30, 0),
+        hourCycle: 24,
+      },
+      emits: {
+        'onUpdate:modelValue': (data: TimeValue) => {
+          return rerender({
+            timeFieldProps: {
+              modelValue: data,
+              hourCycle: 24,
+            },
+          })
+        },
+      },
+    })
+
+    await user.click(hour)
+    await user.keyboard('{1}{4}')
+
+    expect(hour).toHaveTextContent('14')
+    expect(value.textContent).toContain('14:30:00')
+  })
+
   it('overrides the default displayed segments with the `granularity` prop - `hour`', async () => {
     const { queryByTestId, hour } = setup({
       timeFieldProps: {

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -745,7 +745,9 @@ export function useDateField(props: UseDateFieldProps) {
 
     if (isNumberString(e.key)) {
       const num = Number.parseInt(e.key)
-      const is12Hour = uses12HourFormat(props.formatter.getLocale())
+      const is12Hour = props.hourCycle !== undefined
+        ? props.hourCycle === 12
+        : uses12HourFormat(props.formatter.getLocale())
       const max = is12Hour ? 12 : 24
 
       let displayPrev = prevValue


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2463 (upstream fix for directus/directus#26686)

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

In `handleHourSegmentKeydown`, the 12h vs 24h detection was derived solely from the locale via `uses12HourFormat(props.formatter.getLocale())`. This means that on 12h-default locales (e.g. `en-US`), `max = 12` was always used regardless of the `hourCycle` prop — causing two-digit hours like `14` to resolve to `4` (focus moves after the first digit, second digit lands in minutes).

**Fix:** When `hourCycle` is explicitly set, use it as the source of truth. Fall back to locale-based detection only when `hourCycle` is `undefined`.

```diff
- const is12Hour = uses12HourFormat(props.formatter.getLocale())
+ const is12Hour = props.hourCycle !== undefined
+   ? props.hourCycle === 12
+   : uses12HourFormat(props.formatter.getLocale())
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time field now correctly applies the hourCycle setting to determine 12 vs 24-hour input limits.

* **Tests**
  * Added test validation for two-digit hour input in 24-hour mode across different locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->