### PR TITLE
fix(Menu): fix sub trigger not highlighting on pointermove

### DIFF
--- a/packages/core/src/Menu/Menu.test.ts
+++ b/packages/core/src/Menu/Menu.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import Menu from './story/_Menu.vue'
+import MenuWithSubmenu from './story/_MenuWithSubmenu.vue'
 
 describe('given a default Menu', () => {
   globalThis.ResizeObserver = class ResizeObserver {
@@ -58,5 +59,36 @@ describe('given a default Menu', () => {
         expect(wrapper.emitted('select')?.length).toBe(1)
       })
     })
+  })
+})
+
+describe('given a Menu with submenu', () => {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    mount(MenuWithSubmenu, {
+      attachTo: document.body,
+    })
+  })
+
+  it('should highlight sub trigger on pointermove', async () => {
+    const allItems = await findAllByRole(document.body, 'menuitem')
+    const subTrigger = allItems.find(el => el.getAttribute('aria-haspopup') === 'menu')!
+    expect(subTrigger).toBeTruthy()
+
+    // Simulate pointermove (mouse) on the sub trigger
+    // jsdom doesn't support PointerEvent, so we use MouseEvent with pointerType
+    const pointerMoveEvent = new MouseEvent('pointermove', {
+      bubbles: true,
+    })
+    Object.defineProperty(pointerMoveEvent, 'pointerType', { value: 'mouse' })
+    subTrigger.dispatchEvent(pointerMoveEvent)
+    await nextTick()
+
+    expect(subTrigger.hasAttribute('data-highlighted')).toBe(true)
   })
 })

--- a/packages/core/src/Menu/MenuItemImpl.vue
+++ b/packages/core/src/Menu/MenuItemImpl.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { injectMenuContext } from './MenuRoot.vue'
 
 export interface MenuItemImplProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with the item. */
@@ -29,7 +28,6 @@ defineOptions({
 
 const props = defineProps<MenuItemImplProps>()
 
-const menuContext = injectMenuContext()
 const contentContext = injectMenuContentContext()
 const { forwardRef, currentElement } = useForwardExpose()
 const { CollectionItem } = useCollection()
@@ -38,9 +36,8 @@ const isFocused = ref(false)
 const isHighlighted = computed(() => isFocused.value || (contentContext.highlightedElement.value === currentElement.value))
 
 async function handlePointerMove(event: PointerEvent) {
-  if (event.defaultPrevented || !isMouseEvent(event) || !menuContext.open.value) {
+  if (event.defaultPrevented || !isMouseEvent(event))
     return
-  }
   if (props.disabled) {
     contentContext.onItemLeave(event)
   }

--- a/packages/core/src/Menu/story/_MenuWithSubmenu.vue
+++ b/packages/core/src/Menu/story/_MenuWithSubmenu.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import {
+  MenuAnchor,
+  MenuContent,
+  MenuItem,
+  MenuPortal,
+  MenuRoot,
+  MenuSub,
+  MenuSubContent,
+  MenuSubTrigger,
+} from '..'
+</script>
+
+<template>
+  <MenuRoot
+    :open="true"
+    :modal="false"
+  >
+    <MenuAnchor :style="{ display: 'inline-block' }" />
+    <MenuPortal disabled>
+      <MenuContent
+        align="start"
+        @close-auto-focus.prevent
+      >
+        <MenuItem>
+          Item 1
+        </MenuItem>
+        <MenuSub>
+          <MenuSubTrigger>
+            Sub Trigger
+          </MenuSubTrigger>
+          <MenuPortal disabled>
+            <MenuSubContent>
+              <MenuItem>
+                Sub Item 1
+              </MenuItem>
+              <MenuItem>
+                Sub Item 2
+              </MenuItem>
+            </MenuSubContent>
+          </MenuPortal>
+        </MenuSub>
+        <MenuItem>
+          Item 2
+        </MenuItem>
+      </MenuContent>
+    </MenuPortal>
+  </MenuRoot>
+</template>


### PR DESCRIPTION
## Summary
- Fixes sub-trigger not getting highlighted when hovering over it (regression in v2.9.1)
- The `menuContext.open.value` check added in #2110 incorrectly referenced the sub-menu's context (provided by `MenuSub`) instead of the parent menu's. Since the submenu starts closed, `MenuItemImpl.handlePointerMove` returned early and skipped highlighting.
- Removed the unnecessary `menuContext.open` check from `MenuItemImpl` — if the parent menu is closed, its content is unmounted and no pointer events fire anyway.
- Added a regression test that verifies sub-trigger highlighting on pointermove.

Closes #2505

## Test plan
- [x] Added test: `should highlight sub trigger on pointermove` — verified it fails with the old code and passes with the fix
- [x] Manual: hover over a dropdown menu sub-trigger and confirm it highlights immediately
- [x] Manual: verify moving cursor between submenu and sub-trigger doesn't cause flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Menu with Submenu example demonstrating how to implement nested submenu functionality within menus.

* **Tests**
  * Added comprehensive test suite for Menu with Submenu, validating pointer event interactions and highlighted state behavior.

* **Refactor**
  * Improved pointer event handling logic in menu item implementation for simplified interaction patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->