### PR TITLE
fix(useForwardProps): return Partial<T> to correctly type optional boolean props

### DIFF
--- a/packages/core/src/shared/useForwardProps.ts
+++ b/packages/core/src/shared/useForwardProps.ts
@@ -8,6 +8,17 @@ interface PropOptions {
 }
 
 /**
+ * Vue coerces optional boolean props (e.g. `foo?: boolean`) to non-optional (`foo: boolean`)
+ * in the `defineProps` return type. Since `useForwardProps` only returns props that were
+ * explicitly assigned, boolean-typed props should remain optional in the return type.
+ */
+type WithOptionalBooleans<T> = {
+  [K in keyof T as [T[K]] extends [boolean] ? K : never]?: T[K]
+} & {
+  [K in keyof T as [T[K]] extends [boolean] ? never : K]: T[K]
+}
+
+/**
  * The `useForwardProps` function in TypeScript takes in a set of props and returns a computed value
  * that combines default props with assigned props from the current instance.
  * @param {T} props - The `props` parameter is an object that represents the props passed to a
@@ -36,8 +47,8 @@ export function useForwardProps<T extends Record<string, any>>(props: MaybeRefOr
     // Only return value from the props parameter
     return Object.keys({ ...defaultProps, ...preservedProps }).reduce((prev, curr) => {
       if (refProps.value[curr] !== undefined)
-        prev[curr as keyof T] = refProps.value[curr]
+        (prev as Record<string, any>)[curr] = refProps.value[curr]
       return prev
-    }, {} as Partial<T>)
+    }, {} as WithOptionalBooleans<T>)
   })
 }

--- a/packages/core/src/shared/useForwardProps.ts
+++ b/packages/core/src/shared/useForwardProps.ts
@@ -38,6 +38,6 @@ export function useForwardProps<T extends Record<string, any>>(props: MaybeRefOr
       if (refProps.value[curr] !== undefined)
         prev[curr as keyof T] = refProps.value[curr]
       return prev
-    }, {} as T)
+    }, {} as Partial<T>)
   })
 }


### PR DESCRIPTION
## Summary

- Changes the return type of `useForwardProps` from `ComputedRef<T>` to `ComputedRef<Partial<T>>`
- Vue coerces optional boolean props (e.g. `optionalBoolProp?: boolean`) to non-optional (`boolean`) in the `defineProps` return type. Since `useForwardProps` only returns props that were actually assigned, `Partial<T>` correctly reflects that any prop may be absent at runtime
- `useForwardPropsEmits` inherits the fix transitively

Fixes #2538

## Test plan

- [x] Existing `useForwardProps` unit tests all pass (7/7)
- [x] No runtime behavior changes — only the TypeScript return type is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced type accuracy for the `useForwardProps` hook, improving TypeScript inference and IDE autocomplete support when forwarding props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->