### PR TITLE
fix(Tabs): allow Tabs type to have boolean value

### DIFF
--- a/packages/core/src/Tabs/TabsContent.vue
+++ b/packages/core/src/Tabs/TabsContent.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import type { StringOrNumber } from '@/shared/types'
 import { useForwardExpose } from '@/shared'
+import type { TabValue } from './utils'
 
 export interface TabsContentProps extends PrimitiveProps {
   /** A unique value that associates the content with a trigger. */
-  value: StringOrNumber
+  value: TabValue
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.

--- a/packages/core/src/Tabs/TabsRoot.vue
+++ b/packages/core/src/Tabs/TabsRoot.vue
@@ -1,25 +1,26 @@
 <script lang="ts">
 import type { Ref } from 'vue'
-import type { DataOrientation, Direction, StringOrNumber } from '../shared/types'
+import type { DataOrientation, Direction } from '../shared/types'
 import type { PrimitiveProps } from '@/Primitive'
 import { useVModel } from '@vueuse/core'
 import { createContext, useDirection, useForwardExpose, useId } from '@/shared'
+import type { TabValue } from './utils'
 
 export interface TabsRootContext {
-  modelValue: Ref<StringOrNumber | undefined>
-  changeModelValue: (value: StringOrNumber) => void
+  modelValue: Ref<TabValue | undefined>
+  changeModelValue: (value: TabValue) => void
   orientation: Ref<DataOrientation>
   dir: Ref<Direction>
   unmountOnHide: Ref<boolean>
   activationMode: 'automatic' | 'manual'
   baseId: string
   tabsList: Ref<HTMLElement | undefined>
-  contentIds: Ref<Set<StringOrNumber>>
-  registerContent: (value: StringOrNumber) => void
-  unregisterContent: (value: StringOrNumber) => void
+  contentIds: Ref<Set<TabValue>>
+  registerContent: (value: TabValue) => void
+  unregisterContent: (value: TabValue) => void
 }
 
-export interface TabsRootProps<T extends StringOrNumber = StringOrNumber> extends PrimitiveProps {
+export interface TabsRootProps<T extends TabValue = TabValue> extends PrimitiveProps {
   /**
    * The value of the tab that should be active when initially rendered. Use when you do not need to control the state of the tabs
    */
@@ -48,7 +49,7 @@ export interface TabsRootProps<T extends StringOrNumber = StringOrNumber> extend
    */
   unmountOnHide?: boolean
 }
-export type TabsRootEmits<T extends StringOrNumber = StringOrNumber> = {
+export type TabsRootEmits<T extends TabValue = TabValue> = {
   /** Event handler called when the value changes */
   'update:modelValue': [payload: T]
 }
@@ -57,7 +58,7 @@ export const [injectTabsRootContext, provideTabsRootContext]
   = createContext<TabsRootContext>('TabsRoot')
 </script>
 
-<script setup lang="ts" generic="T extends StringOrNumber = StringOrNumber">
+<script setup lang="ts" generic="T extends TabValue = TabValue">
 import { ref, shallowRef, toRefs } from 'vue'
 import { Primitive } from '@/Primitive'
 
@@ -85,11 +86,11 @@ const modelValue = useVModel<TabsRootProps<T>, 'modelValue', 'update:modelValue'
 })
 
 const tabsList = ref<HTMLElement>()
-const contentIds = shallowRef<Set<StringOrNumber>>(new Set())
+const contentIds = shallowRef<Set<TabValue>>(new Set())
 
 provideTabsRootContext({
   modelValue,
-  changeModelValue: (value: StringOrNumber) => {
+  changeModelValue: (value: TabValue) => {
     modelValue.value = value as T
   },
   orientation,
@@ -99,10 +100,10 @@ provideTabsRootContext({
   baseId: useId(undefined, 'reka-tabs'),
   tabsList,
   contentIds,
-  registerContent: (value: StringOrNumber) => {
+  registerContent: (value: TabValue) => {
     contentIds.value = new Set([...contentIds.value, value])
   },
-  unregisterContent: (value: StringOrNumber) => {
+  unregisterContent: (value: TabValue) => {
     const newSet = new Set(contentIds.value)
     newSet.delete(value)
     contentIds.value = newSet

--- a/packages/core/src/Tabs/TabsTrigger.vue
+++ b/packages/core/src/Tabs/TabsTrigger.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import type { StringOrNumber } from '@/shared/types'
 import { useForwardExpose } from '@/shared'
+import type { TabValue } from './utils'
 
 export interface TabsTriggerProps extends PrimitiveProps {
   /** A unique value that associates the trigger with a content. */
-  value: StringOrNumber
+  value: TabValue
   /** When `true`, prevents the user from interacting with the tab. */
   disabled?: boolean
 }

--- a/packages/core/src/Tabs/utils.ts
+++ b/packages/core/src/Tabs/utils.ts
@@ -1,9 +1,9 @@
-import type { StringOrNumber } from '@/shared/types'
+export type TabValue = string | number | boolean
 
-export function makeTriggerId(baseId: string, value: StringOrNumber) {
+export function makeTriggerId(baseId: string, value: TabValue) {
   return `${baseId}-trigger-${value}`
 }
 
-export function makeContentId(baseId: string, value: StringOrNumber) {
+export function makeContentId(baseId: string, value: TabValue) {
   return `${baseId}-content-${value}`
 }


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

None.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Tabs effectively allow `boolean` values as it works in runtime, but prints warnings in the console from props validation. This change adds `boolean` to the value type, no runtime changes.

### 📸 Screenshots (if appropriate)



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

If docs will need update, I'll update them too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tabs updated to accept boolean identifiers in addition to strings and numbers (expanded identifier types).
  * Public types and APIs adjusted to reflect the broader identifier support; runtime behavior and interactions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->