### PR TITLE
fix(ColorField): forward custom attributes in ColorFieldRoot

### DIFF
--- a/packages/core/src/ColorArea/ColorAreaRoot.vue
+++ b/packages/core/src/ColorArea/ColorAreaRoot.vue
@@ -66,10 +66,6 @@ import {
 } from '@/shared/color'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
 
-defineOptions({
-  inheritAttrs: false,
-})
-
 const props = withDefaults(defineProps<ColorAreaRootProps>(), {
   colorSpace: 'hsl',
   xChannel: 'hue',
@@ -228,7 +224,6 @@ provideColorAreaRootContext({
 
 <template>
   <Primitive
-    v-bind="$attrs"
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"

--- a/packages/core/src/ColorArea/ColorAreaRoot.vue
+++ b/packages/core/src/ColorArea/ColorAreaRoot.vue
@@ -228,6 +228,7 @@ provideColorAreaRootContext({
 
 <template>
   <Primitive
+    v-bind="$attrs"
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"

--- a/packages/core/src/ColorField/ColorFieldRoot.vue
+++ b/packages/core/src/ColorField/ColorFieldRoot.vue
@@ -73,10 +73,6 @@ import {
 } from '@/shared/color'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
 
-defineOptions({
-  inheritAttrs: false,
-})
-
 const props = withDefaults(defineProps<ColorFieldRootProps>(), {
   colorSpace: 'hsl',
   disabled: false,
@@ -305,7 +301,6 @@ provideColorFieldRootContext({
 
 <template>
   <Primitive
-    v-bind="$attrs"
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"

--- a/packages/core/src/ColorField/ColorFieldRoot.vue
+++ b/packages/core/src/ColorField/ColorFieldRoot.vue
@@ -305,6 +305,7 @@ provideColorFieldRootContext({
 
 <template>
   <Primitive
+    v-bind="$attrs"
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"


### PR DESCRIPTION
## Summary

Both `ColorFieldRoot` and `ColorAreaRoot` had `inheritAttrs: false` set unnecessarily. Since both components have a single root element (`Primitive`), Vue automatically forwards attributes to it — the explicit `inheritAttrs: false` was blocking this default behavior, causing custom attributes (e.g. \`data-*\`) to be dropped from the rendered DOM.

Fix: remove \`defineOptions({ inheritAttrs: false })\` from both components.

Fixes #2545

## Test plan

- [ ] Add a \`ColorFieldRoot\` with custom \`data-*\` attributes and verify they appear on the rendered DOM element
- [ ] Add a \`ColorAreaRoot\` with custom \`data-*\` attributes and verify they appear on the rendered DOM element
- [ ] Verify \`role="group"\` and other existing attributes still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ColorArea and ColorField components now properly inherit HTML attributes to their root elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->