### PR TITLE
fix(Calendar): remove HTML comment that breaks attrs forwarding in production

### DIFF
--- a/packages/core/src/Calendar/CalendarGrid.vue
+++ b/packages/core/src/Calendar/CalendarGrid.vue
@@ -17,11 +17,6 @@ const readonly = computed(() => rootContext.readonly.value ? true : undefined)
 </script>
 
 <template>
-  <!--
-    role="application" is intentional: it ensures screen readers like NVDA pass
-    keyboard events (arrow keys) to the web app instead of intercepting them
-    for virtual cursor navigation. This is the same pattern used by React Aria.
-  -->
   <Primitive
     v-bind="props"
     tabindex="-1"

--- a/packages/core/src/MonthPicker/MonthPickerGrid.vue
+++ b/packages/core/src/MonthPicker/MonthPickerGrid.vue
@@ -17,11 +17,6 @@ const readonly = computed(() => rootContext.readonly.value ? true : undefined)
 </script>
 
 <template>
-  <!--
-    role="application" is intentional: it ensures screen readers like NVDA pass
-    keyboard events (arrow keys) to the web app instead of intercepting them
-    for virtual cursor navigation. This is the same pattern used by React Aria.
-  -->
   <Primitive
     v-bind="props"
     tabindex="-1"

--- a/packages/core/src/MonthRangePicker/MonthRangePickerGrid.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerGrid.vue
@@ -17,11 +17,6 @@ const readonly = computed(() => rootContext.readonly.value ? true : undefined)
 </script>
 
 <template>
-  <!--
-    role="application" is intentional: it ensures screen readers like NVDA pass
-    keyboard events (arrow keys) to the web app instead of intercepting them
-    for virtual cursor navigation. This is the same pattern used by React Aria.
-  -->
   <Primitive
     v-bind="props"
     tabindex="-1"

--- a/packages/core/src/RangeCalendar/RangeCalendarGrid.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarGrid.vue
@@ -18,11 +18,6 @@ const readonly = computed(() => rootContext.readonly.value ? true : undefined)
 </script>
 
 <template>
-  <!--
-    role="application" is intentional: it ensures screen readers like NVDA pass
-    keyboard events (arrow keys) to the web app instead of intercepting them
-    for virtual cursor navigation. This is the same pattern used by React Aria.
-  -->
   <Primitive
     v-bind="props"
     tabindex="-1"

--- a/packages/core/src/YearPicker/YearPickerGrid.vue
+++ b/packages/core/src/YearPicker/YearPickerGrid.vue
@@ -17,11 +17,6 @@ const readonly = computed(() => rootContext.readonly.value ? true : undefined)
 </script>
 
 <template>
-  <!--
-    role="application" is intentional: it ensures screen readers like NVDA pass
-    keyboard events (arrow keys) to the web app instead of intercepting them
-    for virtual cursor navigation. This is the same pattern used by React Aria.
-  -->
   <Primitive
     v-bind="props"
     tabindex="-1"

--- a/packages/core/src/YearRangePicker/YearRangePickerGrid.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerGrid.vue
@@ -17,11 +17,6 @@ const readonly = computed(() => rootContext.readonly.value ? true : undefined)
 </script>
 
 <template>
-  <!--
-    role="application" is intentional: it ensures screen readers like NVDA pass
-    keyboard events (arrow keys) to the web app instead of intercepting them
-    for virtual cursor navigation. This is the same pattern used by React Aria.
-  -->
   <Primitive
     v-bind="props"
     tabindex="-1"


### PR DESCRIPTION
## Summary
- Fixes #2504
- Removes HTML template comments from all 6 Grid components (`CalendarGrid`, `RangeCalendarGrid`, `MonthPickerGrid`, `YearPickerGrid`, `MonthRangePickerGrid`, `YearRangePickerGrid`)
- The comment node before `<Primitive>` created a fragment (multi-root) component, causing Vue to silently drop `$attrs` (class, style, etc.) in production builds

## Test plan
- [ ] Verify `class` and other attrs are forwarded to the rendered `<table>` element in production mode
- [ ] Verify `role="application"` is still present on the rendered element
- [ ] Test with NVDA to confirm keyboard navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation comments from calendar components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->