### PR TITLE
fix(Splitter): nested px group ignores defaultSize & percentage drift

### DIFF
--- a/packages/core/src/Splitter/Splitter.test.ts
+++ b/packages/core/src/Splitter/Splitter.test.ts
@@ -33,15 +33,16 @@ describe('nested px SplitterGroup layout re-initialization (issue #2509)', () =>
   beforeEach(() => {
     resizeCallbacks.length = 0
     vi.stubGlobal('ResizeObserver', class MockResizeObserver {
+      private callback: ResizeObserverCallback
       constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
         resizeCallbacks.push(callback)
       }
 
       observe() {}
       unobserve() {}
       disconnect() {
-        // remove this instance's callback on disconnect
-        const idx = resizeCallbacks.indexOf(this.constructor as any)
+        const idx = resizeCallbacks.indexOf(this.callback)
         if (idx !== -1)
           resizeCallbacks.splice(idx, 1)
       }

--- a/packages/core/src/Splitter/Splitter.test.ts
+++ b/packages/core/src/Splitter/Splitter.test.ts
@@ -1,7 +1,8 @@
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { nextTick } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
+import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from '.'
 import Splitter from './story/_Splitter.vue'
 
 // Simple a11y test for now
@@ -19,5 +20,101 @@ describe('test splitter functionalities', () => {
         'nested-interactive': { enabled: false },
       },
     })).toHaveNoViolations()
+  })
+})
+
+// Regression test for https://github.com/unovue/reka-ui/issues/2509
+// Bug 1: nested sizeUnit="px" group ignores defaultSize due to a ResizeObserver
+// timing issue where the inner group is measured before the outer group's flex
+// layout completes, producing a near-zero container size at initialization.
+describe('nested px SplitterGroup layout re-initialization (issue #2509)', () => {
+  const resizeCallbacks: ResizeObserverCallback[] = []
+
+  beforeEach(() => {
+    resizeCallbacks.length = 0
+    vi.stubGlobal('ResizeObserver', class MockResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback)
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        // remove this instance's callback on disconnect
+        const idx = resizeCallbacks.indexOf(this.constructor as any)
+        if (idx !== -1)
+          resizeCallbacks.splice(idx, 1)
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  function fireResize(width: number) {
+    resizeCallbacks.forEach(cb =>
+      cb(
+        [{ contentRect: { width, height: 600 } } as ResizeObserverEntry],
+        {} as ResizeObserver,
+      ),
+    )
+  }
+
+  it('should re-initialize layout when container grows from a tiny initial size', async () => {
+    // This component starts with no panels so we can fire a ResizeObserver callback
+    // with a tiny size BEFORE the panels register — replicating the exact timing
+    // that occurs with nested SplitterGroups in a browser.
+    const showPanels = ref(false)
+
+    const TestComponent = defineComponent({
+      components: { SplitterGroup, SplitterPanel, SplitterResizeHandle },
+      setup() {
+        return { showPanels }
+      },
+      template: `
+        <SplitterGroup direction="horizontal">
+          <template v-if="showPanels">
+            <SplitterPanel id="sidebar" size-unit="px" :default-size="200" :min-size="100" />
+            <SplitterResizeHandle />
+            <SplitterPanel id="content" />
+          </template>
+        </SplitterGroup>
+      `,
+    })
+
+    const wrapper = mount(TestComponent)
+    const splitterGroup = wrapper.findComponent(SplitterGroup)
+
+    // Simulate the inner group being measured while the outer group is still
+    // laying out: container reports only 3.45px.
+    fireResize(3.45)
+    await nextTick()
+
+    // Now panels mount — they register with groupSizeInPixels already = 3.45.
+    // The panelDataArrayChanged watcher will initialize a wrong layout.
+    showPanels.value = true
+    await nextTick() // re-render + registerPanel calls
+    await nextTick() // panelDataArrayChanged watcher fires (wrong layout)
+
+    // Outer group finishes layout: container jumps to its real size.
+    fireResize(923)
+    await nextTick() // groupSizeInPixels watcher detects tiny initSize → triggers re-init
+    await nextTick() // panelDataArrayChanged watcher fires with correct 923px size
+
+    // The most recent 'layout' event should contain the sidebar at ~200px
+    // (i.e. 200 / 923 * 100 ≈ 21.67% converted back to px) and the content
+    // panel absorbing the remainder as a percentage.
+    // emitted() wraps each call as [args], so emitted()[n][0] is the layout array.
+    const events = splitterGroup.emitted('layout') as [number[]][]
+    expect(events).not.toBeNull()
+    expect(events!.length).toBeGreaterThan(0)
+
+    const lastLayout = events!.at(-1)[0]
+    // Sidebar panel (px): should be close to its 200px defaultSize
+    expect(lastLayout[0]).toBeCloseTo(200, 0)
+    // Content panel (%): should occupy the bulk of the remaining space
+    expect(lastLayout[1]).toBeGreaterThan(50)
   })
 })

--- a/packages/core/src/Splitter/Splitter.test.ts
+++ b/packages/core/src/Splitter/Splitter.test.ts
@@ -109,10 +109,10 @@ describe('nested px SplitterGroup layout re-initialization (issue #2509)', () =>
     // panel absorbing the remainder as a percentage.
     // emitted() wraps each call as [args], so emitted()[n][0] is the layout array.
     const events = splitterGroup.emitted('layout') as [number[]][]
-    expect(events).not.toBeNull()
+    expect(events).toBeDefined()
     expect(events!.length).toBeGreaterThan(0)
 
-    const lastLayout = events!.at(-1)[0]
+    const lastLayout = events!.at(-1)![0]
     // Sidebar panel (px): should be close to its 200px defaultSize
     expect(lastLayout[0]).toBeCloseTo(200, 0)
     // Content panel (%): should occupy the bulk of the remaining space

--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -121,6 +121,7 @@ const { forwardRef, currentElement: panelGroupElementRef } = useForwardExpose()
 
 const dragState = ref<DragState | null>(null)
 const groupSizeInPixels = ref<number | null>(null)
+const groupSizeAtLastLayoutInit = ref<number | null>(null)
 const layout = ref<number[]>([])
 const panelIdToLastNotifiedSizeMapRef = ref<Record<string, number>>({})
 const panelSizeBeforeCollapseRef = ref<Map<string, number>>(new Map())
@@ -357,6 +358,11 @@ watch(() => eagerValuesRef.value.panelDataArrayChanged, () => {
       panelConstraints,
     })
 
+    // Track the group size used for this initialization.
+    // Used to detect when a nested px group was measured with an unreliable (too small)
+    // container size before the outer group finished layout.
+    groupSizeAtLastLayoutInit.value = getGroupSizeInPixels()
+
     if (!areEqual(prevLayout, nextLayout)) {
       setLayout(nextLayout)
 
@@ -382,6 +388,20 @@ watch(groupSizeInPixels, (nextSize, prevSize) => {
     return
   if (!hasPixelSizedPanel(panelDataArray))
     return
+
+  // Detect if the layout was initialized with an unreliably small container.
+  // This happens with nested SplitterGroups using sizeUnit="px": the inner group's
+  // ResizeObserver fires before the outer group's flex layout completes, giving a
+  // near-zero container size (e.g. 3.45px). When the outer group finishes and the
+  // container grows to its real size (e.g. 923px), we must re-initialize rather
+  // than recalculate (which would "preserve" the garbage pixel sizes from 3.45px).
+  // We guard with initSize < 50 so that legitimately small-but-real containers
+  // (e.g. a sidebar at 60px) are not accidentally re-initialized on normal resizes.
+  const initSize = groupSizeAtLastLayoutInit.value
+  if (initSize != null && initSize > 0 && initSize < 50 && nextSize > initSize * 10) {
+    eagerValuesRef.value.panelDataArrayChanged = true
+    return
+  }
 
   const recalculatedLayout = recalculateLayoutForPixelPanels({
     layout: prevLayout,

--- a/packages/core/src/Splitter/utils/units.test.ts
+++ b/packages/core/src/Splitter/utils/units.test.ts
@@ -175,4 +175,43 @@ describe('recalculateLayoutForPixelPanels', () => {
     // center gets remaining: 60 * (50 / 60) = 50
     expect(result![1]).toBe(50)
   })
+
+  it('should normalize result to exactly 100% when floating-point drift occurs (bug #2509)', () => {
+    // Two all-px panels, 50/50, resizing from 920→921px.
+    // Raw arithmetic: (460/921)*100 ≈ 49.945… per panel → sum ≈ 99.89 ≠ 100.
+    // The fix normalises the output so the sum is always exactly 100.
+    const panels = [
+      createPanelData({ id: 'a', constraints: { sizeUnit: 'px' } }),
+      createPanelData({ id: 'b', constraints: { sizeUnit: 'px' } }),
+    ]
+    const result = recalculateLayoutForPixelPanels({
+      layout: [50, 50],
+      panelDataArray: panels,
+      prevGroupSize: 920,
+      nextGroupSize: 921,
+    })
+    expect(result).not.toBeNull()
+    const total = result!.reduce((sum, v) => sum + v, 0)
+    expect(Math.abs(total - 100)).toBeLessThan(1e-9)
+  })
+
+  it('should normalise when three all-px panels produce fractional remainders', () => {
+    // Three px panels at equal thirds (33.33...%) in a group that resizes.
+    // Floating-point triple-division will not sum to exactly 100.
+    const panels = [
+      createPanelData({ id: 'a', constraints: { sizeUnit: 'px' } }),
+      createPanelData({ id: 'b', constraints: { sizeUnit: 'px' } }),
+      createPanelData({ id: 'c', constraints: { sizeUnit: 'px' } }),
+    ]
+    const oneThird = 100 / 3
+    const result = recalculateLayoutForPixelPanels({
+      layout: [oneThird, oneThird, oneThird],
+      panelDataArray: panels,
+      prevGroupSize: 900,
+      nextGroupSize: 901,
+    })
+    expect(result).not.toBeNull()
+    const total = result!.reduce((sum, v) => sum + v, 0)
+    expect(Math.abs(total - 100)).toBeLessThan(1e-9)
+  })
 })

--- a/packages/core/src/Splitter/utils/units.ts
+++ b/packages/core/src/Splitter/utils/units.ts
@@ -157,5 +157,17 @@ export function recalculateLayoutForPixelPanels({
     nextLayout[index] = prevSize * scaleFactor
   }
 
+  // Normalize to ensure percentages always sum to exactly 100.
+  // Floating-point arithmetic in the px→% conversions above can cause drift
+  // (e.g. 99.89% instead of 100%) that gets persisted to localStorage and
+  // triggers validation warnings on every subsequent page load.
+  const total = nextLayout.reduce((sum, size) => sum + size, 0)
+  if (total > 0 && Math.abs(total - 100) > 1e-9) {
+    const factor = 100 / total
+    for (let index = 0; index < nextLayout.length; index++) {
+      nextLayout[index] = (nextLayout[index] ?? 0) * factor
+    }
+  }
+
   return nextLayout
 }


### PR DESCRIPTION
## Summary

Fixes #2509 — two related bugs with `sizeUnit="px"` panels in nested `SplitterGroup` layouts.

### Bug 1 — Nested px group ignores `defaultSize` (timing issue)

When a `SplitterGroup` with `sizeUnit="px"` panels is nested inside another `SplitterGroup`, the outer group's flex layout hasn't finished when the inner group's `ResizeObserver` first fires. The inner group is measured at a near-zero size (e.g. `3.45px`), panels register against that bogus container size, and the layout is initialised from a percentage derived from `3.45px` rather than from `defaultSize`.

**Fix:** In the `watch(groupSizeInPixels)` handler, detect when the container grows by more than 10× from an initial size under 50px and trigger a layout re-initialisation with the correct container size.

### Bug 2 — Floating-point drift causes layout sum ≠ 100%

When all panels use `sizeUnit="px"` and the group resizes, `recalculateLayoutForPixelPanels` converts each panel's pixel size back to a percentage independently. Floating-point arithmetic means the results rarely sum to exactly 100%, causing cumulative drift.

**Fix:** After recalculating, normalise the array so it always sums to exactly 100%.

## Test plan

- [x] `units.test.ts` — two new cases verify the normalisation fix (2-panel and 3-panel all-px groups, sizes that produce irrational percentages)
- [x] `Splitter.test.ts` — component-level regression: mocks `ResizeObserver` to replay the exact timing (tiny size → panels register → real size fires), asserts sidebar re-initialises to its `200px` `defaultSize`
- [x] All existing Splitter tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed re-initialization of nested Splitter groups so pixel-sized panels layout correctly after container size changes
  * Ensured panel size percentages sum exactly to 100% to eliminate floating-point drift during resizes

* **Tests**
  * Added a regression test covering delayed panel mounting and subsequent resize reflow
  * Added precision tests validating normalization of layout percentages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->