### PR TITLE
fix(FocusScope): don't move focus if DOM mutation occurred before any nodes had focus

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -1,8 +1,8 @@
 import type { RenderResult } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { render, waitFor } from '@testing-library/vue'
+import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import { FocusScope } from '.'
 import { DialogContent, DialogRoot, DialogTitle, DialogTrigger } from '../Dialog'
 import { SelectContent, SelectItem, SelectRoot, SelectTrigger, SelectValue } from '../Select'
@@ -61,19 +61,20 @@ describe('focusScope', () => {
     it('should focus the last element in the scope on shift+tab from the first element in scope', async () => {
       tabbableFirst.focus()
       await userEvent.tab({ shift: true })
-      await waitFor(() => expect(tabbableLast).toBe(document.activeElement))
+      expect(tabbableLast).toHaveFocus()
     })
 
     it('should focus the first element in scope on tab from the last element in scope', async () => {
       tabbableLast.focus()
       await userEvent.tab()
-      expect(tabbableFirst).toBe(document.activeElement)
+      expect(tabbableFirst).toHaveFocus()
     })
 
     it('should focus container when focused element is removed from the DOM', async () => {
       tabbableFirst.focus()
       tabbableFirst.remove()
-      await waitFor(() => expect(focusContainer).toHaveFocus())
+      await nextTick()
+      expect(focusContainer).toHaveFocus()
     })
   })
 
@@ -104,13 +105,13 @@ describe('focusScope', () => {
     it('should skip the element with a negative tabindex on tab', async () => {
       tabbableLast.focus()
       await userEvent.tab()
-      expect(tabbableSecond).toBe(document.activeElement)
+      expect(tabbableSecond).toHaveFocus()
     })
 
     it('should skip the element with a negative tabindex on shift+tab', async () => {
       tabbableSecond.focus()
       await userEvent.tab({ shift: true })
-      await waitFor(() => expect(tabbableLast).toBe(document.activeElement))
+      expect(tabbableLast).toHaveFocus()
     })
   })
 
