### PR TITLE
fix(TimeField,DateField): avoid changing focus prematurely with previous segment value of 0

### DIFF
--- a/packages/core/src/DateField/DateField.test.ts
+++ b/packages/core/src/DateField/DateField.test.ts
@@ -289,6 +289,28 @@ describe('dateField', async () => {
     }
   })
 
+  it('doesn\'t change focus prematurely with segment value of 0', async () => {
+    const { getByTestId, user, day, month, year } = setup({
+      dateFieldProps: {
+        modelValue: zonedDateTime,
+        granularity: 'second',
+      },
+    })
+    const { hour, minute, second } = getTimeSegments(getByTestId)
+
+    const segments = [month, day, year, hour, minute, second]
+
+    for (const segment of segments) {
+      await user.click(segment)
+      await user.keyboard('{0}')
+      await user.keyboard(kbd.TAB)
+      expect(segment).not.toHaveFocus()
+      await user.click(segment)
+      await user.keyboard('{1}')
+      expect(segment).toHaveFocus()
+    }
+  })
+
   it(`preserve other segment when one segment's value is deleted`, async () => {
     const { user, day, month, year } = setup({
       dateFieldProps: {

--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -227,6 +227,28 @@ describe('datePicker', async () => {
     }
   })
 
+  it('doesn\'t change focus prematurely with segment value of 0', async () => {
+    const { getByTestId, user, day, month, year } = setup({
+      datePickerProps: {
+        modelValue: zonedDateTime,
+        granularity: 'second',
+      },
+    })
+    const { hour, minute, second } = getTimeSegments(getByTestId)
+
+    const segments = [month, day, year, hour, minute, second]
+
+    for (const segment of segments) {
+      await user.click(segment)
+      await user.keyboard('{0}')
+      await user.keyboard(kbd.TAB)
+      expect(segment).not.toHaveFocus()
+      await user.click(segment)
+      await user.keyboard('{1}')
+      expect(segment).toHaveFocus()
+    }
+  })
+
   it('prevents interaction and picker to be opened when `disabled` is `true`', async () => {
     const { trigger, day, month, year } = setup({
       datePickerProps: {

--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -227,28 +227,6 @@ describe('datePicker', async () => {
     }
   })
 
-  it('doesn\'t change focus prematurely with segment value of 0', async () => {
-    const { getByTestId, user, day, month, year } = setup({
-      datePickerProps: {
-        modelValue: zonedDateTime,
-        granularity: 'second',
-      },
-    })
-    const { hour, minute, second } = getTimeSegments(getByTestId)
-
-    const segments = [month, day, year, hour, minute, second]
-
-    for (const segment of segments) {
-      await user.click(segment)
-      await user.keyboard('{0}')
-      await user.keyboard(kbd.TAB)
-      expect(segment).not.toHaveFocus()
-      await user.click(segment)
-      await user.keyboard('{1}')
-      expect(segment).toHaveFocus()
-    }
-  })
-
   it('prevents interaction and picker to be opened when `disabled` is `true`', async () => {
     const { trigger, day, month, year } = setup({
       datePickerProps: {

--- a/packages/core/src/TimeField/TimeField.test.ts
+++ b/packages/core/src/TimeField/TimeField.test.ts
@@ -276,6 +276,30 @@ describe('timeField', async () => {
     }
   })
 
+  it('doesn\'t change focus prematurely with segment value of 0', async () => {
+    const { getByTestId, user, hour } = setup({
+      timeFieldProps: {
+        modelValue: time,
+        granularity: 'second',
+      },
+    })
+
+    const minute = getByTestId('minute')
+    const second = getByTestId('second')
+
+    const segments = [hour, minute, second]
+
+    for (const segment of segments) {
+      await user.click(segment)
+      await user.keyboard('{0}')
+      await user.keyboard(kbd.TAB)
+      expect(segment).not.toHaveFocus()
+      await user.click(segment)
+      await user.keyboard('{1}')
+      expect(segment).toHaveFocus()
+    }
+  })
+
   it('prevents interaction when `disabled`', async () => {
     const { user, getByTestId, hour } = setup({
       timeFieldProps: {

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -367,6 +367,7 @@ export function useDateField(props: UseDateFieldProps) {
      */
     if (props.hasLeftFocus.value) {
       props.hasLeftFocus.value = false
+      props.lastKeyZero.value = false
       prev = null
     }
 

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -445,6 +445,7 @@ export function useDateField(props: UseDateFieldProps) {
      */
     if (props.hasLeftFocus.value) {
       props.hasLeftFocus.value = false
+      props.lastKeyZero.value = false
       prev = null
     }
 
@@ -524,6 +525,7 @@ export function useDateField(props: UseDateFieldProps) {
     // probably not implement, kind of weird
     if (props.hasLeftFocus.value) {
       props.hasLeftFocus.value = false
+      props.lastKeyZero.value = false
       prev = null
     }
 


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Fixes [#2567](https://github.com/unovue/reka-ui/issues/2567)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In `updateHour` and `updateMinuteOrSecond` functions the `props.lastKeyZero` value was not being resetted when changing focus, it has been fixed so that context is always clean when starting to work on a segment.

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focus state management in date and time input fields to prevent premature segment switching and ensure proper focus handling when users enter zero values during keyboard input.

* **Tests**
  * Added comprehensive test coverage validating focus behavior and segment navigation across date and time input fields when entering zero values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->