### PR TITLE
fix(DismissableLayer): guard against non-Element targets in isLayerExist

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -4,10 +4,21 @@ import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { sleep } from '@/test'
 import DismissableLayer from './story/_DismissableLayer.vue'
+import { isLayerExist } from './utils'
 
 const OPEN_LABEL = 'Open'
 const CLOSE_LABEL = 'Close'
 const OUTSIDE_LABEL = 'Outside'
+
+describe('isLayerExist', () => {
+  it('should return false for non-Element targets without throwing', () => {
+    const layer = document.createElement('div')
+    layer.setAttribute('data-dismissable-layer', '')
+
+    expect(isLayerExist(layer, document as any)).toBe(false)
+    expect(isLayerExist(layer, document.createTextNode('x') as any)).toBe(false)
+  })
+})
 
 describe('given a default DismissableLayer', () => {
   let wrapper: VueWrapper<InstanceType<typeof DismissableLayer>>

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -13,7 +13,10 @@ export const CONTEXT_UPDATE = 'dismissableLayer.update'
 export const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside'
 export const FOCUS_OUTSIDE = 'dismissableLayer.focusOutside'
 
-function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
+export function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
+  if (!(targetElement instanceof Element))
+    return false
+
   const targetLayer = targetElement.closest(
     '[data-dismissable-layer]',
   )


### PR DESCRIPTION
### 🔗 Linked issue

#1779

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`isLayerExist` in `DismissableLayer/utils.ts` crashes with `TypeError: target.closest is not a function` when `event.target` is a valid but non-Element DOM node (e.g. `Document`, `Text`).

This happens because `useFocusOutside` listens for `focusin` on `ownerDocument` and passes `event.target` to `isLayerExist`, which unconditionally calls `targetElement.closest(...)`. The `.closest()` method only exists on `Element` — not on all `EventTarget` types.

PR #1860 added `!target` guards before calling `isLayerExist`, which catches `null`/`undefined`. But when `event.target` is a `Document` or `Text` node, it's **truthy** yet lacks `.closest()`.

**Fix:** Add an `instanceof Element` guard at the top of `isLayerExist`. This protects all callers in one place and handles every non-Element EventTarget type.

Resolves #1779

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for the layer detection utility, validating behavior with various input types and edge cases.

* **Refactor**
  * Enhanced the layer detection utility with improved type safety and made it publicly available for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->