### PR TITLE
fix(MonthPicker, YearPicker): preserve day/month when selecting

### DIFF
--- a/packages/core/src/MonthPicker/MonthPickerRoot.vue
+++ b/packages/core/src/MonthPicker/MonthPickerRoot.vue
@@ -205,23 +205,29 @@ watch(modelValue, (_modelValue) => {
   }
 })
 
+function resolveMonthValue(value: DateValue, reference?: DateValue) {
+  if (!reference)
+    return value.copy()
+  return reference.copy().set({ month: value.month, year: value.year })
+}
+
 function onMonthChange(value: DateValue) {
   if (!multiple.value) {
     if (!modelValue.value) {
-      modelValue.value = value.copy()
+      modelValue.value = resolveMonthValue(value, placeholder.value)
       return
     }
 
     if (!preventDeselect.value && isSameYearMonth(modelValue.value as DateValue, value)) {
-      placeholder.value = value.copy()
+      placeholder.value = resolveMonthValue(value, modelValue.value as DateValue)
       modelValue.value = undefined
     }
     else {
-      modelValue.value = value.copy()
+      modelValue.value = resolveMonthValue(value, modelValue.value as DateValue)
     }
   }
   else if (!modelValue.value) {
-    modelValue.value = [value.copy()]
+    modelValue.value = [resolveMonthValue(value, placeholder.value)]
   }
   else {
     const modelValueArray = Array.isArray(modelValue.value)
@@ -230,12 +236,12 @@ function onMonthChange(value: DateValue) {
 
     const index = modelValueArray.findIndex(date => isSameYearMonth(date, value))
     if (index === -1) {
-      modelValue.value = [...modelValueArray, value.copy()]
+      modelValue.value = [...modelValueArray, resolveMonthValue(value, placeholder.value)]
     }
     else if (!preventDeselect.value) {
       const next = modelValueArray.filter(date => !isSameYearMonth(date, value))
       if (!next.length) {
-        placeholder.value = value.copy()
+        placeholder.value = resolveMonthValue(value, modelValueArray[index])
         modelValue.value = undefined
         return
       }

--- a/packages/core/src/MonthPicker/MonthPickerRoot.vue
+++ b/packages/core/src/MonthPicker/MonthPickerRoot.vue
@@ -208,7 +208,7 @@ watch(modelValue, (_modelValue) => {
 function resolveMonthValue(value: DateValue, reference?: DateValue) {
   if (!reference)
     return value.copy()
-  return reference.copy().set({ month: value.month, year: value.year })
+  return value.copy().set({ day: reference.day })
 }
 
 function onMonthChange(value: DateValue) {

--- a/packages/core/src/MonthPicker/useMonthPicker.ts
+++ b/packages/core/src/MonthPicker/useMonthPicker.ts
@@ -134,13 +134,13 @@ export function useMonthPicker(props: UseMonthPickerProps) {
     if (nextPageFunc || props.nextPage.value) {
       const newDate = (nextPageFunc || props.nextPage.value)!(currentDate)
       grid.value = createMonthGrid({ dateObj: newDate })
-      props.placeholder.value = newDate.set({ day: 1 })
+      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
       return
     }
 
     const newDate = currentDate.add({ years: 1 })
     grid.value = createMonthGrid({ dateObj: newDate })
-    props.placeholder.value = newDate.set({ day: 1 })
+    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
   }
 
   const prevPage = (prevPageFunc?: (date: DateValue) => DateValue) => {
@@ -149,13 +149,13 @@ export function useMonthPicker(props: UseMonthPickerProps) {
     if (prevPageFunc || props.prevPage.value) {
       const newDate = (prevPageFunc || props.prevPage.value)!(currentDate)
       grid.value = createMonthGrid({ dateObj: newDate })
-      props.placeholder.value = newDate.set({ day: 1 })
+      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
       return
     }
 
     const newDate = currentDate.subtract({ years: 1 })
     grid.value = createMonthGrid({ dateObj: newDate })
-    props.placeholder.value = newDate.set({ day: 1 })
+    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
   }
 
   watch(props.placeholder, (value) => {

--- a/packages/core/src/MonthPicker/useMonthPicker.ts
+++ b/packages/core/src/MonthPicker/useMonthPicker.ts
@@ -134,13 +134,13 @@ export function useMonthPicker(props: UseMonthPickerProps) {
     if (nextPageFunc || props.nextPage.value) {
       const newDate = (nextPageFunc || props.nextPage.value)!(currentDate)
       grid.value = createMonthGrid({ dateObj: newDate })
-      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+      props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
       return
     }
 
     const newDate = currentDate.add({ years: 1 })
     grid.value = createMonthGrid({ dateObj: newDate })
-    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+    props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
   }
 
   const prevPage = (prevPageFunc?: (date: DateValue) => DateValue) => {
@@ -149,13 +149,13 @@ export function useMonthPicker(props: UseMonthPickerProps) {
     if (prevPageFunc || props.prevPage.value) {
       const newDate = (prevPageFunc || props.prevPage.value)!(currentDate)
       grid.value = createMonthGrid({ dateObj: newDate })
-      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+      props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
       return
     }
 
     const newDate = currentDate.subtract({ years: 1 })
     grid.value = createMonthGrid({ dateObj: newDate })
-    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+    props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
   }
 
   watch(props.placeholder, (value) => {

--- a/packages/core/src/YearPicker/YearPickerRoot.vue
+++ b/packages/core/src/YearPicker/YearPickerRoot.vue
@@ -214,7 +214,7 @@ watch(modelValue, (_modelValue) => {
 function resolveYearValue(value: DateValue, reference?: DateValue) {
   if (!reference)
     return value.copy()
-  return reference.copy().set({ year: value.year })
+  return value.copy().set({ month: reference.month, day: reference.day })
 }
 
 function onYearChange(value: DateValue) {

--- a/packages/core/src/YearPicker/YearPickerRoot.vue
+++ b/packages/core/src/YearPicker/YearPickerRoot.vue
@@ -211,33 +211,39 @@ watch(modelValue, (_modelValue) => {
   }
 })
 
+function resolveYearValue(value: DateValue, reference?: DateValue) {
+  if (!reference)
+    return value.copy()
+  return reference.copy().set({ year: value.year })
+}
+
 function onYearChange(value: DateValue) {
   if (!multiple.value) {
     if (!modelValue.value) {
-      modelValue.value = value.copy()
+      modelValue.value = resolveYearValue(value, placeholder.value)
       return
     }
 
     if (!preventDeselect.value && isSameYear(modelValue.value as DateValue, value)) {
-      placeholder.value = value.copy()
+      placeholder.value = resolveYearValue(value, modelValue.value as DateValue)
       modelValue.value = undefined
     }
     else {
-      modelValue.value = value.copy()
+      modelValue.value = resolveYearValue(value, modelValue.value as DateValue)
     }
   }
   else if (!modelValue.value) {
-    modelValue.value = [value.copy()]
+    modelValue.value = [resolveYearValue(value, placeholder.value)]
   }
   else if (Array.isArray(modelValue.value)) {
     const index = modelValue.value.findIndex(date => isSameYear(date, value))
     if (index === -1) {
-      modelValue.value = [...modelValue.value, value.copy()]
+      modelValue.value = [...modelValue.value, resolveYearValue(value, placeholder.value)]
     }
     else if (!preventDeselect.value) {
       const next = modelValue.value.filter(date => !isSameYear(date, value))
       if (!next.length) {
-        placeholder.value = value.copy()
+        placeholder.value = resolveYearValue(value, modelValue.value[index])
         modelValue.value = undefined
         return
       }

--- a/packages/core/src/YearPicker/useYearPicker.ts
+++ b/packages/core/src/YearPicker/useYearPicker.ts
@@ -138,13 +138,13 @@ export function useYearPicker(props: UseYearPickerProps) {
     if (nextPageFunc || props.nextPage.value) {
       const newDate = (nextPageFunc || props.nextPage.value)!(firstYearInGrid)
       grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-      props.placeholder.value = newDate.set({ month: 1, day: 1 })
+      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
       return
     }
 
     const newDate = firstYearInGrid.add({ years: props.yearsPerPage.value })
     grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-    props.placeholder.value = newDate.set({ month: 1, day: 1 })
+    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
   }
 
   const prevPage = (prevPageFunc?: (date: DateValue) => DateValue) => {
@@ -153,13 +153,13 @@ export function useYearPicker(props: UseYearPickerProps) {
     if (prevPageFunc || props.prevPage.value) {
       const newDate = (prevPageFunc || props.prevPage.value)!(firstYearInGrid)
       grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-      props.placeholder.value = newDate.set({ month: 1, day: 1 })
+      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
       return
     }
 
     const newDate = firstYearInGrid.subtract({ years: props.yearsPerPage.value })
     grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-    props.placeholder.value = newDate.set({ month: 1, day: 1 })
+    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
   }
 
   watch(props.placeholder, (value) => {

--- a/packages/core/src/YearPicker/useYearPicker.ts
+++ b/packages/core/src/YearPicker/useYearPicker.ts
@@ -138,13 +138,13 @@ export function useYearPicker(props: UseYearPickerProps) {
     if (nextPageFunc || props.nextPage.value) {
       const newDate = (nextPageFunc || props.nextPage.value)!(firstYearInGrid)
       grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+      props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
       return
     }
 
     const newDate = firstYearInGrid.add({ years: props.yearsPerPage.value })
     grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+    props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
   }
 
   const prevPage = (prevPageFunc?: (date: DateValue) => DateValue) => {
@@ -153,13 +153,13 @@ export function useYearPicker(props: UseYearPickerProps) {
     if (prevPageFunc || props.prevPage.value) {
       const newDate = (prevPageFunc || props.prevPage.value)!(firstYearInGrid)
       grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-      props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+      props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
       return
     }
 
     const newDate = firstYearInGrid.subtract({ years: props.yearsPerPage.value })
     grid.value = createYearGrid({ dateObj: newDate, yearsPerPage: props.yearsPerPage.value, decadeAligned: false })
-    props.placeholder.value = props.placeholder.value.set({ year: newDate.year })
+    props.placeholder.value = newDate.set({ month: props.placeholder.value.month, day: props.placeholder.value.day })
   }
 
   watch(props.placeholder, (value) => {


### PR DESCRIPTION
## Summary
- **MonthPicker** was resetting the day to 1 when a new month was selected (e.g., `2077-10-20` → `2077-03-01`). Now only the month/year segment changes, preserving the day.
- **YearPicker** was resetting both month and day to 1 when a new year was selected (e.g., `2077-10-20` → `2099-01-01`). Now only the year segment changes.
- Also fixed `nextPage`/`prevPage` in both hooks to preserve placeholder's day/month instead of resetting them.

Closes #2587, closes #2588

## Test plan
- [x] Type check passes (`pnpm type-check`)
- [x] All 1629 tests pass
- [ ] Manual: bind a `CalendarDate` with a non-first day (e.g., `2025-10-20`) to `MonthPickerRoot` via `v-model`, change the month, verify the day stays `20`
- [ ] Manual: bind a date like `2025-10-20` to `YearPickerRoot` via `v-model`, change the year, verify month and day stay `10-20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Month picker: preserve existing day/month when selecting, deselecting, or navigating; correctly resolve placeholder when removing the last selected month.
  * Year picker: preserve existing month/day when selecting, deselecting, or navigating; correctly recompute placeholder on last-item removal.
  * Overall: improved consistency of placeholder preservation across date navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->