@@ -142,7 +143,7 @@ describe('focusScope', () => {
       tabbableFirst.focus()
       await userEvent.tab({ shift: true })
       await userEvent.tab()
-      await waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
+      expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -4,6 +4,8 @@ import { render, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { FocusScope } from '.'
+import { DialogContent, DialogRoot, DialogTitle, DialogTrigger } from '../Dialog'
+import { SelectContent, SelectItem, SelectRoot, SelectTrigger, SelectValue } from '../Select'
 
 const INNER_NAME_INPUT_LABEL = 'Name'
 const INNER_EMAIL_INPUT_LABEL = 'Email'
@@ -141,6 +143,47 @@ describe('focusScope', () => {
       await userEvent.tab({ shift: true })
       await userEvent.tab()
       await waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
+    })
+  })
+
+  // https://github.com/unovue/reka-ui/issues/2550
+  describe('given a FocusScope with SelectTrigger inside Dialog (#2550)', () => {
+    const DialogWithSelect = defineComponent({
+      components: { DialogRoot, DialogTrigger, DialogContent, DialogTitle, SelectRoot, SelectTrigger, SelectValue, SelectContent, SelectItem },
+      template: `
+        <DialogRoot>
+          <DialogTrigger>Open</DialogTrigger>
+          <DialogContent>
+            <DialogTitle>Test Dialog</DialogTitle>
+            <input data-testid="email-input" type="text" placeholder="you@example.com" />
+            <SelectRoot>
+              <SelectTrigger>
+                <SelectValue placeholder="Select" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="a">Option A</SelectItem>
+                <SelectItem value="b">Option B</SelectItem>
+              </SelectContent>
+            </SelectRoot>
+          </DialogContent>
+        </DialogRoot>
+      `,
+    })
+
+    it('should auto-focus the first tabbable element when SelectTrigger is present', async () => {
+      const rendered = render(DialogWithSelect)
+
+      const trigger = rendered.getByRole('button', { name: 'Open' })
+      await userEvent.click(trigger)
+
+      const input1 = rendered.getByTestId('email-input')
+      expect(input1).toHaveFocus()
+
+      // close and reopen, and ensure the input is focused again, not the SelectTrigger
+      await userEvent.keyboard('{Escape}')
+      await userEvent.click(trigger)
+      const inputReopen = rendered.getByTestId('email-input')
+      expect(inputReopen).toHaveFocus()
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -24,6 +24,7 @@ const TestField = ({
 describe('focusScope', () => {
   describe('given a default FocusScope', () => {
     let rendered: RenderResult
+    let focusContainer: HTMLElement
     let tabbableFirst: HTMLInputElement
     let tabbableSecond: HTMLInputElement
     let tabbableLast: HTMLButtonElement
@@ -33,7 +34,7 @@ describe('focusScope', () => {
         components: { TestField, FocusScope },
         template: `<div>
         <FocusScope asChild loop trapped>
-          <form>
+          <form data-testid="focus-scope">
             <TestField label=${INNER_NAME_INPUT_LABEL} />
             <TestField label=${INNER_EMAIL_INPUT_LABEL} />
             <button>${INNER_SUBMIT_LABEL}</button>
@@ -43,6 +44,7 @@ describe('focusScope', () => {
         <button>some outer button</button>
       </div>`,
       }))
+      focusContainer = rendered.getByTestId('focus-scope') as HTMLElement
       tabbableFirst = rendered.getByLabelText(INNER_NAME_INPUT_LABEL) as HTMLInputElement
       tabbableSecond = rendered.getByLabelText(INNER_EMAIL_INPUT_LABEL) as HTMLInputElement
       tabbableLast = rendered.getByText(INNER_SUBMIT_LABEL) as HTMLButtonElement
@@ -57,13 +59,19 @@ describe('focusScope', () => {
     it('should focus the last element in the scope on shift+tab from the first element in scope', async () => {
       tabbableFirst.focus()
       await userEvent.tab({ shift: true })
-      waitFor(() => expect(tabbableLast).toBe(document.activeElement))
+      await waitFor(() => expect(tabbableLast).toBe(document.activeElement))
     })
 
     it('should focus the first element in scope on tab from the last element in scope', async () => {
       tabbableLast.focus()
       await userEvent.tab()
       expect(tabbableFirst).toBe(document.activeElement)
+    })
+
+    it('should focus container when focused element is removed from the DOM', async () => {
+      tabbableFirst.focus()
+      tabbableFirst.remove()
+      await waitFor(() => expect(focusContainer).toHaveFocus())
     })
   })
 
@@ -100,7 +108,7 @@ describe('focusScope', () => {
     it('should skip the element with a negative tabindex on shift+tab', async () => {
       tabbableSecond.focus()
       await userEvent.tab({ shift: true })
-      waitFor(() => expect(tabbableLast).toBe(document.activeElement))
+      await waitFor(() => expect(tabbableLast).toBe(document.activeElement))
     })
   })
 
@@ -111,7 +119,9 @@ describe('focusScope', () => {
     beforeEach(() => {
       rendered = render(defineComponent({
         components: { TestField, FocusScope },
-        props: { handleLastFocusableElementBlur },
+        setup() {
+          return { handleLastFocusableElementBlur }
+        },
         template: `<div>
         <FocusScope asChild loop trapped>
           <form>
@@ -130,7 +140,7 @@ describe('focusScope', () => {
       tabbableFirst.focus()
       await userEvent.tab({ shift: true })
       await userEvent.tab()
-      waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
+      await waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -117,7 +117,21 @@ watchEffect((cleanupFn) => {
   // if the element still exist inside the container,
   // if not then we focus to the container
   function handleMutations(mutations: MutationRecord[]) {
-    const isLastFocusedElementExist = container.contains(lastFocusedElementRef.value)
+    const lastFocusedElement = lastFocusedElementRef.value
+
+    // Mutation may be triggered by something unrelated to focus, e.g. class is set on an element
+    // so we first check if we even have a previously focused element.
+    if (lastFocusedElement === null) {
+      return
+    }
+
+    // Ensure mutations removed nodes from the DOM at all.
+    const anyNodesRemoved = mutations.some(m => m.removedNodes.length > 0)
+    if (!anyNodesRemoved) {
+      return
+    }
+
+    const isLastFocusedElementExist = container.contains(lastFocusedElement)
     if (!isLastFocusedElementExist)
       focus(container)
   }


### PR DESCRIPTION
DOM mutation may be triggered by something unrelated to focus, e.g. class changed on an element, so first check if we even have a previously focused element. Also ensure that captured DOM mutations even have removed nodes before restoring focus.

Add test to ensure focus is restored to container on node removal.<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
resolves #2506 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Did some debugging locally with 1Password extension enabled and noticed that MutationObserver callback might be called even before first element is focused and `lastFocusedElementRef` is updated. For example, `iconify` sets class on SVGs. In this case `lastFocusedElementRef` is still `null` and `container.contains` check returns false and focus is move to container.

Additionally updated FocusScope tests as these didn't properly await `waitFor` results and thus didn't even verify expected results. 

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

Here's with 1Password extension enabled and mentioned fix. First tabbable element focused correctly each time the dialog is opened.

https://github.com/user-attachments/assets/1d7c217c-275f-4ee1-873f-ac7c8f5d61e9

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling so containers reliably receive and retain focus when previously focused elements are removed; avoids errors when there was no prior focus and skips adjustments if no DOM removals occur.

* **Tests**
  * Added regression test for dialogs to autofocus the first tabbable field when opened with a dropdown trigger present.
  * Simplified and hardened focus assertions and added a test for removed-focused-element behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->