### PR TITLE
fix(ListboxVirtualizer): ignore non-element VNodes in slot children

### DIFF
--- a/packages/core/src/Listbox/ListboxVirtualizer.vue
+++ b/packages/core/src/Listbox/ListboxVirtualizer.vue
@@ -83,7 +83,7 @@ const virtualizedItems = computed(() => virtualizer.value.getVirtualItems().map(
   })[0]
 
   const targetNode = defaultNode.type === Fragment && Array.isArray(defaultNode.children)
-    ? defaultNode.children[0] as VNode
+    ? defaultNode.children.find(child => typeof (child as VNode).type !== 'symbol') as VNode
     : defaultNode
 
   return {


### PR DESCRIPTION
## Summary
- Fixes `ListboxVirtualizer` slot rendering when comment or text nodes are present (e.g. `<!-- @vue-expect-error -->`)
- Replaces `children[0]` with a `.find()` that skips non-element VNodes (`Comment`, `Text`, `Static`, `Fragment`) by checking `typeof type !== 'symbol'`

Closes #2563

## Test plan
- [ ] Verify `ComboboxVirtualizer` / `ListboxVirtualizer` renders correctly when slot contains comment nodes
- [ ] Verify normal virtualizer usage without comments still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed virtualized listbox rendering in certain component layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->