### PR TITLE
fix(useBodyScrollLock): prevent permanent scroll lock on rapid toggle

### DIFF
--- a/packages/core/src/shared/useBodyScrollLock.test.ts
+++ b/packages/core/src/shared/useBodyScrollLock.test.ts
@@ -95,6 +95,18 @@ describe('useBodyScrollLock', () => {
     expect(document.body.style.overflow).toBe('')
   })
 
+  it('should not permanently lock when toggled rapidly in the same tick', async () => {
+    const locked = useBodyScrollLock()
+
+    // Lock and immediately unlock in the same synchronous tick
+    locked.value = true
+    locked.value = false
+
+    await nextTick()
+    expect(document.body.style.overflow).toBe('')
+    expect(document.body.style.pointerEvents).toBe('')
+  })
+
   it('should preserve user overflow', async () => {
     document.body.style.overflow = 'scroll'
 

--- a/packages/core/src/shared/useBodyScrollLock.ts
+++ b/packages/core/src/shared/useBodyScrollLock.ts
@@ -80,6 +80,8 @@ const useBodyLockStackCount = createSharedComposable(() => {
 
     // let dismissibleLayer set previous pointerEvent first
     nextTick(() => {
+      if (!locked.value)
+        return
       document.body.style.pointerEvents = 'none'
       document.body.style.overflow = 'hidden'
     })


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

resolves https://github.com/unovue/reka-ui/issues/2480

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll lock behavior when rapidly toggling lock states to ensure styles properly reset.

* **Tests**
  * Added test coverage for rapid toggle scenarios in scroll lock functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->