### PR TITLE
fix(useForwardExpose): sync `currentElement` on DOM update

### DIFF
--- a/packages/core/src/shared/useForwardExpose.test.ts
+++ b/packages/core/src/shared/useForwardExpose.test.ts
@@ -1,7 +1,8 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import { computed, defineComponent, Fragment, h, ref } from 'vue'
+import { computed, defineComponent, Fragment, h, ref, watchPostEffect } from 'vue'
 
+import { Primitive } from '../Primitive'
 import { useForwardExpose } from './useForwardExpose'
 
 describe('useForwardRef', async () => {
@@ -293,5 +294,32 @@ describe('useForwardRef', async () => {
     parentRef.value?.increment()
     expect(parentRef.value?.count).toBe(1)
     expect(parentRef.value?.$el).toBeInstanceOf(HTMLButtonElement)
+  })
+
+  it('should update currentElement when as-child conditional child swaps', async () => {
+    const toggle = ref(true)
+    let renderNode: string | undefined
+
+    mount(defineComponent({
+      setup() {
+        const { forwardRef, currentElement } = useForwardExpose()
+        watchPostEffect(() => {
+          renderNode = currentElement.value?.nodeName.toLowerCase()
+        })
+        return () => {
+          const showButton = toggle.value
+          return h(Primitive, { ref: forwardRef, asChild: true }, {
+            default: () => [showButton ? h('button') : h('span')],
+          })
+        }
+      },
+    }))
+
+    await flushPromises()
+    expect(renderNode).toBe('button')
+
+    toggle.value = !toggle.value
+    await flushPromises()
+    expect(renderNode).toBe('span')
   })
 })

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -1,3 +1,4 @@
+import type { MaybeElement } from '@vueuse/core'
 import type { ComponentPublicInstance } from 'vue'
 // reference: https://github.com/vuejs/rfcs/issues/258#issuecomment-1068697672
 import { unrefElement } from '@vueuse/core'
@@ -18,10 +19,13 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
     }
   })
 
-  function resolveCurrentElement(): HTMLElement {
+  function resolveCurrentElement() {
     // $el could be text/comment for non-single root normal or text root, thus we retrieve the nextElementSibling
-    // @ts-expect-error ignore ts error
-    return ['#text', '#comment'].includes(currentRef.value?.$el.nodeName) ? currentRef.value?.$el.nextElementSibling : unrefElement(currentRef)
+    return currentRef.value
+      && '$el' in currentRef.value
+      && ['#text', '#comment'].includes(currentRef.value.$el.nodeName)
+      ? currentRef.value.$el.nextElementSibling as HTMLElement
+      : unrefElement(currentRef as unknown as MaybeElement) as HTMLElement
   }
 
   // Do give us credit if you reference our code :D

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -1,17 +1,28 @@
 import type { ComponentPublicInstance } from 'vue'
 // reference: https://github.com/vuejs/rfcs/issues/258#issuecomment-1068697672
 import { unrefElement } from '@vueuse/core'
-import { computed, getCurrentInstance, ref } from 'vue'
+import { computed, getCurrentInstance, onUpdated, ref, triggerRef } from 'vue'
 
 export function useForwardExpose<T extends ComponentPublicInstance>() {
   const instance = getCurrentInstance()!
 
   const currentRef = ref<Element | T | null>()
-  const currentElement = computed<HTMLElement>(() => {
+  const currentElement = computed(() => resolveCurrentElement())
+
+  // When using as-child with conditional rendering (v-if/v-else), the underlying
+  // DOM element ($el) changes but currentRef (component instance) stays the same.
+  // Since $el is not reactive, we sync currentElement after DOM updates.
+  onUpdated(() => {
+    if (currentElement.value !== resolveCurrentElement()) {
+      triggerRef(currentRef)
+    }
+  })
+
+  function resolveCurrentElement(): HTMLElement {
     // $el could be text/comment for non-single root normal or text root, thus we retrieve the nextElementSibling
     // @ts-expect-error ignore ts error
     return ['#text', '#comment'].includes(currentRef.value?.$el.nodeName) ? currentRef.value?.$el.nextElementSibling : unrefElement(currentRef)
-  })
+  }
 
   // Do give us credit if you reference our code :D
   // localExpose should only be assigned once else will create infinite loop


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

resolves https://github.com/unovue/reka-ui/issues/2474

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed element references not updating when conditional rendering swaps between different element types.
  * Improved element resolution to correctly locate the rendered element even when intermediary text/comment nodes are present.

* **Tests**
  * Added test coverage verifying element tracking updates correctly as conditional child elements change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->