### PR TITLE
fix(Toast): resolve accessibility issues flagged by axe-core

### DIFF
--- a/packages/core/src/Toast/FocusProxy.vue
+++ b/packages/core/src/Toast/FocusProxy.vue
@@ -11,7 +11,6 @@ const providerContext = injectToastProviderContext()
 
 <template>
   <VisuallyHidden
-    aria-hidden="true"
     tabindex="0"
     style="position: fixed"
     @focus="(event: FocusEvent) => {

--- a/packages/core/src/Toast/Toast.test.ts
+++ b/packages/core/src/Toast/Toast.test.ts
@@ -19,18 +19,16 @@ describe('given a default Toast', () => {
     trigger = wrapper.find('button')
   })
 
-  it('should have visible toast with role="alert" for screen readers', async () => {
+  it('should have visible toast that is focusable', async () => {
     // Open toast
     await fireEvent.click(trigger.element)
 
     // Wait for toast to appear in DOM
-    await findByText(document.body, 'Scheduled: Catch up')
+    const toastText = await findByText(document.body, 'Scheduled: Catch up')
 
-    // The visible toast element has role="alert" and aria-live="off"
-    // This is the interactive element that users see
-    const toastElement = document.querySelector('[role="alert"]')
+    // The visible toast element should be focusable
+    const toastElement = toastText.closest('li')
     expect(toastElement).toBeTruthy()
-    expect(toastElement?.getAttribute('aria-live')).toBe('off')
     expect(toastElement?.getAttribute('tabindex')).toBe('0')
   })
 

--- a/packages/core/src/Toast/ToastRootImpl.vue
+++ b/packages/core/src/Toast/ToastRootImpl.vue
@@ -182,7 +182,6 @@ provideToastRootContext({ onClose: handleClose })
     v-if="announceTextContent"
     role="alert"
     :aria-live="type === 'foreground' ? 'assertive' : 'polite'"
-    aria-atomic="true"
   >
     {{ announceTextContent }}
   </ToastAnnounce>
@@ -194,9 +193,6 @@ provideToastRootContext({ onClose: handleClose })
     <CollectionItem>
       <Primitive
         :ref="forwardRef"
-        role="alert"
-        aria-live="off"
-        aria-atomic="true"
         tabindex="0"
         v-bind="$attrs"
         :as="as"


### PR DESCRIPTION
## Summary

- Remove `aria-hidden` from focusable FocusProxy elements (aria-hidden-focus violation)
- Remove disallowed `role="alert"` from `<li>` toast element (aria-allowed-role violation)
- Remove unneeded `aria-atomic` from ToastAnnounce

Ported from Radix UI fix: https://github.com/radix-ui/primitives/pull/2595

Closes #2486

## Test plan
- [ ] Verify toast notifications still announce correctly to screen readers
- [ ] Run axe-core and confirm no more violations on Toast component
- [ ] Verify focus management still works (tab through toasts, focus proxy behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Toast accessibility: toast messages are now exposed to assistive technologies and are keyboard-focusable, making notifications easier to discover and interact with for screen reader and keyboard users.
  * Corresponding tests updated to reflect focusable toast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->