### PR TITLE
[#2483]fix(combobox): close content when focus moves outside with openOnFocus

### DIFF
--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -303,6 +303,28 @@ describe('given a Combobox with openOnFocus', () => {
 
     expect(document.activeElement).toBe(button.element)
   })
+
+  it('should close content when focus moves to an element outside', async () => {
+    // Add an external focusable element
+    const externalButton = document.createElement('button')
+    externalButton.textContent = 'External'
+    document.body.appendChild(externalButton)
+
+    const input = wrapper.find('input')
+
+    // Focus input to open via openOnFocus
+    await input.trigger('focus')
+    await nextTick()
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    // Simulate blur with relatedTarget pointing to external element
+    await input.trigger('blur', { relatedTarget: externalButton })
+    await nextTick()
+
+    expect(wrapper.find('[role=group]').exists()).toBe(false)
+
+    externalButton.remove()
+  })
 })
 
 describe('given combobox in a form', async () => {

--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -60,6 +60,19 @@ function handleFocus() {
     rootContext.onOpenChange(true)
 }
 
+function handleBlur(ev: FocusEvent) {
+  const nextFocus = ev.relatedTarget as HTMLElement
+
+  if (rootContext.open.value && nextFocus) {
+    const isInsideRoot = rootContext.parentElement.value?.contains(nextFocus)
+    const isInsideContent = document.getElementById(rootContext.contentId)?.contains(nextFocus)
+
+    if (!isInsideRoot && !isInsideContent) {
+      rootContext.onOpenChange(false)
+    }
+  }
+}
+
 function handleClick() {
   if (rootContext.openOnClick.value && !rootContext.open.value)
     rootContext.onOpenChange(true)
@@ -122,6 +135,7 @@ watch(rootContext.filterState, (_newValue, oldValue) => {
     @input="handleInput"
     @keydown.down.up.prevent="handleKeyDown"
     @focus="handleFocus"
+    @blur="handleBlur"
   >
     <slot />
   </ListboxFilter>

--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -61,15 +61,20 @@ function handleFocus() {
 }
 
 function handleBlur(ev: FocusEvent) {
-  const nextFocus = ev.relatedTarget as HTMLElement
+  if (!rootContext.open.value)
+    return
 
-  if (rootContext.open.value && nextFocus) {
-    const isInsideRoot = rootContext.parentElement.value?.contains(nextFocus)
-    const isInsideContent = document.getElementById(rootContext.contentId)?.contains(nextFocus)
+  const nextFocus = ev.relatedTarget as Element | null
 
-    if (!isInsideRoot && !isInsideContent) {
-      rootContext.onOpenChange(false)
-    }
+  // If focus moves to nothing (e.g. click on non-focusable area), let DismissableLayer handle it
+  if (!nextFocus)
+    return
+
+  const isInsideRoot = rootContext.parentElement.value?.contains(nextFocus)
+  const isInsideContent = document.getElementById(rootContext.contentId)?.contains(nextFocus)
+
+  if (!isInsideRoot && !isInsideContent) {
+    rootContext.onOpenChange(false)
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue 
Resolves #2483

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)


### 📚 Description
Summary
Fix an issue where the ComboboxContent remains open when focus moves to an external element while openOnFocus is enabled.

Problem
When openOnFocus is enabled, focusing the input opens the content. However, since the focus starts on the input (which is often outside the DismissableLayer portal content), clicking or tabbing to another external focusable element (such as a separate Select component) does not always trigger the DismissableLayer focus-outside logic.

Solution

Implement handleBlur in ComboboxInput.vue to track focus changes manually.

The logic checks whether the relatedTarget (the element receiving focus) is outside both the Combobox root container and the floating content portal.

If the focus has left the component tree, it calls onOpenChange(false) to close the content and keep the UI state in sync.

Impact

Fixes inconsistent closing behavior in openOnFocus and openOnClick scenarios

Improves accessibility and UX by preventing the popover from remaining open when users interact with other parts of the page

### 📸 Screenshots (if appropriate)
![fix#2483](https://github.com/user-attachments/assets/4ddaf88a-21f7-4219-9ec4-e587330637f9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combobox focus handling so the popup reliably closes when focus moves outside the component.

* **Tests**
  * Added tests confirming the combobox closes when focus shifts to an external element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->