### PR TITLE
fix(FocusScope): prevent focus handling when no last focused element

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -1,9 +1,12 @@
 import type { RenderResult } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { render, waitFor } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
 import { FocusScope } from '.'
+import { DialogContent, DialogRoot, DialogTitle, DialogTrigger } from '../Dialog'
+import { SelectContent, SelectItem, SelectRoot, SelectTrigger, SelectValue } from '../Select'
 
 const INNER_NAME_INPUT_LABEL = 'Name'
 const INNER_EMAIL_INPUT_LABEL = 'Email'
@@ -131,6 +134,53 @@ describe('focusScope', () => {
       await userEvent.tab({ shift: true })
       await userEvent.tab()
       waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1))
+    })
+  })
+
+  // https://github.com/unovue/reka-ui/issues/2550
+  describe('given a FocusScope with SelectTrigger inside Dialog (#2550)', () => {
+    beforeAll(() => {
+      window.HTMLElement.prototype.releasePointerCapture = vi.fn()
+      window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+      globalThis.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    })
+
+    const DialogWithSelect = defineComponent({
+      components: { DialogRoot, DialogTrigger, DialogContent, DialogTitle, SelectRoot, SelectTrigger, SelectValue, SelectContent, SelectItem },
+      template: `
+        <DialogRoot>
+          <DialogTrigger>Open</DialogTrigger>
+          <DialogContent>
+            <DialogTitle>Test Dialog</DialogTitle>
+            <input data-testid="email-input" type="text" placeholder="you@example.com" />
+            <SelectRoot>
+              <SelectTrigger>
+                <SelectValue placeholder="Select" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="a">Option A</SelectItem>
+                <SelectItem value="b">Option B</SelectItem>
+              </SelectContent>
+            </SelectRoot>
+          </DialogContent>
+        </DialogRoot>
+      `,
+    })
+
+    it('should auto-focus the first tabbable element when SelectTrigger is present', async () => {
+      document.body.innerHTML = ''
+      const wrapper = mount(DialogWithSelect, { attachTo: document.body })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const input = document.querySelector('[data-testid="email-input"]') as HTMLInputElement
+      expect(input).toBeTruthy()
+      expect(document.activeElement).toBe(input)
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -117,6 +117,8 @@ watchEffect((cleanupFn) => {
   // if the element still exist inside the container,
   // if not then we focus to the container
   function handleMutations(mutations: MutationRecord[]) {
+    if (!lastFocusedElementRef.value)
+      return
     const isLastFocusedElementExist = container.contains(lastFocusedElementRef.value)
     if (!isLastFocusedElementExist)
       focus(container)


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

resolves https://github.com/unovue/reka-ui/issues/2550

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus-management guard to avoid attempting container focus when no prior focused element exists, making focus behavior more reliable.

* **Tests**
  * Added mount-based test coverage verifying autofocus of the first tabbable element within a dialog when a select trigger is present; stabilized related test environment behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->