### PR TITLE
fix(core): prevent /*#__PURE__*/ annotation inside function declarations

### DIFF
--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -3,8 +3,9 @@ import { defineConfig } from 'tsdown'
 
 // Match `defineComponent(`, `createContext(`, `reactive(` at word boundaries,
 // skipping calls already preceded by a PURE annotation or prefixed with a
-// word character (e.g. _defineComponent).
-const PURE_PATTERN = /(?<=^|[^.\w$])(defineComponent|createContext|reactive)\s*\(/g
+// word character (e.g. _defineComponent), or preceded by `function` keyword
+// (function declarations should not be annotated).
+const PURE_PATTERN = /(?<!function\s)(?<=^|[^.\w$])(defineComponent|createContext|reactive)\s*\(/g
 const ALREADY_PURE = /\/\*\s*[#@]__PURE__\s*\*\/\s*$/
 const PATH_SEP = /[\\/]/g
 


### PR DESCRIPTION
## Summary

- The `pureAnnotationPlugin` regex in `tsdown.config.ts` matched `createContext(` inside **function declarations** (e.g. `function createContext(...)`), inserting `/*#__PURE__*/` between the `function` keyword and the function name
- This caused Rollup/Vite 7 to emit a warning: _"A comment contains an annotation that Rollup cannot interpret due to the position of the comment"_
- Fix adds a negative lookbehind `(?<!function\s)` so only actual **call sites** get the `/*#__PURE__*/` annotation, not declarations

Fixes #2579

## Test plan

- [ ] Run `vite build` on a project using `reka-ui` — warning should no longer appear
- [ ] Verify tree-shaking still works: unused `createContext(...)` calls should still be annotated as pure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved build optimization logic for pure function annotations, refining when certain function declarations are marked for optimization during the bundling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->