### PR TITLE
fix(useHideOthers): handle browsers without :popover-open support (Safari 18)

### DIFF
--- a/packages/core/src/shared/useHideOthers.ts
+++ b/packages/core/src/shared/useHideOthers.ts
@@ -17,7 +17,13 @@ export function useHideOthers(target: MaybeElementRef) {
     if (import.meta.env.MODE === 'test')
       return
     // Skip if inside a closed native popover
-    if (el && !el.closest('[popover]:not(:popover-open)'))
+    // Use try/catch as `:popover-open` pseudo-class is not supported in all browsers (e.g. Safari 18)
+    let isInsideClosedPopover = false
+    try {
+      isInsideClosedPopover = !!el?.closest('[popover]:not(:popover-open)')
+    }
+    catch {}
+    if (el && !isInsideClosedPopover)
       undo = hideOthers(el)
     else if (undo)
       undo()


### PR DESCRIPTION
## Summary

- Fixes a crash introduced in v2.9.1 where `closest('[popover]:not(:popover-open)')` throws `"The string did not match the expected pattern"` in browsers that don't support the `:popover-open` pseudo-class (e.g. Safari 18)
- Wraps the selector call in a `try/catch` so unsupported browsers fall back gracefully and continue to work normally
- The original behavior from the fix in #2336 is preserved for browsers that do support the selector

Closes #2511

## Test plan

- [ ] Verify dialogs/modals still work correctly in Chrome/Firefox (`:popover-open` supported)
- [ ] Verify dialogs/modals no longer throw in Safari 18 (`:popover-open` unsupported)
- [ ] Verify nested-in-native-popover edge case still works in supported browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced browser compatibility for popover functionality on Safari and other browsers with limited CSS selector support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->