### PR TITLE
feat(Menu): add aria-labelledby to MenuGroup

### DIFF
--- a/packages/core/src/Menu/MenuGroup.vue
+++ b/packages/core/src/Menu/MenuGroup.vue
@@ -1,19 +1,31 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import { createContext, useId } from '@/shared'
 
 export interface MenuGroupProps extends PrimitiveProps {}
+
+interface MenuGroupContext {
+  id: string
+}
+
+export const [injectMenuGroupContext, provideMenuGroupContext]
+  = createContext<MenuGroupContext>('MenuGroup')
 </script>
 
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
 
 const props = defineProps<MenuGroupProps>()
+
+const id = useId(undefined, 'reka-menu-group')
+provideMenuGroupContext({ id })
 </script>
 
 <template>
   <Primitive
     role="group"
     v-bind="props"
+    :aria-labelledby="id"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Menu/MenuLabel.vue
+++ b/packages/core/src/Menu/MenuLabel.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import { injectMenuGroupContext } from './MenuGroup.vue'
 
 export interface MenuLabelProps extends PrimitiveProps {}
 </script>
@@ -10,10 +11,15 @@ import { Primitive } from '@/Primitive'
 const props = withDefaults(defineProps<MenuLabelProps>(), {
   as: 'div',
 })
+
+const groupContext = injectMenuGroupContext({ id: '' })
 </script>
 
 <template>
-  <Primitive v-bind="props">
+  <Primitive
+    v-bind="props"
+    :id="groupContext.id || undefined"
+  >
     <slot />
   </Primitive>
 </template>


### PR DESCRIPTION
## Summary
- Add `aria-labelledby` to `MenuGroup` linking it to `MenuLabel` via shared context, so screen readers can announce the group label
- Mirrors the existing `ListboxGroup` / `ListboxGroupLabel` pattern

Closes #2097
Supersedes #2108

Co-authored with @markjaniczak

## Test plan
- [ ] Verify `MenuGroup` renders `aria-labelledby` pointing to the generated ID
- [ ] Verify `MenuLabel` renders the matching `id` attribute
- [ ] Verify screen readers announce the group label in DropdownMenu/ContextMenu
- [ ] Verify `MenuLabel` used outside `MenuGroup` does not render an empty `id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced menu accessibility with improved label-to-group associations for better screen reader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->