### PR TITLE
fix(DateField): restore preventDefault for non-TAB keys in segment keydown

### DIFF
--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -874,6 +874,8 @@ export function useDateField(props: UseDateFieldProps) {
   function handleSegmentKeydown(e: KeyboardEvent) {
     const disabled = props.disabled.value
     const readonly = props.readonly.value
+    if (e.key !== kbd.TAB)
+      e.preventDefault()
 
     if (disabled || readonly)
       return

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -874,11 +874,10 @@ export function useDateField(props: UseDateFieldProps) {
   function handleSegmentKeydown(e: KeyboardEvent) {
     const disabled = props.disabled.value
     const readonly = props.readonly.value
-    if (e.key !== kbd.TAB)
-      e.preventDefault()
-
     if (disabled || readonly)
       return
+    if (e.key !== kbd.TAB)
+      e.preventDefault()
     const segmentKeydownHandlers = {
       day: handleDaySegmentKeydown,
       month: handleMonthSegmentKeydown,


### PR DESCRIPTION
## Summary
- Restores the `e.preventDefault()` call for non-TAB keys in `handleSegmentKeydown` that was accidentally removed
- Without it, the browser's default input behavior fires alongside the custom segment handler, causing TimeField inputs to display incorrect values despite the modelValue being correct

Closes #2487

## Test plan
- [x] All existing tests pass (78 test files, 1581 tests)
- [ ] Manually verify TimeField: type `0` then `2` in hours slot → should show `02`
- [ ] Manually verify typing `00` in minutes slot → should show `00`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in date fields: most non‑Tab key presses are now prevented from triggering default browser behavior when the field is editable, reducing unintended interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->