### PR TITLE
fix(SelectItem): export SelectItemEmits type (#2526)

### DIFF
--- a/packages/core/src/Select/index.ts
+++ b/packages/core/src/Select/index.ts
@@ -19,6 +19,7 @@ export {
 export {
   injectSelectItemContext,
   default as SelectItem,
+  type SelectItemEmits,
   type SelectItemProps,
   type SelectEvent as SelectItemSelectEvent,
 } from './SelectItem.vue'


### PR DESCRIPTION
Exported missing SelectItemEmits type from its Vue component for improved type safety and usage consistency.

Fixes Issue https://github.com/unovue/reka-ui/issues/2526


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Exported additional type definitions from the Select component to improve developer experience when working with component APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->