### PR TITLE
fix(Listbox): restore highlightOnHover behavior

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ export default antfu(
       'vue/one-component-per-file': 'off',
       'unicorn/prefer-dom-node-text-content': 'off',
       'unicorn/prefer-number-properties': 'off',
+      'unicorn/prefer-at': 'off',
       'unused-imports/no-unused-vars': 'off',
       'regexp/no-super-linear-backtracking': 'off',
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ export default antfu(
       'unicorn/prefer-dom-node-text-content': 'off',
       'unicorn/prefer-number-properties': 'off',
       'unicorn/prefer-at': 'off',
+      'e18e/prefer-array-at': 'off',
       'unused-imports/no-unused-vars': 'off',
       'regexp/no-super-linear-backtracking': 'off',
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,8 +36,6 @@ export default antfu(
       'vue/one-component-per-file': 'off',
       'unicorn/prefer-dom-node-text-content': 'off',
       'unicorn/prefer-number-properties': 'off',
-      'unicorn/prefer-at': 'off',
-      'e18e/prefer-array-at': 'off',
       'unused-imports/no-unused-vars': 'off',
       'regexp/no-super-linear-backtracking': 'off',
     },

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -92,8 +92,8 @@ provideListboxItemContext({
         if (rootContext.highlightedElement.value === currentElement)
           return
 
-        if (rootContext.highlightOnHover.value && !rootContext.focusable.value)
-          rootContext.changeHighlight(currentElement, false)
+        if (rootContext.highlightOnHover.value)
+          rootContext.changeHighlight(currentElement, false, false)
       }"
     >
       <slot />

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -211,7 +211,7 @@ function onKeydownTypeAhead(event: KeyboardEvent) {
       const values = collection.map(i => i.value)
       modelValue.value = [...values]
       event.preventDefault()
-      const lastItem = collection[collection.length - 1]
+      const lastItem = collection.at(-1)
       if (lastItem)
         changeHighlight(lastItem.ref)
     }
@@ -311,7 +311,7 @@ function handleMultipleReplace(event: KeyboardEvent, targetEl: HTMLElement) {
     let lastValue = collection.find(i => i.ref === targetEl)?.value
 
     if (event.key === kbd.END)
-      lastValue = collection[collection.length - 1]?.value
+      lastValue = collection.at(-1)?.value
     else if (event.key === kbd.HOME)
       lastValue = collection[0].value
 

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -27,7 +27,7 @@ type ListboxRootContext<T> = {
 
   onLeave: (event: Event) => void
   onEnter: (event: Event) => void
-  changeHighlight: (el: HTMLElement, scrollIntoView?: boolean) => void
+  changeHighlight: (el: HTMLElement, scrollIntoView?: boolean, focus?: boolean) => void
   onKeydownNavigation: (event: KeyboardEvent) => void
   onKeydownEnter: (event: KeyboardEvent) => void
   onKeydownTypeAhead: (event: KeyboardEvent) => void
@@ -157,12 +157,12 @@ function getCollectionItem() {
   return getItems().map(i => i.ref).filter(i => i.dataset.disabled !== '')
 }
 
-function changeHighlight(el: HTMLElement, scrollIntoView = true) {
+function changeHighlight(el: HTMLElement, scrollIntoView = true, focus = focusable.value) {
   if (!el)
     return
 
   highlightedElement.value = el
-  if (focusable.value)
+  if (focus)
     highlightedElement.value.focus()
   if (scrollIntoView)
     highlightedElement.value.scrollIntoView({ block: 'nearest' })
@@ -211,7 +211,7 @@ function onKeydownTypeAhead(event: KeyboardEvent) {
       const values = collection.map(i => i.value)
       modelValue.value = [...values]
       event.preventDefault()
-      changeHighlight(collection[collection.length - 1].ref)
+      changeHighlight(collection.at(-1).ref)
     }
     else if (!isMetaKey) {
       const el = handleTypeaheadSearch(event.key, getItems())
@@ -309,7 +309,7 @@ function handleMultipleReplace(event: KeyboardEvent, targetEl: HTMLElement) {
     let lastValue = collection.find(i => i.ref === targetEl)?.value
 
     if (event.key === kbd.END)
-      lastValue = collection[collection.length - 1].value
+      lastValue = collection.at(-1).value
     else if (event.key === kbd.HOME)
       lastValue = collection[0].value
 

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -157,12 +157,12 @@ function getCollectionItem() {
   return getItems().map(i => i.ref).filter(i => i.dataset.disabled !== '')
 }
 
-function changeHighlight(el: HTMLElement, scrollIntoView = true, focus = focusable.value) {
+function changeHighlight(el: HTMLElement, scrollIntoView = true, focus?: boolean) {
   if (!el)
     return
 
   highlightedElement.value = el
-  if (focus)
+  if (focus ?? focusable.value)
     highlightedElement.value.focus()
   if (scrollIntoView)
     highlightedElement.value.scrollIntoView({ block: 'nearest' })

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -211,7 +211,9 @@ function onKeydownTypeAhead(event: KeyboardEvent) {
       const values = collection.map(i => i.value)
       modelValue.value = [...values]
       event.preventDefault()
-      changeHighlight(collection.at(-1).ref)
+      const lastItem = collection.at(-1)
+      if (lastItem)
+        changeHighlight(lastItem.ref)
     }
     else if (!isMetaKey) {
       const el = handleTypeaheadSearch(event.key, getItems())
@@ -309,7 +311,7 @@ function handleMultipleReplace(event: KeyboardEvent, targetEl: HTMLElement) {
     let lastValue = collection.find(i => i.ref === targetEl)?.value
 
     if (event.key === kbd.END)
-      lastValue = collection.at(-1).value
+      lastValue = collection.at(-1)?.value
     else if (event.key === kbd.HOME)
       lastValue = collection[0].value
 

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -211,7 +211,7 @@ function onKeydownTypeAhead(event: KeyboardEvent) {
       const values = collection.map(i => i.value)
       modelValue.value = [...values]
       event.preventDefault()
-      const lastItem = collection.at(-1)
+      const lastItem = collection[collection.length - 1]
       if (lastItem)
         changeHighlight(lastItem.ref)
     }
@@ -311,7 +311,7 @@ function handleMultipleReplace(event: KeyboardEvent, targetEl: HTMLElement) {
     let lastValue = collection.find(i => i.ref === targetEl)?.value
 
     if (event.key === kbd.END)
-      lastValue = collection.at(-1)?.value
+      lastValue = collection[collection.length - 1]?.value
     else if (event.key === kbd.HOME)
       lastValue = collection[0].value
 

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -313,7 +313,7 @@ function handleMultipleReplace(event: KeyboardEvent, targetEl: HTMLElement) {
     if (event.key === kbd.END)
       lastValue = collection.at(-1)?.value
     else if (event.key === kbd.HOME)
-      lastValue = collection[0].value
+      lastValue = collection[0]?.value
 
     if (!lastValue || !firstValue.value)
       return


### PR DESCRIPTION
## Summary

- Fixes `highlightOnHover` being completely non-functional in `Listbox` since v2.6.0
- The `pointermove` handler in `ListboxItem` gated highlighting on `!rootContext.focusable.value`, but `focusable` is always `true` — so the condition was never satisfied
- Adds an optional `focus` parameter to `changeHighlight` and passes `false` on hover, so the highlight updates visually without stealing DOM focus (preserving Combobox input focus as well)

## Root cause

PR #2219 added `&& !rootContext.focusable.value` to prevent focus from being stolen from the Combobox input on pointer hover. However, `focusable` is initialized as `ref(true)` in `ListboxRoot` and is never changed, making the guard always `false` and disabling `highlightOnHover` entirely.

## Test plan

- [ ] Open a `Listbox` with `highlightOnHover` enabled — hovering items should now visually highlight them
- [ ] Open a `Combobox` — typing in the input while hovering over dropdown items should not steal focus from the input
- [ ] Keyboard navigation still moves focus to highlighted items as expected

Closes #2556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listbox highlight behavior during pointer interactions to properly respond to hover states.
  * Enhanced multi-selection keyboard shortcut handling to safely manage edge cases with empty collections.
  * Fixed keyboard navigation behavior when using Shift+End to prevent potential errors on empty listboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->