### PR TITLE
fix(Splitter): emit correct units for pixel-sized panels in events

### DIFF
--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -193,6 +193,20 @@ function getPanelDataWithPercentConstraints(groupSizeOverride?: number | null) {
 
 const setLayout = (val: number[]) => layout.value = val
 
+/** Convert internal layout (always in %) to native units for each panel */
+function convertLayoutToNativeUnits(internalLayout: number[]): number[] {
+  const { panelDataArray } = eagerValuesRef.value
+  const groupSize = getGroupSizeInPixels()
+
+  return internalLayout.map((size, index) => {
+    const panelData = panelDataArray[index]
+    if (panelData && (panelData.constraints.sizeUnit ?? '%') === 'px' && groupSize != null) {
+      return (size / 100) * groupSize
+    }
+    return size
+  })
+}
+
 useWindowSplitterPanelGroupBehavior({
   eagerValuesRef,
   groupId,
@@ -347,12 +361,13 @@ watch(() => eagerValuesRef.value.panelDataArrayChanged, () => {
       setLayout(nextLayout)
 
       eagerValuesRef.value.layout = nextLayout
-      emits('layout', nextLayout)
+      emits('layout', convertLayoutToNativeUnits(nextLayout))
 
       callPanelCallbacks(
         panelDataArray,
         nextLayout,
         panelIdToLastNotifiedSizeMapRef.value,
+        getGroupSizeInPixels(),
       )
     }
   }
@@ -391,12 +406,13 @@ watch(groupSizeInPixels, (nextSize, prevSize) => {
     setLayout(nextLayout)
 
     eagerValuesRef.value.layout = nextLayout
-    emits('layout', nextLayout)
+    emits('layout', convertLayoutToNativeUnits(nextLayout))
 
     callPanelCallbacks(
       panelDataArray,
       nextLayout,
       panelIdToLastNotifiedSizeMapRef.value,
+      getGroupSizeInPixels(),
     )
   }
 })
@@ -484,12 +500,13 @@ function registerResizeHandle(dragHandleId: string) {
       setLayout(nextLayout)
 
       eagerValuesRef.value.layout = nextLayout
-      emits('layout', nextLayout)
+      emits('layout', convertLayoutToNativeUnits(nextLayout))
 
       callPanelCallbacks(
         panelDataArray,
         nextLayout,
         panelIdToLastNotifiedSizeMapRef.value,
+        getGroupSizeInPixels(),
       )
     }
   }
@@ -540,12 +557,13 @@ function resizePanel(panelData: PanelData, unsafePanelSize: number) {
     setLayout(nextLayout)
 
     eagerValuesRef.value.layout = nextLayout
-    emits('layout', nextLayout)
+    emits('layout', convertLayoutToNativeUnits(nextLayout))
 
     callPanelCallbacks(
       panelDataArray,
       nextLayout,
       panelIdToLastNotifiedSizeMapRef.value,
+      getGroupSizeInPixels(),
     )
   }
 }
@@ -682,12 +700,13 @@ function collapsePanel(panelData: PanelData) {
 
         eagerValuesRef.value.layout = nextLayout
 
-        emits('layout', nextLayout)
+        emits('layout', convertLayoutToNativeUnits(nextLayout))
 
         callPanelCallbacks(
           panelDataArray,
           nextLayout,
           panelIdToLastNotifiedSizeMapRef.value,
+          getGroupSizeInPixels(),
         )
       }
     }
@@ -747,12 +766,13 @@ function expandPanel(panelData: PanelData) {
 
         eagerValuesRef.value.layout = nextLayout
 
-        emits('layout', nextLayout)
+        emits('layout', convertLayoutToNativeUnits(nextLayout))
 
         callPanelCallbacks(
           panelDataArray,
           nextLayout,
           panelIdToLastNotifiedSizeMapRef.value,
+          getGroupSizeInPixels(),
         )
       }
     }

--- a/packages/core/src/Splitter/utils/callPanelCallbacks.test.ts
+++ b/packages/core/src/Splitter/utils/callPanelCallbacks.test.ts
@@ -236,4 +236,178 @@ describe('callPanelCallbacks', () => {
       expect(onCollapse).not.toHaveBeenCalled()
     })
   })
