### PR TITLE
fix(tooltip,popover,hovercard): close on scrollable ancestor scroll

### DIFF
--- a/packages/core/src/Dialog/story/DialogWithScrollableTooltip.story.vue
+++ b/packages/core/src/Dialog/story/DialogWithScrollableTooltip.story.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import {
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+} from '..'
+import {
+  TooltipArrow,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+} from '../../Tooltip'
+
+const items = Array.from({ length: 20 }, (_, i) => ({
+  id: i + 1,
+  name: `Item ${i + 1}`,
+  description: `Description for item ${i + 1}`,
+}))
+</script>
+
+<template>
+  <Story
+    title="Dialog/With Scrollable Tooltip"
+    :layout="{ type: 'single', iframe: false }"
+  >
+    <Variant title="closeOnAncestorScroll (default: true)">
+      <div class="flex items-center justify-center p-8">
+        <TooltipProvider>
+          <DialogRoot>
+            <DialogTrigger
+              class="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
+            >
+              Open Dialog
+            </DialogTrigger>
+            <DialogPortal>
+              <DialogOverlay class="bg-blackA9 fixed inset-0" />
+              <DialogContent
+                class="fixed top-[50%] left-[50%] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none"
+              >
+                <div class="flex items-center justify-between border-b border-mauve6 px-6 py-4">
+                  <DialogTitle class="text-mauve12 text-[17px] font-medium">
+                    Scrollable list
+                  </DialogTitle>
+                  <DialogClose
+                    class="text-mauve11 hover:bg-mauve4 inline-flex h-[25px] w-[25px] items-center justify-center rounded-full focus:outline-none"
+                    aria-label="Close"
+                  >
+                    <Icon icon="lucide:x" />
+                  </DialogClose>
+                </div>
+
+                <p class="text-mauve11 px-6 py-2 text-[13px]">
+                  Hover an item to open its tooltip, then scroll — the tooltip will close automatically.
+                </p>
+
+                <div class="max-h-[320px] overflow-y-auto px-6 pb-6">
+                  <ul class="flex flex-col gap-2 pt-2">
+                    <li
+                      v-for="item in items"
+                      :key="item.id"
+                      class="flex items-center justify-between rounded-[4px] border border-mauve6 px-4 py-3"
+                    >
+                      <span class="text-mauve12 text-[14px]">{{ item.name }}</span>
+                      <TooltipRoot>
+                        <TooltipTrigger
+                          class="text-mauve11 hover:bg-mauve4 inline-flex h-[26px] w-[26px] items-center justify-center rounded-full focus:outline-none"
+                          :aria-label="`Info about ${item.name}`"
+                        >
+                          <Icon
+                            icon="lucide:info"
+                            class="h-4 w-4"
+                          />
+                        </TooltipTrigger>
+                        <TooltipPortal>
+                          <TooltipContent
+                            side="left"
+                            :side-offset="8"
+                            class="text-mauve12 select-none rounded-[4px] bg-white px-[12px] py-[8px] text-[13px] leading-normal shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px]"
+                          >
+                            {{ item.description }}
+                            <TooltipArrow class="fill-white" />
+                          </TooltipContent>
+                        </TooltipPortal>
+                      </TooltipRoot>
+                    </li>
+                  </ul>
+                </div>
+              </DialogContent>
+            </DialogPortal>
+          </DialogRoot>
+        </TooltipProvider>
+      </div>
+    </Variant>
+
+    <Variant title="closeOnAncestorScroll: false (stays open on scroll)">
+      <div class="flex items-center justify-center p-8">
+        <TooltipProvider>
+          <DialogRoot>
+            <DialogTrigger
+              class="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
+            >
+              Open Dialog
+            </DialogTrigger>
+            <DialogPortal>
+              <DialogOverlay class="bg-blackA9 fixed inset-0" />
+              <DialogContent
+                class="fixed top-[50%] left-[50%] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none"
+              >
+                <div class="flex items-center justify-between border-b border-mauve6 px-6 py-4">
+                  <DialogTitle class="text-mauve12 text-[17px] font-medium">
+                    Scrollable list
+                  </DialogTitle>
+                  <DialogClose
+                    class="text-mauve11 hover:bg-mauve4 inline-flex h-[25px] w-[25px] items-center justify-center rounded-full focus:outline-none"
+                    aria-label="Close"
+                  >
+                    <Icon icon="lucide:x" />
+                  </DialogClose>
+                </div>
+
+                <p class="text-mauve11 px-6 py-2 text-[13px]">
+                  Hover an item to open its tooltip, then scroll — the tooltip will stay open (legacy behavior).
+                </p>
+
+                <div class="max-h-[320px] overflow-y-auto px-6 pb-6">
+                  <ul class="flex flex-col gap-2 pt-2">
+                    <li
+                      v-for="item in items"
+                      :key="item.id"
+                      class="flex items-center justify-between rounded-[4px] border border-mauve6 px-4 py-3"
+                    >
+                      <span class="text-mauve12 text-[14px]">{{ item.name }}</span>
+                      <TooltipRoot :close-on-ancestor-scroll="false">
+                        <TooltipTrigger
+                          class="text-mauve11 hover:bg-mauve4 inline-flex h-[26px] w-[26px] items-center justify-center rounded-full focus:outline-none"
+                          :aria-label="`Info about ${item.name}`"
+                        >
+                          <Icon
+                            icon="lucide:info"
+                            class="h-4 w-4"
+                          />
+                        </TooltipTrigger>
+                        <TooltipPortal>
+                          <TooltipContent
+                            side="left"
+                            :side-offset="8"
+                            class="text-mauve12 select-none rounded-[4px] bg-white px-[12px] py-[8px] text-[13px] leading-normal shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px]"
+                          >
+                            {{ item.description }}
+                            <TooltipArrow class="fill-white" />
+                          </TooltipContent>
+                        </TooltipPortal>
+                      </TooltipRoot>
+                    </li>
+                  </ul>
+                </div>
+              </DialogContent>
+            </DialogPortal>
+          </DialogRoot>
+        </TooltipProvider>
+      </div>
+    </Variant>
+  </Story>
+</template>

