### PR TITLE
fix(tooltip,hovercard): close when scrollable ancestor is scrolled

### DIFF
--- a/packages/core/src/HoverCard/HoverCardContentImpl.vue
+++ b/packages/core/src/HoverCard/HoverCardContentImpl.vue
@@ -9,6 +9,7 @@ export interface HoverCardContentImplProps extends PopperContentProps {}
 </script>
 
 <script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
 import { nextTick, onMounted, onUnmounted, ref, watchEffect } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { PopperContent } from '@/Popper'
@@ -68,6 +69,12 @@ onMounted(() => {
     const tabbables = getTabbableNodes(contentElement.value)
     tabbables.forEach(tabbable => tabbable.setAttribute('tabindex', '-1'))
   }
+
+  useEventListener(window, 'scroll', (event: Event) => {
+    const target = event.target as HTMLElement
+    if (target?.contains(rootContext.triggerElement.value!))
+      rootContext.onDismiss()
+  }, { capture: true })
 })
 
 onUnmounted(() => {

--- a/packages/core/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/core/src/Tooltip/TooltipContentImpl.vue
@@ -85,7 +85,7 @@ onMounted(() => {
     const target = event.target as HTMLElement
     if (target?.contains(rootContext.trigger.value!))
       rootContext.onClose()
-  })
+  }, { capture: true })
   // Close this tooltip if another one opens
   useEventListener(window, TOOLTIP_OPEN, rootContext.onClose)
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2543

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`TooltipContent` and `HoverCardContent` did not close when a scrollable **ancestor container** was scrolled — the floating element would stay open and appear visually detached from its trigger.

**Root cause:** `scroll` events do not bubble. A listener on `window` without `{ capture: true }` only fires for page-level scroll (`window`/`document`), never for scrolls inside overflow containers.

**Tooltip** already had a window scroll listener with the right logic (`target.contains(trigger)`) — it just needed `{ capture: true }` to intercept scrolls from inner containers.

**HoverCard** had no scroll handler at all — added the same pattern.

**Changes:**

- `TooltipContentImpl.vue` — add `{ capture: true }` to the existing `useEventListener` scroll call (one-character change)
- `HoverCardContentImpl.vue` — add `useEventListener(window, 'scroll', ..., { capture: true })` calling `onDismiss()` when the scrolled element contains the trigger

No new props, no new API surface, no dependency on `getOverflowAncestors`. The `capture` phase approach catches scroll from any ancestor container without needing to enumerate them.

### 📝 Checklist

- [x] I have linked an issue or discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HoverCards now automatically dismiss when scrolling occurs within the trigger area

* **Bug Fixes**
  * Improved Tooltip scroll event detection for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->