### PR TITLE
fix(SelectRoot): normalize hidden control conditions (#2572)

### DIFF
--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -255,7 +255,7 @@ describe('given Select in a form', async () => {
   const wrapper = mount({
     props: ['handleSubmit'],
     components: { Select },
-    template: '<form @submit="handleSubmit"><Select value="true" /></form>',
+    template: '<form @submit="handleSubmit"><Select name="test" value="true" /></form>',
   }, {
     props: { handleSubmit },
     attachTo: document.body,

--- a/packages/core/src/Select/SelectRoot.vue
+++ b/packages/core/src/Select/SelectRoot.vue
@@ -201,7 +201,7 @@ provideSelectRootContext({
     />
 
     <BubbleSelect
-      v-if="isFormControl"
+      v-if="isFormControl && name"
       :key="nativeSelectKey"
       aria-hidden="true"
       tabindex="-1"


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
Fixes Issue https://github.com/unovue/reka-ui/issues/2572

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Normalize `SelectRoot` to conditionally render `BubbleSelect` based on `isFormControl` and `name`, consistent with other form controls.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select component form submission now correctly serializes data using the `name` attribute when submitted (e.g., `{ fieldName: 'selectedValue' }`).
  * Improved conditional rendering of the native select field to require both form control context and the `name` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->