+
+  describe('edge cases', () => {
+    it('should handle collapsedSize of 0 for pixel panels', () => {
+      const onCollapse = vi.fn()
+      const onExpand = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onCollapse, onExpand },
+          constraints: {
+            sizeUnit: 'px',
+            collapsible: true,
+            collapsedSize: 0,
+          },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // Panel at 200px
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+      expect(onExpand).toHaveBeenCalledTimes(1)
+
+      onExpand.mockClear()
+
+      // Collapse to 0px (0%)
+      callPanelCallbacks(panels, [0], sizeMap, 1000)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+    })
+
+    it('should use fuzzy comparison for floating point precision', () => {
+      const onCollapse = vi.fn()
+      const onExpand = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onCollapse, onExpand },
+          constraints: {
+            sizeUnit: 'px',
+            collapsible: true,
+            collapsedSize: 48,
+          },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // Start expanded
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+      onExpand.mockClear()
+
+      // Collapse: 4.800000000000001% of 1000 = 48.00000000000001 ≈ 48
+      callPanelCallbacks(panels, [4.800000000000001], sizeMap, 1000)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+    })
+
+    it('should track sizes independently per panel in sizeMap', () => {
+      const onResizeA = vi.fn()
+      const onResizeB = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-a',
+          callbacks: { onResize: onResizeA },
+          constraints: { sizeUnit: 'px' },
+        }),
+        createPanelData({
+          id: 'panel-b',
+          callbacks: { onResize: onResizeB },
+          constraints: { sizeUnit: '%' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      callPanelCallbacks(panels, [30, 70], sizeMap, 1000)
+      expect(sizeMap['panel-a']).toBe(300) // stored in px
+      expect(sizeMap['panel-b']).toBe(70) // stored in %
+
+      // Only panel-a changes
+      callPanelCallbacks(panels, [25, 70], sizeMap, 1000)
+      expect(onResizeA).toHaveBeenCalledTimes(2)
+      expect(onResizeB).toHaveBeenCalledTimes(1) // not called again
+      expect(sizeMap['panel-a']).toBe(250)
+    })
+
+    it('should handle groupSizeInPixels of undefined (no arg)', () => {
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onResize },
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // No groupSizeInPixels argument
+      callPanelCallbacks(panels, [20], sizeMap)
+      expect(onResize).toHaveBeenCalledWith(20, undefined)
+    })
+
+    it('should handle panels with no callbacks', () => {
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: {},
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // Should not throw
+      expect(() => callPanelCallbacks(panels, [20], sizeMap, 1000)).not.toThrow()
+      expect(sizeMap['panel-1']).toBe(200)
+    })
+
+    it('should handle collapse/expand cycle correctly for pixel panels', () => {
+      const onCollapse = vi.fn()
+      const onExpand = vi.fn()
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onCollapse, onExpand, onResize },
+          constraints: {
+            sizeUnit: 'px',
+            collapsible: true,
+            collapsedSize: 48,
+          },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // 1. Start at 200px
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+      expect(onExpand).toHaveBeenCalledTimes(1)
+      expect(onResize).toHaveBeenCalledWith(200, undefined)
+
+      // 2. Collapse to 48px
+      callPanelCallbacks(panels, [4.8], sizeMap, 1000)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+      expect(onResize).toHaveBeenCalledWith(48, 200)
+
+      // 3. Expand to 200px
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+      expect(onExpand).toHaveBeenCalledTimes(2)
+      expect(onResize).toHaveBeenCalledWith(200, 48)
+
+      // 4. Collapse again
+      callPanelCallbacks(panels, [4.8], sizeMap, 1000)
+      expect(onCollapse).toHaveBeenCalledTimes(2)
+      expect(onResize).toHaveBeenCalledWith(48, 200)
+
+      expect(onResize).toHaveBeenCalledTimes(4)
+    })
+
+    it('should handle different group sizes for the same percentage', () => {
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onResize },
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // 20% of 1000px = 200px
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+      expect(onResize).toHaveBeenLastCalledWith(200, undefined)
+
+      // Same percentage but different group size: 20% of 800px = 160px
+      callPanelCallbacks(panels, [20], sizeMap, 800)
+      expect(onResize).toHaveBeenLastCalledWith(160, 200)
+      expect(onResize).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/packages/core/src/Splitter/utils/callPanelCallbacks.test.ts
+++ b/packages/core/src/Splitter/utils/callPanelCallbacks.test.ts
@@ -1,0 +1,239 @@
+import type { PanelData } from '../SplitterPanel.vue'
+import { describe, expect, it, vi } from 'vitest'
+import { callPanelCallbacks } from './callPanelCallbacks'
+
+function createPanelData(overrides: Partial<PanelData> & { id: string }): PanelData {
+  return {
+    callbacks: {},
+    constraints: {},
+    idIsFromProps: true,
+    order: undefined,
+    ...overrides,
+  }
+}
+
+describe('callPanelCallbacks', () => {
+  describe('onResize', () => {
+    it('should call onResize with percentage values for percent-based panels', () => {
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onResize },
+          constraints: { sizeUnit: '%' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      callPanelCallbacks(panels, [50], sizeMap, 1000)
+
+      expect(onResize).toHaveBeenCalledWith(50, undefined)
+      expect(sizeMap['panel-1']).toBe(50)
+    })
+
+    it('should convert percentage to pixels for px-based panels', () => {
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onResize },
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // 20% of 1000px = 200px
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+
+      expect(onResize).toHaveBeenCalledWith(200, undefined)
+      expect(sizeMap['panel-1']).toBe(200)
+    })
+
+    it('should pass previous size in native units', () => {
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onResize },
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      callPanelCallbacks(panels, [20], sizeMap, 1000) // 200px
+      callPanelCallbacks(panels, [25], sizeMap, 1000) // 250px
+
+      expect(onResize).toHaveBeenCalledTimes(2)
+      expect(onResize).toHaveBeenLastCalledWith(250, 200)
+    })
+
+    it('should fall back to percentage when groupSizeInPixels is not available', () => {
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onResize },
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      callPanelCallbacks(panels, [20], sizeMap, null)
+
+      expect(onResize).toHaveBeenCalledWith(20, undefined)
+    })
+
+    it('should handle mixed percent and pixel panels', () => {
+      const onResizePercent = vi.fn()
+      const onResizePx = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-percent',
+          callbacks: { onResize: onResizePercent },
+          constraints: { sizeUnit: '%' },
+        }),
+        createPanelData({
+          id: 'panel-px',
+          callbacks: { onResize: onResizePx },
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // 70% stays as 70, 30% of 1000px = 300px
+      callPanelCallbacks(panels, [70, 30], sizeMap, 1000)
+
+      expect(onResizePercent).toHaveBeenCalledWith(70, undefined)
+      expect(onResizePx).toHaveBeenCalledWith(300, undefined)
+    })
+
+    it('should not call onResize if size has not changed', () => {
+      const onResize = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onResize },
+          constraints: { sizeUnit: 'px' },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      callPanelCallbacks(panels, [20], sizeMap, 1000) // 200px
+      callPanelCallbacks(panels, [20], sizeMap, 1000) // 200px again
+
+      expect(onResize).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('onCollapse / onExpand for pixel-sized panels', () => {
+    it('should call onCollapse when pixel panel reaches collapsedSize', () => {
+      const onCollapse = vi.fn()
+      const onExpand = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onCollapse, onExpand },
+          constraints: {
+            sizeUnit: 'px',
+            collapsible: true,
+            collapsedSize: 48,
+          },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // First call: panel starts at 200px (20% of 1000)
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+      expect(onCollapse).not.toHaveBeenCalled()
+      expect(onExpand).toHaveBeenCalledTimes(1) // expanded from undefined
+
+      onExpand.mockClear()
+
+      // Second call: panel collapses to 48px (4.8% of 1000)
+      callPanelCallbacks(panels, [4.8], sizeMap, 1000)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+      expect(onExpand).not.toHaveBeenCalled()
+    })
+
+    it('should call onExpand when pixel panel expands from collapsedSize', () => {
+      const onCollapse = vi.fn()
+      const onExpand = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onCollapse, onExpand },
+          constraints: {
+            sizeUnit: 'px',
+            collapsible: true,
+            collapsedSize: 48,
+          },
+        }),
+      ]
+      // Start already collapsed at 48px
+      const sizeMap: Record<string, number> = { 'panel-1': 48 }
+
+      // Panel expands to 200px (20% of 1000)
+      callPanelCallbacks(panels, [20], sizeMap, 1000)
+      expect(onExpand).toHaveBeenCalledTimes(1)
+      expect(onCollapse).not.toHaveBeenCalled()
+    })
+
+    it('should not fire collapse/expand for non-collapsible panels', () => {
+      const onCollapse = vi.fn()
+      const onExpand = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onCollapse, onExpand },
+          constraints: {
+            sizeUnit: 'px',
+            collapsible: false,
+            collapsedSize: 48,
+          },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      callPanelCallbacks(panels, [4.8], sizeMap, 1000) // 48px = collapsedSize
+      expect(onCollapse).not.toHaveBeenCalled()
+      expect(onExpand).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onCollapse / onExpand for percent-based panels', () => {
+    it('should still work for percentage panels', () => {
+      const onCollapse = vi.fn()
+      const onExpand = vi.fn()
+      const panels: PanelData[] = [
+        createPanelData({
+          id: 'panel-1',
+          callbacks: { onCollapse, onExpand },
+          constraints: {
+            sizeUnit: '%',
+            collapsible: true,
+            collapsedSize: 5,
+          },
+        }),
+      ]
+      const sizeMap: Record<string, number> = {}
+
+      // Start expanded
+      callPanelCallbacks(panels, [30], sizeMap, 1000)
+      expect(onExpand).toHaveBeenCalledTimes(1)
+
+      onExpand.mockClear()
+
+      // Collapse to 5%
+      callPanelCallbacks(panels, [5], sizeMap, 1000)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+      expect(onExpand).not.toHaveBeenCalled()
+
+      onCollapse.mockClear()
+
+      // Expand from 5%
+      callPanelCallbacks(panels, [25], sizeMap, 1000)
+      expect(onExpand).toHaveBeenCalledTimes(1)
+      expect(onCollapse).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/Splitter/utils/callPanelCallbacks.ts
+++ b/packages/core/src/Splitter/utils/callPanelCallbacks.ts
@@ -1,41 +1,49 @@
 import type { PanelData } from '../SplitterPanel.vue'
 import { assert } from './assert'
+import { fuzzyNumbersEqual } from './compare'
 
 // Layout should be pre-converted into percentages
 export function callPanelCallbacks(
   panelsArray: PanelData[],
   layout: number[],
   panelIdToLastNotifiedSizeMap: Record<string, number>,
+  groupSizeInPixels?: number | null,
 ) {
   layout.forEach((size, index) => {
     const panelData = panelsArray[index]
     assert(panelData)
 
     const { callbacks, constraints, id: panelId } = panelData
-    const { collapsedSize = 0, collapsible } = constraints
+    const { collapsedSize = 0, collapsible, sizeUnit } = constraints
+
+    // Convert size to native units for px panels
+    let displaySize = size
+    if (sizeUnit === 'px' && groupSizeInPixels != null) {
+      displaySize = (size / 100) * groupSizeInPixels
+    }
 
     const lastNotifiedSize = panelIdToLastNotifiedSizeMap[panelId]
-    if (lastNotifiedSize == null || size !== lastNotifiedSize) {
-      panelIdToLastNotifiedSizeMap[panelId] = size
+    if (lastNotifiedSize == null || !fuzzyNumbersEqual(displaySize, lastNotifiedSize)) {
+      panelIdToLastNotifiedSizeMap[panelId] = displaySize
 
       const { onCollapse, onExpand, onResize } = callbacks
 
       if (onResize)
-        onResize(size, lastNotifiedSize)
+        onResize(displaySize, lastNotifiedSize)
 
       if (collapsible && (onCollapse || onExpand)) {
         if (
           onExpand
-          && (lastNotifiedSize == null || lastNotifiedSize === collapsedSize)
-          && size !== collapsedSize
+          && (lastNotifiedSize == null || fuzzyNumbersEqual(lastNotifiedSize, collapsedSize))
+          && !fuzzyNumbersEqual(displaySize, collapsedSize)
         ) {
           onExpand()
         }
 
         if (
           onCollapse
-          && (lastNotifiedSize == null || lastNotifiedSize !== collapsedSize)
-          && size === collapsedSize
+          && (lastNotifiedSize == null || !fuzzyNumbersEqual(lastNotifiedSize, collapsedSize))
+          && fuzzyNumbersEqual(displaySize, collapsedSize)
         ) {
           onCollapse()
         }

--- a/packages/core/src/Splitter/utils/units.test.ts
+++ b/packages/core/src/Splitter/utils/units.test.ts
@@ -1,0 +1,178 @@
+import type { PanelData } from '../SplitterPanel.vue'
+import { describe, expect, it } from 'vitest'
+import { convertPanelConstraintsToPercent, hasPixelSizedPanel, recalculateLayoutForPixelPanels } from './units'
+
+function createPanelData(overrides: Partial<PanelData> & { id: string }): PanelData {
+  return {
+    callbacks: {},
+    constraints: {},
+    idIsFromProps: true,
+    order: undefined,
+    ...overrides,
+  }
+}
+
+describe('hasPixelSizedPanel', () => {
+  it('should return false when no panels use px', () => {
+    const panels = [
+      createPanelData({ id: 'a', constraints: { sizeUnit: '%' } }),
+      createPanelData({ id: 'b', constraints: {} }),
+    ]
+    expect(hasPixelSizedPanel(panels)).toBe(false)
+  })
+
+  it('should return true when at least one panel uses px', () => {
+    const panels = [
+      createPanelData({ id: 'a', constraints: { sizeUnit: '%' } }),
+      createPanelData({ id: 'b', constraints: { sizeUnit: 'px' } }),
+    ]
+    expect(hasPixelSizedPanel(panels)).toBe(true)
+  })
+})
+
+describe('convertPanelConstraintsToPercent', () => {
+  it('should return constraints as-is for percent panels', () => {
+    const panels = [
+      createPanelData({
+        id: 'a',
+        constraints: { sizeUnit: '%', minSize: 10, maxSize: 80, defaultSize: 50 },
+      }),
+    ]
+    const result = convertPanelConstraintsToPercent({ panelDataArray: panels, groupSizeInPixels: 1000 })
+    expect(result).not.toBeNull()
+    expect(result![0].minSize).toBe(10)
+    expect(result![0].maxSize).toBe(80)
+    expect(result![0].defaultSize).toBe(50)
+    expect(result![0].sizeUnit).toBe('%')
+  })
+
+  it('should convert px constraints to percent', () => {
+    const panels = [
+      createPanelData({
+        id: 'a',
+        constraints: {
+          sizeUnit: 'px',
+          minSize: 200,
+          maxSize: 400,
+          defaultSize: 300,
+          collapsedSize: 50,
+          collapsible: true,
+        },
+      }),
+    ]
+    const result = convertPanelConstraintsToPercent({ panelDataArray: panels, groupSizeInPixels: 1000 })
+    expect(result).not.toBeNull()
+    expect(result![0].minSize).toBe(20) // 200/1000 * 100
+    expect(result![0].maxSize).toBe(40) // 400/1000 * 100
+    expect(result![0].defaultSize).toBe(30) // 300/1000 * 100
+    expect(result![0].collapsedSize).toBe(5) // 50/1000 * 100
+    expect(result![0].sizeUnit).toBe('%')
+  })
+
+  it('should return null when px panel exists but groupSize is null', () => {
+    const panels = [
+      createPanelData({ id: 'a', constraints: { sizeUnit: 'px', defaultSize: 200 } }),
+    ]
+    const result = convertPanelConstraintsToPercent({ panelDataArray: panels, groupSizeInPixels: null })
+    expect(result).toBeNull()
+  })
+
+  it('should handle mixed percent and px panels', () => {
+    const panels = [
+      createPanelData({
+        id: 'sidebar',
+        constraints: { sizeUnit: 'px', defaultSize: 250, minSize: 150, maxSize: 350 },
+      }),
+      createPanelData({
+        id: 'content',
+        constraints: { sizeUnit: '%', minSize: 30 },
+      }),
+    ]
+    const result = convertPanelConstraintsToPercent({ panelDataArray: panels, groupSizeInPixels: 1000 })
+    expect(result).not.toBeNull()
+    // px panel converted
+    expect(result![0].defaultSize).toBe(25) // 250/1000 * 100
+    expect(result![0].minSize).toBe(15) // 150/1000 * 100
+    expect(result![0].maxSize).toBe(35) // 350/1000 * 100
+    // % panel unchanged
+    expect(result![1].minSize).toBe(30)
+  })
+})
+
+describe('recalculateLayoutForPixelPanels', () => {
+  it('should return null if no pixel panels exist', () => {
+    const panels = [
+      createPanelData({ id: 'a', constraints: { sizeUnit: '%' } }),
+      createPanelData({ id: 'b', constraints: { sizeUnit: '%' } }),
+    ]
+    const result = recalculateLayoutForPixelPanels({
+      layout: [50, 50],
+      panelDataArray: panels,
+      prevGroupSize: 1000,
+      nextGroupSize: 800,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('should maintain pixel panel size when group resizes', () => {
+    const panels = [
+      createPanelData({ id: 'sidebar', constraints: { sizeUnit: 'px' } }),
+      createPanelData({ id: 'content', constraints: { sizeUnit: '%' } }),
+    ]
+    // Sidebar is 200px (20% of 1000), content is 80%
+    const result = recalculateLayoutForPixelPanels({
+      layout: [20, 80],
+      panelDataArray: panels,
+      prevGroupSize: 1000,
+      nextGroupSize: 800,
+    })
+    expect(result).not.toBeNull()
+    // 200px / 800px * 100 = 25%
+    expect(result![0]).toBe(25)
+    // Remaining percentage adjusted: 80 * (75/80) = 75
+    expect(result![1]).toBe(75)
+  })
+
+  it('should return null for invalid group sizes', () => {
+    const panels = [
+      createPanelData({ id: 'a', constraints: { sizeUnit: 'px' } }),
+      createPanelData({ id: 'b', constraints: { sizeUnit: '%' } }),
+    ]
+
+    expect(recalculateLayoutForPixelPanels({
+      layout: [20, 80],
+      panelDataArray: panels,
+      prevGroupSize: null,
+      nextGroupSize: 800,
+    })).toBeNull()
+
+    expect(recalculateLayoutForPixelPanels({
+      layout: [20, 80],
+      panelDataArray: panels,
+      prevGroupSize: 1000,
+      nextGroupSize: 0,
+    })).toBeNull()
+  })
+
+  it('should handle multiple pixel panels', () => {
+    const panels = [
+      createPanelData({ id: 'left', constraints: { sizeUnit: 'px' } }),
+      createPanelData({ id: 'center', constraints: { sizeUnit: '%' } }),
+      createPanelData({ id: 'right', constraints: { sizeUnit: 'px' } }),
+    ]
+    // left=200px (20%), center=60%, right=200px (20%) at 1000px group
+    const result = recalculateLayoutForPixelPanels({
+      layout: [20, 60, 20],
+      panelDataArray: panels,
+      prevGroupSize: 1000,
+      nextGroupSize: 800,
+    })
+    expect(result).not.toBeNull()
+    // left: 200px / 800px * 100 = 25%
+    expect(result![0]).toBe(25)
+    // right: 200px / 800px * 100 = 25%
+    expect(result![2]).toBe(25)
+    // center gets remaining: 60 * (50 / 60) = 50
+    expect(result![1]).toBe(50)
+  })
+})


### PR DESCRIPTION
## Summary
- **`@layout` event**: Now converts internal percentage values to native units (px) for pixel-sized panels before emitting
- **`@resize` event**: Now emits size in the panel's native unit (px for pixel panels) instead of always emitting percentages
- **`@collapse`/`@expand` events**: Fixed not firing for pixel-sized panels — the root cause was comparing layout sizes (in %) against `collapsedSize` (in px); now both are compared in the same unit
- Used `fuzzyNumbersEqual` for size comparisons to prevent floating-point precision issues

Closes #2481

## Test plan
- [ ] Verify `@layout` event returns pixel values for pixel-sized panels and percentage values for percentage-sized panels
- [ ] Verify `@resize` event returns correct pixel values for pixel-sized panels
- [ ] Verify `@collapse` and `@expand` events fire correctly for pixel-sized collapsible panels
- [ ] Verify `isCollapsed`/`isExpanded` state is correct for pixel-sized panels
- [ ] Verify percentage-only groups still work as before (no regression)
- [ ] Test with the [reproduction from the issue](https://stackblitz.com/edit/reka-ui-splitter-reproduction?file=src%2FApp.vue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved panel resizing and collapse/expand behavior when mixing pixel and percentage sizes—layouts now emit and apply native pixel values where appropriate for more consistent sizing across resizes and group-size changes.

* **Tests**
  * Added extensive tests covering resize callbacks, unit conversion, and collapse/expand scenarios to ensure stable, predictable panel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->