--- a/packages/core/src/HoverCard/HoverCard.test.ts
+++ b/packages/core/src/HoverCard/HoverCard.test.ts
@@ -1,8 +1,15 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
+import { defineComponent, nextTick } from 'vue'
 import { sleep } from '@/test'
+import {
+  HoverCardContent,
+  HoverCardPortal,
+  HoverCardRoot,
+  HoverCardTrigger,
+} from '.'
 import HoverCard from './story/_HoverCard.vue'
 
 describe('given a default HoverCard', () => {
@@ -30,4 +37,107 @@ describe('given a default HoverCard', () => {
   })
 
   // HoverCard mainly depends on Popper, test for Popper is not required here
+})
+
+describe('closeOnAncestorScroll', () => {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  const HoverCardInScrollableContainer = defineComponent({
+    components: { HoverCardRoot, HoverCardTrigger, HoverCardContent, HoverCardPortal },
+    props: {
+      closeOnAncestorScroll: { type: Boolean, default: true },
+      openDelay: { type: Number, default: 0 },
+    },
+    template: `
+      <div id="scrollable-ancestor" style="overflow: auto; height: 200px; width: 200px;">
+        <HoverCardRoot
+          :close-on-ancestor-scroll="closeOnAncestorScroll"
+          :open-delay="openDelay"
+          :close-delay="0"
+        >
+          <HoverCardTrigger as="button">trigger</HoverCardTrigger>
+          <HoverCardPortal>
+            <HoverCardContent>HoverCard text</HoverCardContent>
+          </HoverCardPortal>
+        </HoverCardRoot>
+      </div>
+    `,
+  })
+
+  // jsdom doesn't support PointerEvent, so we use MouseEvent with pointerType
+  function pointerEnter(el: Element) {
+    const event = new MouseEvent('pointerenter', { bubbles: true })
+    Object.defineProperty(event, 'pointerType', { value: 'mouse' })
+    el.dispatchEvent(event)
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    vi.useFakeTimers()
+  })
+
+  afterEach(async () => {
+    await flushPromises()
+    vi.useRealTimers()
+  })
+
+  it('should close the hover card when a scrollable ancestor is scrolled', async () => {
+    const wrapper = mount(HoverCardInScrollableContainer, { attachTo: document.body })
+
+    pointerEnter(wrapper.find('button').element)
+    vi.runAllTimers()
+    await flushPromises()
+    expect(document.body.innerHTML).toContain('HoverCard text')
+
+    document.getElementById('scrollable-ancestor')!.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(document.body.innerHTML).not.toContain('HoverCard text')
+    wrapper.unmount()
+  })
+
+  it('should not close the hover card when closeOnAncestorScroll is false', async () => {
+    const wrapper = mount(HoverCardInScrollableContainer, {
+      attachTo: document.body,
+      props: { closeOnAncestorScroll: false },
+    })
+
+    pointerEnter(wrapper.find('button').element)
+    vi.runAllTimers()
+    await flushPromises()
+    expect(document.body.innerHTML).toContain('HoverCard text')
+
+    document.getElementById('scrollable-ancestor')!.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(document.body.innerHTML).toContain('HoverCard text')
+    wrapper.unmount()
+  })
+
+  it('should cancel a pending open timer when ancestor is scrolled during openDelay', async () => {
+    const wrapper = mount(HoverCardInScrollableContainer, {
+      attachTo: document.body,
+      props: { openDelay: 500 },
+    })
+
+    // Start the open timer — card is still closed
+    pointerEnter(wrapper.find('button').element)
+    await nextTick()
+    expect(document.body.innerHTML).not.toContain('HoverCard text')
+
+    // Scroll before openDelay fires — should cancel the timer
+    document.getElementById('scrollable-ancestor')!.dispatchEvent(new Event('scroll'))
+    await nextTick()
+
+    // Advance past openDelay — card must NOT open because timer was cancelled
+    vi.advanceTimersByTime(600)
+    await nextTick()
+
+    expect(document.body.innerHTML).not.toContain('HoverCard text')
+    wrapper.unmount()
+  })
 })

--- a/packages/core/src/HoverCard/HoverCardRoot.vue
+++ b/packages/core/src/HoverCard/HoverCardRoot.vue
@@ -11,6 +11,11 @@ export interface HoverCardRootProps {
   openDelay?: number
   /** The duration from when the mouse leaves the trigger or content until the hover card closes. */
   closeDelay?: number
+  /**
+   * Whether to close the hover card when a scrollable ancestor is scrolled.
+   * @defaultValue true
+   */
+  closeOnAncestorScroll?: boolean
 }
 export type HoverCardRootEmits = {
   /** Event handler called when the open state of the hover card changes. */
@@ -34,8 +39,9 @@ export const [injectHoverCardRootContext, provideHoverCardRootContext]
 </script>
 
 <script setup lang="ts">
+import { getOverflowAncestors } from '@floating-ui/dom'
 import { useVModel } from '@vueuse/core'
-import { ref, toRefs } from 'vue'
+import { onUnmounted, ref, toRefs, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
 
 const props = withDefaults(defineProps<HoverCardRootProps>(), {
@@ -43,6 +49,7 @@ const props = withDefaults(defineProps<HoverCardRootProps>(), {
   open: undefined,
   openDelay: 700,
   closeDelay: 300,
+  closeOnAncestorScroll: true,
 })
 const emit = defineEmits<HoverCardRootEmits>()
 
@@ -82,6 +89,29 @@ function handleClose() {
 function handleDismiss() {
   open.value = false
 }
+
+let scrollAncestors: (Element | Window | VisualViewport)[] = []
+
+function removeScrollListeners() {
+  scrollAncestors.forEach(a => a.removeEventListener('scroll', handleAncestorScroll))
+  scrollAncestors = []
+}
+
+function handleAncestorScroll() {
+  clearTimeout(openTimerRef.value)
+  clearTimeout(closeTimerRef.value)
+  handleDismiss()
+}
+
+watch([triggerElement, () => props.closeOnAncestorScroll], ([el, closeOnScroll]) => {
+  removeScrollListeners()
+  if (!el || !closeOnScroll)
+    return
+  scrollAncestors = getOverflowAncestors(el as HTMLElement)
+  scrollAncestors.forEach(a => a.addEventListener('scroll', handleAncestorScroll, { passive: true }))
+})
+
+onUnmounted(removeScrollListeners)
 
 provideHoverCardRootContext({
   open,

--- a/packages/core/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/core/src/HoverCard/HoverCardTrigger.vue
@@ -4,6 +4,7 @@ export interface HoverCardTriggerProps extends PopperAnchorProps {}
 
 <script setup lang="ts">
 import type { PopperAnchorProps } from '@/Popper'
+import { onMounted } from 'vue'
 import { PopperAnchor } from '@/Popper'
 import { Primitive } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
@@ -16,7 +17,10 @@ withDefaults(defineProps<HoverCardTriggerProps>(), {
 
 const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
-rootContext.triggerElement = currentElement
+
+onMounted(() => {
+  rootContext.triggerElement.value = currentElement.value
+})
 
 function handleLeave() {
   setTimeout(() => {

--- a/packages/core/src/Popover/PopoverRoot.vue
+++ b/packages/core/src/Popover/PopoverRoot.vue
@@ -17,6 +17,11 @@ export interface PopoverRootProps {
    * @defaultValue false
    */
   modal?: boolean
+  /**
+   * Whether to close the popover when a scrollable ancestor is scrolled.
+   * @defaultValue false
+   */
+  closeOnAncestorScroll?: boolean
 }
 export type PopoverRootEmits = {
   /**
@@ -41,14 +46,16 @@ export const [injectPopoverRootContext, providePopoverRootContext]
 </script>
 
 <script setup lang="ts">
+import { getOverflowAncestors } from '@floating-ui/dom'
 import { useVModel } from '@vueuse/core'
-import { ref, toRefs } from 'vue'
+import { onUnmounted, ref, toRefs, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
 
 const props = withDefaults(defineProps<PopoverRootProps>(), {
   defaultOpen: false,
   open: undefined,
   modal: false,
+  closeOnAncestorScroll: false,
 })
 const emit = defineEmits<PopoverRootEmits>()
 
@@ -70,6 +77,28 @@ const open = useVModel(props, 'open', emit, {
 
 const triggerElement = ref<HTMLElement>()
 const hasCustomAnchor = ref(false)
+
+let scrollAncestors: (Element | Window | VisualViewport)[] = []
+
+function removeScrollListeners() {
+  scrollAncestors.forEach(a => a.removeEventListener('scroll', handleAncestorScroll))
+  scrollAncestors = []
+}
+
+function handleAncestorScroll() {
+  if (open.value)
+    open.value = false
+}
+
+watch([triggerElement, () => props.closeOnAncestorScroll], ([el, closeOnScroll]) => {
+  removeScrollListeners()
+  if (!el || !closeOnScroll)
+    return
+  scrollAncestors = getOverflowAncestors(el as HTMLElement)
+  scrollAncestors.forEach(a => a.addEventListener('scroll', handleAncestorScroll, { passive: true }))
+})
+
+onUnmounted(removeScrollListeners)
 
 providePopoverRootContext({
   contentId: '',

--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -1,9 +1,11 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
+import { defineComponent, nextTick } from 'vue'
+import { TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from '.'
 import Tooltip from './stories/_Tooltip.vue'
-import TooltipProvider from './TooltipProvider.vue'
+import TooltipProviderComponent from './TooltipProvider.vue'
 
 describe('given default Tooltip', () => {
   let wrapper: VueWrapper<InstanceType<typeof Tooltip>>
@@ -73,7 +75,7 @@ describe('given tooltip within TooltipProvider', () => {
   it('should use the provider content values', async () => {
     await wrapper.find('button').trigger('focus')
 
-    const tooltipContentImpl = wrapper.findComponent(TooltipProvider)
+    const tooltipContentImpl = wrapper.findComponent(TooltipProviderComponent)
 
     expect(tooltipContentImpl.props('content')).toBe(undefined)
 
@@ -94,5 +96,187 @@ describe('given tooltip within TooltipProvider', () => {
     })
 
     expect(tooltipContentImpl.html()).toContain('data-side="left"')
+  })
+})
+
+describe('closeOnAncestorScroll', () => {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  const TooltipInScrollableContainer = defineComponent({
+    components: { TooltipProvider, TooltipRoot, TooltipTrigger, TooltipContent, TooltipPortal },
+    props: {
+      closeOnAncestorScroll: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    template: `
+      <TooltipProvider>
+        <div id="scrollable-ancestor" style="overflow: auto; height: 200px; width: 200px;">
+          <TooltipRoot :close-on-ancestor-scroll="closeOnAncestorScroll">
+            <TooltipTrigger>trigger</TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent>Tooltip text</TooltipContent>
+            </TooltipPortal>
+          </TooltipRoot>
+        </div>
+      </TooltipProvider>
+    `,
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('should close the tooltip when a scrollable ancestor is scrolled', async () => {
+    const wrapper = mount(TooltipInScrollableContainer, { attachTo: document.body })
+
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    const scrollable = document.getElementById('scrollable-ancestor')!
+    scrollable.dispatchEvent(new Event('scroll'))
+    // usePresence does `await nextTick()` internally before unmounting,
+    // so flushPromises() is needed to let it complete all async steps
+    await flushPromises()
+
+    expect(document.body.innerHTML).not.toContain('Tooltip text')
+    wrapper.unmount()
+  })
+
+  it('should not close the tooltip when closeOnAncestorScroll is false', async () => {
+    const wrapper = mount(TooltipInScrollableContainer, {
+      attachTo: document.body,
+      props: { closeOnAncestorScroll: false },
+    })
+
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    const scrollable = document.getElementById('scrollable-ancestor')!
+    scrollable.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(document.body.innerHTML).toContain('Tooltip text')
+    wrapper.unmount()
+  })
+
+  it('should not close a closed tooltip when scrolled', async () => {
+    const wrapper = mount(TooltipInScrollableContainer, { attachTo: document.body })
+
+    expect(document.body.innerHTML).not.toContain('Tooltip text')
+
+    const scrollable = document.getElementById('scrollable-ancestor')!
+    scrollable.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(document.body.innerHTML).not.toContain('Tooltip text')
+    wrapper.unmount()
+  })
+
+  it('should remove listeners when closeOnAncestorScroll is toggled false at runtime', async () => {
+    const wrapper = mount(TooltipInScrollableContainer, { attachTo: document.body })
+    await nextTick()
+
+    // Listeners are attached when prop is true (default)
+    const scrollable = document.getElementById('scrollable-ancestor')!
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    scrollable.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+    expect(document.body.innerHTML).not.toContain('Tooltip text')
+
+    // Toggle prop to false — listeners must be removed
+    await wrapper.setProps({ closeOnAncestorScroll: false })
+    await nextTick()
+
+    // Re-open the tooltip
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    // Scroll should no longer close the tooltip
+    scrollable.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    wrapper.unmount()
+  })
+
+  it('should add listeners when closeOnAncestorScroll is toggled true at runtime', async () => {
+    const wrapper = mount(TooltipInScrollableContainer, {
+      attachTo: document.body,
+      props: { closeOnAncestorScroll: false },
+    })
+    await nextTick()
+
+    const scrollable = document.getElementById('scrollable-ancestor')!
+
+    // With prop false — scroll must not close
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    scrollable.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    // Toggle prop to true — listeners must be attached
+    await wrapper.setProps({ closeOnAncestorScroll: true })
+    await nextTick()
+
+    // Re-open and scroll — must close now
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('Tooltip text')
+
+    scrollable.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+    expect(document.body.innerHTML).not.toContain('Tooltip text')
+
+    wrapper.unmount()
+  })
+
+  it('should remove scroll listeners on unmount', async () => {
+    const addElSpy = vi.spyOn(HTMLElement.prototype, 'addEventListener')
+    const removeElSpy = vi.spyOn(HTMLElement.prototype, 'removeEventListener')
+    const addWinSpy = vi.spyOn(Window.prototype, 'addEventListener')
+    const removeWinSpy = vi.spyOn(Window.prototype, 'removeEventListener')
+    const addVvSpy = globalThis.VisualViewport
+      ? vi.spyOn(VisualViewport.prototype, 'addEventListener')
+      : null
+    const removeVvSpy = globalThis.VisualViewport
+      ? vi.spyOn(VisualViewport.prototype, 'removeEventListener')
+      : null
+
+    const countScroll = (spy: ReturnType<typeof vi.spyOn>) =>
+      spy.mock.calls.filter(([event]) => event === 'scroll').length
+
+    const wrapper = mount(TooltipInScrollableContainer, { attachTo: document.body })
+    await nextTick()
+
+    const added
+      = countScroll(addElSpy)
+        + countScroll(addWinSpy)
+        + (addVvSpy ? countScroll(addVvSpy) : 0)
+    expect(added).toBeGreaterThan(0)
+
+    wrapper.unmount()
+    await nextTick()
+
+    const removed
+      = countScroll(removeElSpy)
+        + countScroll(removeWinSpy)
+        + (removeVvSpy ? countScroll(removeVvSpy) : 0)
+    expect(removed).toBe(added)
+
+    addElSpy.mockRestore()
+    removeElSpy.mockRestore()
+    addWinSpy.mockRestore()
+    removeWinSpy.mockRestore()
+    addVvSpy?.mockRestore()
+    removeVvSpy?.mockRestore()
   })
 })

--- a/packages/core/src/Tooltip/TooltipRoot.vue
+++ b/packages/core/src/Tooltip/TooltipRoot.vue
@@ -43,6 +43,11 @@ export interface TooltipRootProps {
    * @defaultValue false
    */
   ignoreNonKeyboardFocus?: boolean
+  /**
+   * Whether to close the tooltip when a scrollable ancestor is scrolled.
+   * @defaultValue true
+   */
+  closeOnAncestorScroll?: boolean
 }
 
 export type TooltipRootEmits = {
@@ -71,8 +76,9 @@ export const [injectTooltipRootContext, provideTooltipRootContext]
 </script>
 
 <script setup lang="ts">
+import { getOverflowAncestors } from '@floating-ui/dom'
 import { useTimeoutFn, useVModel } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
 import { injectTooltipProviderContext } from './TooltipProvider.vue'
 import { TOOLTIP_OPEN } from './utils'
@@ -85,6 +91,7 @@ const props = withDefaults(defineProps<TooltipRootProps>(), {
   disableClosingTrigger: undefined,
   disabled: undefined,
   ignoreNonKeyboardFocus: undefined,
+  closeOnAncestorScroll: true,
 })
 
 const emit = defineEmits<TooltipRootEmits>()
@@ -127,6 +134,28 @@ watch(open, (isOpen) => {
 
 const wasOpenDelayedRef = ref(false)
 const trigger = ref<HTMLElement>()
+
+let scrollAncestors: (Element | Window | VisualViewport)[] = []
+
+function removeScrollListeners() {
+  scrollAncestors.forEach(a => a.removeEventListener('scroll', handleAncestorScroll))
+  scrollAncestors = []
+}
+
+function handleAncestorScroll() {
+  if (open.value)
+    handleClose()
+}
+
+watch([trigger, () => props.closeOnAncestorScroll], ([el, closeOnScroll]) => {
+  removeScrollListeners()
+  if (!el || !closeOnScroll)
+    return
+  scrollAncestors = getOverflowAncestors(el as HTMLElement)
+  scrollAncestors.forEach(a => a.addEventListener('scroll', handleAncestorScroll, { passive: true }))
+})
+
+onUnmounted(removeScrollListeners)
 
 const stateAttribute = computed(() => {
   if (!open.value)

--- a/packages/core/src/Tooltip/stories/Tooltip.story.vue
+++ b/packages/core/src/Tooltip/stories/Tooltip.story.vue
@@ -5,6 +5,11 @@ import { TooltipArrow, TooltipContent, TooltipPortal, TooltipProvider, TooltipRo
 
 const toggleState = ref(false)
 const disableTooltip = ref(false)
+
+const scrollItems = Array.from({ length: 12 }, (_, i) => ({
+  id: i + 1,
+  label: `Button ${i + 1}`,
+}))
 </script>
 
 <template>
@@ -54,6 +59,85 @@ const disableTooltip = ref(false)
             </TooltipPortal>
           </TooltipRoot>
         </TooltipProvider>
+      </div>
+    </Variant>
+
+    <Variant title="closeOnAncestorScroll">
+      <div class="flex flex-col gap-6 p-8">
+        <div>
+          <p class="text-mauve11 mb-1 text-[13px] font-medium">
+            closeOnAncestorScroll: true (default)
+          </p>
+          <p class="text-mauve10 mb-3 text-[12px]">
+            Hover a button, then scroll horizontally — tooltip closes.
+          </p>
+          <div class="overflow-x-auto rounded-[6px] border border-mauve6 bg-mauve2 p-4">
+            <div
+              class="flex gap-3"
+              style="width: max-content"
+            >
+              <TooltipProvider>
+                <TooltipRoot
+                  v-for="item in scrollItems"
+                  :key="item.id"
+                >
+                  <TooltipTrigger
+                    class="text-violet11 shadow-blackA4 hover:bg-violet3 inline-flex h-[35px] w-[35px] shrink-0 items-center justify-center rounded-full bg-white shadow-[0_2px_6px] outline-none focus:shadow-[0_0_0_2px] focus:shadow-black"
+                  >
+                    <Icon icon="radix-icons:plus" />
+                  </TooltipTrigger>
+                  <TooltipPortal>
+                    <TooltipContent
+                      :side-offset="8"
+                      class="text-violet11 select-none rounded-[4px] bg-white px-[12px] py-[8px] text-[13px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px]"
+                    >
+                      {{ item.label }}
+                      <TooltipArrow class="fill-white" />
+                    </TooltipContent>
+                  </TooltipPortal>
+                </TooltipRoot>
+              </TooltipProvider>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <p class="text-mauve11 mb-1 text-[13px] font-medium">
+            closeOnAncestorScroll: false
+          </p>
+          <p class="text-mauve10 mb-3 text-[12px]">
+            Hover a button, then scroll horizontally — tooltip stays open.
+          </p>
+          <div class="overflow-x-auto rounded-[6px] border border-mauve6 bg-mauve2 p-4">
+            <div
+              class="flex gap-3"
+              style="width: max-content"
+            >
+              <TooltipProvider>
+                <TooltipRoot
+                  v-for="item in scrollItems"
+                  :key="item.id"
+                  :close-on-ancestor-scroll="false"
+                >
+                  <TooltipTrigger
+                    class="text-violet11 shadow-blackA4 hover:bg-violet3 inline-flex h-[35px] w-[35px] shrink-0 items-center justify-center rounded-full bg-white shadow-[0_2px_6px] outline-none focus:shadow-[0_0_0_2px] focus:shadow-black"
+                  >
+                    <Icon icon="radix-icons:plus" />
+                  </TooltipTrigger>
+                  <TooltipPortal>
+                    <TooltipContent
+                      :side-offset="8"
+                      class="text-violet11 select-none rounded-[4px] bg-white px-[12px] py-[8px] text-[13px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px]"
+                    >
+                      {{ item.label }}
+                      <TooltipArrow class="fill-white" />
+                    </TooltipContent>
+                  </TooltipPortal>
+                </TooltipRoot>
+              </TooltipProvider>
+            </div>
+          </div>
+        </div>
       </div>
     </Variant>
   </Story>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->
<!-- fix(tooltip,popover,hovercard): close on scrollable ancestor scroll -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Resolves [#2543]

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`TooltipRoot`, `HoverCardRoot`, and `PopoverRoot` did not close their floating content
when a scrollable ancestor container was scrolled. The tooltip/card would stay open and
visually float at its original position, detached from the trigger element.

**Root cause:** two browser mechanics combine to produce the bug:
1. The browser does not fire `pointerleave` when the *element* moves out from under the
   cursor due to scroll — only when the *pointer* moves.
2. `TooltipPortal` renders into `document.body` via `<Teleport>`, so scroll events from
   the ancestor container never reach it.

**Fix:** added a `closeOnAncestorScroll` prop to all three components. When enabled, the
component subscribes to `scroll` events on every overflow ancestor of the trigger element
(found via `getOverflowAncestors` from `@floating-ui/dom`, which is already a direct
dependency) and closes the floating element when any of them fires.

| Component | Default |
|---|---|
| `TooltipRoot` | `true` — tooltip is hover-only, closing on scroll matches user expectation |
| `HoverCardRoot` | `true` — same reasoning as Tooltip |
| `PopoverRoot` | `false` — popover is opened by click and often contains interactive content; unexpected scroll-close would be destructive |

Also fixed `HoverCardTrigger` which was replacing the entire `triggerElement` ref object
in context (`rootContext.triggerElement = currentElement`) instead of setting its value
(`rootContext.triggerElement.value = ...`), which prevented the `watch` in `HoverCardRoot`
from reacting to the trigger being mounted.

### 📸 Screenshots (if appropriate)

<!-- StackBlitz demo link -->

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltip, HoverCard, and Popover gain a closeOnAncestorScroll option to control dismiss-on-scroll (Tooltip/HoverCard default on, Popover default off).
  * Added a dialog example demonstrating scrollable items each with tooltips that can remain open while scrolling.

* **Tests**
  * Added test suites validating open/close behavior, runtime prop toggling, and listener cleanup when ancestor scrolling occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->